### PR TITLE
feat: 내 팀 직관 승률 조회 API 구현

### DIFF
--- a/backend/src/main/java/com/yagubogu/stat/controller/StatController.java
+++ b/backend/src/main/java/com/yagubogu/stat/controller/StatController.java
@@ -1,6 +1,7 @@
 package com.yagubogu.stat.controller;
 
 import com.yagubogu.stat.dto.StatCountsResponse;
+import com.yagubogu.stat.dto.WinRateResponse;
 import com.yagubogu.stat.service.StatService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -23,6 +24,15 @@ public class StatController {
             @RequestParam final int year
     ) {
         StatCountsResponse response = statService.findStatCounts(memberId, year);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/win-rate")
+    public ResponseEntity<WinRateResponse> findWinRate(
+            @RequestParam final long memberId,
+            @RequestParam final int year
+    ) {
+        WinRateResponse response = statService.findWinRate(memberId, year);
         return ResponseEntity.ok(response);
     }
 }

--- a/backend/src/main/java/com/yagubogu/stat/dto/WinRateResponse.java
+++ b/backend/src/main/java/com/yagubogu/stat/dto/WinRateResponse.java
@@ -1,0 +1,4 @@
+package com.yagubogu.stat.dto;
+
+public record WinRateResponse(double winRate) {
+}

--- a/backend/src/main/java/com/yagubogu/stat/service/StatService.java
+++ b/backend/src/main/java/com/yagubogu/stat/service/StatService.java
@@ -6,6 +6,7 @@ import com.yagubogu.global.exception.NotFoundException;
 import com.yagubogu.member.domain.Member;
 import com.yagubogu.member.repository.MemberRepository;
 import com.yagubogu.stat.dto.StatCountsResponse;
+import com.yagubogu.stat.dto.WinRateResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -26,6 +27,24 @@ public class StatService {
         int favoriteCheckInCounts = winCounts + drawCounts + loseCounts;
 
         return new StatCountsResponse(winCounts, drawCounts, loseCounts, favoriteCheckInCounts);
+    }
+
+    public WinRateResponse findWinRate(final long memberId, final int year) {
+        Member member = getById(memberId);
+        validateAdmin(member);
+
+        int winCounts = checkInRepository.findWinCounts(member, year);
+        int drawCounts = checkInRepository.findDrawCounts(member, year);
+        int loseCounts = checkInRepository.findLoseCounts(member, year);
+        int favoriteCheckInCounts = winCounts + drawCounts + loseCounts;
+
+        double winRate = (double) winCounts / favoriteCheckInCounts * 100;
+
+        return new WinRateResponse(calculateRoundRate(winRate));
+    }
+
+    private double calculateRoundRate(final double rate) {
+        return Math.round(rate * 10) / 10.0;
     }
 
     private Member getById(final long memberId) {

--- a/backend/src/test/java/com/yagubogu/stat/StatIntegrationTest.java
+++ b/backend/src/test/java/com/yagubogu/stat/StatIntegrationTest.java
@@ -1,9 +1,10 @@
 package com.yagubogu.stat;
 
 import com.yagubogu.stat.dto.StatCountsResponse;
+import com.yagubogu.stat.dto.WinRateResponse;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
-import org.assertj.core.api.SoftAssertions;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -32,7 +33,7 @@ public class StatIntegrationTest {
     @DisplayName("승패무 횟수와 총 직관 횟수를 조회한다")
     @Test
     void findStatCounts() {
-        StatCountsResponse response = RestAssured.given().log().all()
+        StatCountsResponse actual = RestAssured.given().log().all()
                 .contentType(ContentType.JSON)
                 .queryParams("memberId", 1L, "year", 2025)
                 .when().get("/api/stats/counts")
@@ -41,14 +42,26 @@ public class StatIntegrationTest {
                 .extract()
                 .as(StatCountsResponse.class);
 
-        SoftAssertions.assertSoftly(
-                softAssertions -> {
-                    softAssertions.assertThat(response.winCounts()).isEqualTo(1);
-                    softAssertions.assertThat(response.drawCounts()).isEqualTo(1);
-                    softAssertions.assertThat(response.loseCounts()).isEqualTo(0);
-                    softAssertions.assertThat(response.favoriteCheckInCounts()).isEqualTo(2);
-                }
-        );
+        StatCountsResponse expected = new StatCountsResponse(2, 1, 0, 3);
+
+        Assertions.assertThat(actual).isEqualTo(expected);
+    }
+
+    @DisplayName("직관 승률을 조회한다")
+    @Test
+    void findWinRate() {
+        WinRateResponse actual = RestAssured.given().log().all()
+                .contentType(ContentType.JSON)
+                .queryParams("memberId", 1L, "year", 2025)
+                .when().get("/api/stats/win-rate")
+                .then().log().all()
+                .statusCode(200)
+                .extract()
+                .as(WinRateResponse.class);
+
+        WinRateResponse expected = new WinRateResponse(66.7);
+
+        Assertions.assertThat(actual).isEqualTo(expected);
     }
 }
 

--- a/backend/src/test/java/com/yagubogu/stat/service/StatServiceTest.java
+++ b/backend/src/test/java/com/yagubogu/stat/service/StatServiceTest.java
@@ -1,11 +1,14 @@
 package com.yagubogu.stat.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import com.yagubogu.checkin.repository.CheckInRepository;
 import com.yagubogu.global.exception.ForbiddenException;
 import com.yagubogu.global.exception.NotFoundException;
 import com.yagubogu.member.repository.MemberRepository;
 import com.yagubogu.stat.dto.StatCountsResponse;
-import org.assertj.core.api.Assertions;
+import com.yagubogu.stat.dto.WinRateResponse;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -46,10 +49,10 @@ class StatServiceTest {
         // then
         SoftAssertions.assertSoftly(
                 softAssertions -> {
-                    softAssertions.assertThat(response.winCounts()).isEqualTo(1);
+                    softAssertions.assertThat(response.winCounts()).isEqualTo(2);
                     softAssertions.assertThat(response.drawCounts()).isEqualTo(1);
                     softAssertions.assertThat(response.loseCounts()).isEqualTo(0);
-                    softAssertions.assertThat(response.favoriteCheckInCounts()).isEqualTo(2);
+                    softAssertions.assertThat(response.favoriteCheckInCounts()).isEqualTo(3);
                 }
         );
     }
@@ -104,7 +107,7 @@ class StatServiceTest {
         int year = 2025;
 
         // when & then
-        Assertions.assertThatThrownBy(() -> statService.findStatCounts(memberId, year))
+        assertThatThrownBy(() -> statService.findStatCounts(memberId, year))
                 .isExactlyInstanceOf(NotFoundException.class)
                 .hasMessage("Member is not found");
     }
@@ -117,8 +120,22 @@ class StatServiceTest {
         int year = 2025;
 
         // when & then
-        Assertions.assertThatThrownBy(() -> statService.findStatCounts(memberId, year))
+        assertThatThrownBy(() -> statService.findStatCounts(memberId, year))
                 .isExactlyInstanceOf(ForbiddenException.class)
                 .hasMessage("Member should not be admin");
+    }
+
+    @DisplayName("승률을 계산한다")
+    @Test
+    void findWinRate() {
+        // given
+        long memberId = 1L;
+        int year = 2025;
+
+        // when
+        WinRateResponse response = statService.findWinRate(memberId, year);
+
+        // then
+        assertThat(response.winRate()).isEqualTo(66.7);
     }
 }

--- a/backend/src/test/resources/test-data.sql
+++ b/backend/src/test/resources/test-data.sql
@@ -14,10 +14,12 @@ VALUES ('광주 KIA 챔피언스필드', '챔피언스필드', '광주');
 
 INSERT INTO games (stadium_id, home_team_id, away_team_id, date, home_score, away_score)
 VALUES (1, 1, 2, '2025-07-21', 10, 9),
-       (1, 1, 3, '2025-07-20', 5, 5);
+       (1, 1, 3, '2025-07-20', 5, 5),
+       (1, 1, 3, '2025-07-19', 10, 5);
 
 INSERT INTO check_ins (member_id, game_id)
 VALUES (1, 1),
        (1, 2),
+       (1, 3),
        (2, 1),
        (3, 2);


### PR DESCRIPTION
## 📌 관련 이슈
- close #47

## ✨ 변경 내용
- 내 팀 직관 경기의 승률을 계산해 보여주는 기능

## 🎸 기타 참고 사항
- 4인 페어