### PR TITLE
feat: 내 통계 화면 API 연동

### DIFF
--- a/android/app/src/main/java/com/yagubogu/YaguBoguApplication.kt
+++ b/android/app/src/main/java/com/yagubogu/YaguBoguApplication.kt
@@ -3,11 +3,17 @@ package com.yagubogu
 import android.app.Application
 import com.google.android.gms.location.LocationServices
 import com.yagubogu.data.datasource.LocationLocalDataSource
+import com.yagubogu.data.datasource.StatsRemoteDataSource
+import com.yagubogu.data.network.RetrofitInstance
 import com.yagubogu.data.repository.LocationDefaultRepository
+import com.yagubogu.data.repository.StatsDefaultRepository
 
 class YaguBoguApplication : Application() {
     private val locationClient by lazy { LocationServices.getFusedLocationProviderClient(this) }
 
     private val locationLocalDataSource by lazy { LocationLocalDataSource(locationClient) }
     val locationRepository by lazy { LocationDefaultRepository(locationLocalDataSource) }
+
+    private val statsRemoteDataSource by lazy { StatsRemoteDataSource(RetrofitInstance.statsApiService) }
+    val statsRepository by lazy { StatsDefaultRepository(statsRemoteDataSource) }
 }

--- a/android/app/src/main/java/com/yagubogu/data/datasource/StatsDataSource.kt
+++ b/android/app/src/main/java/com/yagubogu/data/datasource/StatsDataSource.kt
@@ -1,0 +1,22 @@
+package com.yagubogu.data.datasource
+
+import com.yagubogu.data.dto.response.StatsCountsResponse
+import com.yagubogu.data.dto.response.StatsLuckyStadiumsResponse
+import com.yagubogu.data.dto.response.StatsWinRateResponse
+
+interface StatsDataSource {
+    suspend fun getStatsWinRate(
+        memberId: Long,
+        year: Int,
+    ): Result<StatsWinRateResponse>
+
+    suspend fun getStatsCounts(
+        memberId: Long,
+        year: Int,
+    ): Result<StatsCountsResponse>
+
+    suspend fun getLuckyStadiums(
+        memberId: Long,
+        year: Int,
+    ): Result<StatsLuckyStadiumsResponse>
+}

--- a/android/app/src/main/java/com/yagubogu/data/datasource/StatsRemoteDataSource.kt
+++ b/android/app/src/main/java/com/yagubogu/data/datasource/StatsRemoteDataSource.kt
@@ -1,0 +1,35 @@
+package com.yagubogu.data.datasource
+
+import com.yagubogu.data.dto.response.StatsCountsResponse
+import com.yagubogu.data.dto.response.StatsLuckyStadiumsResponse
+import com.yagubogu.data.dto.response.StatsWinRateResponse
+import com.yagubogu.data.service.StatsApiService
+import com.yagubogu.data.util.safeApiCall
+
+class StatsRemoteDataSource(
+    private val statsApiService: StatsApiService,
+) : StatsDataSource {
+    override suspend fun getStatsWinRate(
+        memberId: Long,
+        year: Int,
+    ): Result<StatsWinRateResponse> =
+        safeApiCall {
+            statsApiService.getStatsWinRate(memberId, year)
+        }
+
+    override suspend fun getStatsCounts(
+        memberId: Long,
+        year: Int,
+    ): Result<StatsCountsResponse> =
+        safeApiCall {
+            statsApiService.getStatsCounts(memberId, year)
+        }
+
+    override suspend fun getLuckyStadiums(
+        memberId: Long,
+        year: Int,
+    ): Result<StatsLuckyStadiumsResponse> =
+        safeApiCall {
+            statsApiService.getLuckyStadiums(memberId, year)
+        }
+}

--- a/android/app/src/main/java/com/yagubogu/data/dto/response/StatsCountsResponse.kt
+++ b/android/app/src/main/java/com/yagubogu/data/dto/response/StatsCountsResponse.kt
@@ -1,5 +1,6 @@
 package com.yagubogu.data.dto.response
 
+import com.yagubogu.domain.model.StatsCounts
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -13,4 +14,12 @@ data class StatsCountsResponse(
     val loseCounts: Int, // 패배 횟수
     @SerialName("favoriteCheckInCounts")
     val favoriteCheckInCounts: Int, // 내 팀 직관 횟수
-)
+) {
+    fun toDomain() =
+        StatsCounts(
+            winCounts = winCounts,
+            drawCounts = drawCounts,
+            loseCounts = loseCounts,
+            favoriteCheckInCounts = favoriteCheckInCounts,
+        )
+}

--- a/android/app/src/main/java/com/yagubogu/data/dto/response/StatsLuckyStadiumsResponse.kt
+++ b/android/app/src/main/java/com/yagubogu/data/dto/response/StatsLuckyStadiumsResponse.kt
@@ -1,0 +1,10 @@
+package com.yagubogu.data.dto.response
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class StatsLuckyStadiumsResponse(
+    @SerialName("shortName")
+    val shortName: String?, // 구장 별명, 행운의 구장이 없다면 null
+)

--- a/android/app/src/main/java/com/yagubogu/data/dto/response/StatsWinRateResponse.kt
+++ b/android/app/src/main/java/com/yagubogu/data/dto/response/StatsWinRateResponse.kt
@@ -1,0 +1,10 @@
+package com.yagubogu.data.dto.response
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class StatsWinRateResponse(
+    @SerialName("winRate")
+    val winPercent: Double, // 승률(%)
+)

--- a/android/app/src/main/java/com/yagubogu/data/repository/StatsDefaultRepository.kt
+++ b/android/app/src/main/java/com/yagubogu/data/repository/StatsDefaultRepository.kt
@@ -1,0 +1,42 @@
+package com.yagubogu.data.repository
+
+import com.yagubogu.data.datasource.StatsDataSource
+import com.yagubogu.data.dto.response.StatsCountsResponse
+import com.yagubogu.data.dto.response.StatsLuckyStadiumsResponse
+import com.yagubogu.data.dto.response.StatsWinRateResponse
+import com.yagubogu.domain.model.StatsCounts
+import com.yagubogu.domain.repository.StatsRepository
+
+class StatsDefaultRepository(
+    private val statsDataSource: StatsDataSource,
+) : StatsRepository {
+    override suspend fun getStatsWinRate(
+        memberId: Long,
+        year: Int,
+    ): Result<Double> =
+        statsDataSource
+            .getStatsWinRate(memberId, year)
+            .map { statsWinRateResponse: StatsWinRateResponse ->
+                statsWinRateResponse.winPercent
+            }
+
+    override suspend fun getStatsCounts(
+        memberId: Long,
+        year: Int,
+    ): Result<StatsCounts> =
+        statsDataSource
+            .getStatsCounts(memberId, year)
+            .map { statsCountsResponse: StatsCountsResponse ->
+                statsCountsResponse.toDomain()
+            }
+
+    override suspend fun getLuckyStadiums(
+        memberId: Long,
+        year: Int,
+    ): Result<String?> =
+        statsDataSource
+            .getLuckyStadiums(memberId, year)
+            .map { statsLuckyStadiumsResponse: StatsLuckyStadiumsResponse ->
+                statsLuckyStadiumsResponse.shortName
+            }
+}

--- a/android/app/src/main/java/com/yagubogu/data/service/StatsApiService.kt
+++ b/android/app/src/main/java/com/yagubogu/data/service/StatsApiService.kt
@@ -1,13 +1,28 @@
 package com.yagubogu.data.service
 
 import com.yagubogu.data.dto.response.StatsCountsResponse
+import com.yagubogu.data.dto.response.StatsLuckyStadiumsResponse
+import com.yagubogu.data.dto.response.StatsWinRateResponse
+import retrofit2.Response
 import retrofit2.http.GET
 import retrofit2.http.Query
 
 interface StatsApiService {
+    @GET("/api/stats/win-rate")
+    suspend fun getStatsWinRate(
+        @Query("memberId") memberId: Long,
+        @Query("year") year: Int,
+    ): Response<StatsWinRateResponse>
+
     @GET("/api/stats/counts")
     suspend fun getStatsCounts(
         @Query("memberId") memberId: Long,
         @Query("year") year: Int,
-    ): StatsCountsResponse
+    ): Response<StatsCountsResponse>
+
+    @GET("/api/stats/lucky-stadiums")
+    suspend fun getLuckyStadiums(
+        @Query("memberId") memberId: Long,
+        @Query("year") year: Int,
+    ): Response<StatsLuckyStadiumsResponse>
 }

--- a/android/app/src/main/java/com/yagubogu/data/util/safeApiCall.kt
+++ b/android/app/src/main/java/com/yagubogu/data/util/safeApiCall.kt
@@ -1,0 +1,18 @@
+@file:Suppress("ktlint:standard:filename")
+
+package com.yagubogu.data.util
+
+import retrofit2.HttpException
+import retrofit2.Response
+
+@Suppress("UNCHECKED_CAST")
+inline fun <T> safeApiCall(apiCall: () -> Response<T>): Result<T> =
+    runCatching {
+        val response = apiCall()
+
+        if (response.isSuccessful) {
+            response.body() as T
+        } else {
+            throw HttpException(response)
+        }
+    }

--- a/android/app/src/main/java/com/yagubogu/domain/model/StatsCounts.kt
+++ b/android/app/src/main/java/com/yagubogu/domain/model/StatsCounts.kt
@@ -1,0 +1,8 @@
+package com.yagubogu.domain.model
+
+data class StatsCounts(
+    val winCounts: Int,
+    val drawCounts: Int,
+    val loseCounts: Int,
+    val favoriteCheckInCounts: Int,
+)

--- a/android/app/src/main/java/com/yagubogu/domain/repository/StatsRepository.kt
+++ b/android/app/src/main/java/com/yagubogu/domain/repository/StatsRepository.kt
@@ -1,0 +1,20 @@
+package com.yagubogu.domain.repository
+
+import com.yagubogu.domain.model.StatsCounts
+
+interface StatsRepository {
+    suspend fun getStatsWinRate(
+        memberId: Long,
+        year: Int,
+    ): Result<Double>
+
+    suspend fun getStatsCounts(
+        memberId: Long,
+        year: Int,
+    ): Result<StatsCounts>
+
+    suspend fun getLuckyStadiums(
+        memberId: Long,
+        year: Int,
+    ): Result<String?>
+}

--- a/android/app/src/main/java/com/yagubogu/presentation/stats/my/MyStatsFragment.kt
+++ b/android/app/src/main/java/com/yagubogu/presentation/stats/my/MyStatsFragment.kt
@@ -48,9 +48,9 @@ class MyStatsFragment : Fragment() {
     }
 
     private fun setupObservers() {
-        viewModel.myStatsUiModel.observe(viewLifecycleOwner) { myStats: MyStatsUiModel ->
-            binding.myStatsUiModel = myStats
-            loadChartData(myStats)
+        viewModel.myStatsUiModel.observe(viewLifecycleOwner) { myStatsUiModel: MyStatsUiModel ->
+            binding.myStatsUiModel = myStatsUiModel
+            loadChartData(myStatsUiModel)
         }
     }
 
@@ -73,10 +73,10 @@ class MyStatsFragment : Fragment() {
         }
     }
 
-    private fun loadChartData(myStats: MyStatsUiModel) {
+    private fun loadChartData(myStatsUiModel: MyStatsUiModel) {
         val pieEntries = ArrayList<PieEntry>()
-        pieEntries.add(PieEntry(myStats.winningPercentage.toFloat(), "Win"))
-        pieEntries.add(PieEntry(myStats.etcPercentage.toFloat(), "Etc"))
+        pieEntries.add(PieEntry(myStatsUiModel.winningPercentage.toFloat(), "Win"))
+        pieEntries.add(PieEntry(myStatsUiModel.etcPercentage.toFloat(), "Etc"))
 
         val myStatsChartDataSet = PieDataSet(pieEntries, WINNING_PERCENTAGE)
 

--- a/android/app/src/main/java/com/yagubogu/presentation/stats/my/MyStatsUiModel.kt
+++ b/android/app/src/main/java/com/yagubogu/presentation/stats/my/MyStatsUiModel.kt
@@ -1,13 +1,16 @@
 package com.yagubogu.presentation.stats.my
 
-import kotlin.math.roundToInt
-
 data class MyStatsUiModel(
     val winCount: Int,
     val drawCount: Int,
     val loseCount: Int,
+    val totalCount: Int,
+    val winningPercentage: Int,
+    val luckyStadium: String,
 ) {
-    val totalCount: Int get() = winCount + drawCount + loseCount
-    val winningPercentage: Int get() = ((winCount.toFloat() / totalCount) * 100).roundToInt()
-    val etcPercentage: Int get() = 100 - winningPercentage
+    val etcPercentage: Int get() = FULL_PERCENTAGE - winningPercentage
+
+    companion object {
+        private const val FULL_PERCENTAGE = 100
+    }
 }

--- a/android/app/src/main/java/com/yagubogu/presentation/stats/my/MyStatsUiModel.kt
+++ b/android/app/src/main/java/com/yagubogu/presentation/stats/my/MyStatsUiModel.kt
@@ -6,7 +6,7 @@ data class MyStatsUiModel(
     val loseCount: Int,
     val totalCount: Int,
     val winningPercentage: Int,
-    val luckyStadium: String,
+    val luckyStadium: String?,
 ) {
     val etcPercentage: Int get() = FULL_PERCENTAGE - winningPercentage
 

--- a/android/app/src/main/java/com/yagubogu/presentation/stats/my/MyStatsViewModel.kt
+++ b/android/app/src/main/java/com/yagubogu/presentation/stats/my/MyStatsViewModel.kt
@@ -1,0 +1,69 @@
+package com.yagubogu.presentation.stats.my
+
+import android.util.Log
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.yagubogu.domain.model.StatsCounts
+import com.yagubogu.domain.repository.StatsRepository
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.async
+import kotlinx.coroutines.launch
+import kotlin.math.roundToInt
+
+class MyStatsViewModel(
+    private val statsRepository: StatsRepository,
+) : ViewModel() {
+    private val _myStatsUiModel = MutableLiveData<MyStatsUiModel>()
+    val myStatsUiModel: LiveData<MyStatsUiModel> get() = _myStatsUiModel
+
+    init {
+        fetchMyStats(1, 2025)
+    }
+
+    private fun fetchMyStats(
+        memberId: Long,
+        year: Int,
+    ) {
+        viewModelScope.launch {
+            val statsCountsDeferred: Deferred<Result<StatsCounts>> =
+                async { statsRepository.getStatsCounts(memberId, year) }
+            val winRateDeferred: Deferred<Result<Double>> =
+                async { statsRepository.getStatsWinRate(memberId, year) }
+            val luckyStadiumDeferred: Deferred<Result<String?>> =
+                async { statsRepository.getLuckyStadiums(memberId, year) }
+
+            val statsCountsResult = statsCountsDeferred.await()
+            val winRateResult = winRateDeferred.await()
+            val luckyStadiumResult = luckyStadiumDeferred.await()
+
+            if (statsCountsResult.isSuccess && winRateResult.isSuccess && luckyStadiumResult.isSuccess) {
+                val statsCounts = statsCountsResult.getOrThrow()
+                val winRate = winRateResult.getOrThrow()
+                val luckyStadium = luckyStadiumResult.getOrThrow() ?: "기록 없음"
+
+                val myStatsUiModel =
+                    MyStatsUiModel(
+                        winCount = statsCounts.winCounts,
+                        drawCount = statsCounts.drawCounts,
+                        loseCount = statsCounts.loseCounts,
+                        totalCount = statsCounts.favoriteCheckInCounts,
+                        winningPercentage = winRate.roundToInt(),
+                        luckyStadium = luckyStadium,
+                    )
+                _myStatsUiModel.value = myStatsUiModel
+            } else {
+                val errors: List<String> =
+                    listOf(statsCountsResult, winRateResult, luckyStadiumResult)
+                        .filter { it.isFailure }
+                        .mapNotNull { it.exceptionOrNull()?.message }
+                Log.e(TAG, "API 호출 실패: ${errors.joinToString()}")
+            }
+        }
+    }
+
+    companion object {
+        private const val TAG = "MyStatsViewModel"
+    }
+}

--- a/android/app/src/main/java/com/yagubogu/presentation/stats/my/MyStatsViewModel.kt
+++ b/android/app/src/main/java/com/yagubogu/presentation/stats/my/MyStatsViewModel.kt
@@ -34,14 +34,14 @@ class MyStatsViewModel(
             val luckyStadiumDeferred: Deferred<Result<String?>> =
                 async { statsRepository.getLuckyStadiums(memberId, year) }
 
-            val statsCountsResult = statsCountsDeferred.await()
-            val winRateResult = winRateDeferred.await()
-            val luckyStadiumResult = luckyStadiumDeferred.await()
+            val statsCountsResult: Result<StatsCounts> = statsCountsDeferred.await()
+            val winRateResult: Result<Double> = winRateDeferred.await()
+            val luckyStadiumResult: Result<String?> = luckyStadiumDeferred.await()
 
             if (statsCountsResult.isSuccess && winRateResult.isSuccess && luckyStadiumResult.isSuccess) {
-                val statsCounts = statsCountsResult.getOrThrow()
-                val winRate = winRateResult.getOrThrow()
-                val luckyStadium = luckyStadiumResult.getOrThrow() ?: "기록 없음"
+                val statsCounts: StatsCounts = statsCountsResult.getOrThrow()
+                val winRate: Double = winRateResult.getOrThrow()
+                val luckyStadium: String? = luckyStadiumResult.getOrThrow()
 
                 val myStatsUiModel =
                     MyStatsUiModel(

--- a/android/app/src/main/java/com/yagubogu/presentation/stats/my/MyStatsViewModelFactory.kt
+++ b/android/app/src/main/java/com/yagubogu/presentation/stats/my/MyStatsViewModelFactory.kt
@@ -1,0 +1,17 @@
+package com.yagubogu.presentation.stats.my
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import com.yagubogu.domain.repository.StatsRepository
+
+class MyStatsViewModelFactory(
+    private val statsRepository: StatsRepository,
+) : ViewModelProvider.Factory {
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        if (modelClass.isAssignableFrom(MyStatsViewModel::class.java)) {
+            @Suppress("UNCHECKED_CAST")
+            return MyStatsViewModel(statsRepository) as T
+        }
+        throw IllegalArgumentException()
+    }
+}

--- a/android/app/src/main/res/layout/fragment_my_stats.xml
+++ b/android/app/src/main/res/layout/fragment_my_stats.xml
@@ -17,7 +17,8 @@
 
         <androidx.constraintlayout.widget.ConstraintLayout
             android:layout_width="match_parent"
-            android:layout_height="wrap_content">
+            android:layout_height="wrap_content"
+            android:paddingBottom="20dp">
 
             <androidx.constraintlayout.widget.ConstraintLayout
                 android:id="@+id/constraint_my_stats"
@@ -49,20 +50,20 @@
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toBottomOf="@id/tv_my_chart_title" />
 
-            <TextView
-                android:id="@+id/tv_winning_percentage"
-                style="@style/TextView.Pretendard.Bold.40"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:includeFontPadding="false"
-                android:text="@{@string/stats_percentage(myStatsUiModel.winningPercentage)}"
-                android:textColor="@color/primary500"
-                app:layout_constraintBottom_toTopOf="@id/tv_total_attendance_count"
-                app:layout_constraintEnd_toEndOf="@id/pie_chart"
-                app:layout_constraintStart_toStartOf="@id/pie_chart"
-                app:layout_constraintTop_toTopOf="@id/pie_chart"
-                app:layout_constraintVertical_chainStyle="packed"
-                tools:text="58%" />
+                <TextView
+                    android:id="@+id/tv_winning_percentage"
+                    style="@style/TextView.Pretendard.Bold.40"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:includeFontPadding="false"
+                    android:text="@{@string/stats_percentage(myStatsUiModel.winningPercentage)}"
+                    android:textColor="@color/primary500"
+                    app:layout_constraintBottom_toTopOf="@id/tv_total_attendance_count"
+                    app:layout_constraintEnd_toEndOf="@id/pie_chart"
+                    app:layout_constraintStart_toStartOf="@id/pie_chart"
+                    app:layout_constraintTop_toTopOf="@id/pie_chart"
+                    app:layout_constraintVertical_chainStyle="packed"
+                    tools:text="58%" />
 
                 <TextView
                     android:id="@+id/tv_total_attendance_count"
@@ -186,6 +187,7 @@
                 android:layout_marginTop="20dp"
                 android:layout_marginEnd="10dp"
                 android:background="@drawable/bg_white_radius_12dp"
+                android:paddingVertical="20dp"
                 app:layout_constraintEnd_toStartOf="@id/constraint_lucky_stadium"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@id/constraint_my_stats">
@@ -194,7 +196,6 @@
                     android:id="@+id/tv_my_team_emoji"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_marginTop="20dp"
                     android:text="@string/stats_my_team_emoji"
                     android:textSize="28sp"
                     app:layout_constraintEnd_toEndOf="parent"
@@ -218,7 +219,6 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="4dp"
-                    android:layout_marginBottom="20dp"
                     android:text="@string/stats_my_team"
                     android:textColor="@color/gray500"
                     app:layout_constraintBottom_toBottomOf="parent"
@@ -234,6 +234,7 @@
                 android:layout_marginStart="10dp"
                 android:layout_marginEnd="20dp"
                 android:background="@drawable/bg_white_radius_12dp"
+                android:paddingVertical="20dp"
                 app:layout_constraintBottom_toBottomOf="@id/constraint_my_team"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toEndOf="@id/constraint_my_team"
@@ -244,7 +245,6 @@
                     android:id="@+id/tv_lucky_stadium_emoji"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_marginTop="20dp"
                     android:text="@string/stats_my_lucky_stadium_emoji"
                     android:textSize="28sp"
                     app:layout_constraintEnd_toEndOf="parent"
@@ -257,7 +257,7 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="16dp"
-                    android:text="@{myStatsUiModel.luckyStadium}"
+                    android:text="@{myStatsUiModel.luckyStadium != null ? myStatsUiModel.luckyStadium : @string/stats_my_no_lucky_stadium}"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toBottomOf="@id/tv_lucky_stadium_emoji"
@@ -268,7 +268,6 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="4dp"
-                    android:layout_marginBottom="20dp"
                     android:text="@string/stats_my_lucky_stadium"
                     android:textColor="@color/gray500"
                     app:layout_constraintBottom_toBottomOf="parent"

--- a/android/app/src/main/res/layout/fragment_my_stats.xml
+++ b/android/app/src/main/res/layout/fragment_my_stats.xml
@@ -10,168 +10,273 @@
             type="com.yagubogu.presentation.stats.my.MyStatsUiModel" />
     </data>
 
-    <androidx.constraintlayout.widget.ConstraintLayout
+    <ScrollView
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         tools:context=".presentation.stats.my.MyStatsFragment">
 
         <androidx.constraintlayout.widget.ConstraintLayout
-            android:id="@+id/constraint_my_team"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginHorizontal="20dp"
-            android:layout_marginTop="16dp"
-            android:background="@drawable/bg_white_radius_12dp"
-            android:padding="20dp"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent">
-
-            <TextView
-                android:id="@+id/tv_my_chart_title"
-                style="@style/TextView.Pretendard.Bold.20"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/stats_my_pie_chart_title"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent" />
-
-            <com.github.mikephil.charting.charts.PieChart
-                android:id="@+id/pie_chart"
-                android:layout_width="200dp"
-                android:layout_height="200dp"
-                android:layout_marginTop="20dp"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/tv_my_chart_title" />
-
-            <TextView
-                android:id="@+id/tv_winning_percentage"
-                style="@style/TextView.Pretendard.Bold.40"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:includeFontPadding="false"
-                android:text="@{@string/stats_pie_chart_winning_percentage(myStatsUiModel.winningPercentage)}"
-                android:textColor="@color/primary500"
-                app:layout_constraintBottom_toTopOf="@id/tv_total_attendance_count"
-                app:layout_constraintEnd_toEndOf="@id/pie_chart"
-                app:layout_constraintStart_toStartOf="@id/pie_chart"
-                app:layout_constraintTop_toTopOf="@id/pie_chart"
-                app:layout_constraintVertical_chainStyle="packed"
-                tools:text="58%" />
-
-            <TextView
-                android:id="@+id/tv_total_attendance_count"
-                style="@style/TextView.Pretendard.Medium.16"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:includeFontPadding="false"
-                android:text="@{@string/stats_my_pie_chart_attendance_count(myStatsUiModel.totalCount)}"
-                android:textColor="@color/gray500"
-                app:layout_constraintBottom_toBottomOf="@id/pie_chart"
-                app:layout_constraintEnd_toEndOf="@id/pie_chart"
-                app:layout_constraintStart_toStartOf="@id/pie_chart"
-                app:layout_constraintTop_toBottomOf="@id/tv_winning_percentage"
-                tools:text="24 경기" />
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content">
 
             <androidx.constraintlayout.widget.ConstraintLayout
-                android:id="@+id/constraint_win_count"
+                android:id="@+id/constraint_my_stats"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
-                android:layout_marginTop="30dp"
-                app:layout_constraintEnd_toStartOf="@id/constraint_draw_count"
+                android:layout_marginHorizontal="20dp"
+                android:layout_marginTop="16dp"
+                android:background="@drawable/bg_white_radius_12dp"
+                android:padding="20dp"
+                app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/pie_chart">
+                app:layout_constraintTop_toTopOf="parent">
 
                 <TextView
-                    android:id="@+id/tv_win_title"
-                    style="@style/TextView.Pretendard.Medium.16"
+                    android:id="@+id/tv_my_chart_title"
+                    style="@style/TextView.Pretendard.Bold.20"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:text="@string/stats_my_pie_chart_win"
-                    app:layout_constraintEnd_toEndOf="parent"
+                    android:text="@string/stats_my_pie_chart_title"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toTopOf="parent" />
 
+                <com.github.mikephil.charting.charts.PieChart
+                    android:id="@+id/pie_chart"
+                    android:layout_width="200dp"
+                    android:layout_height="200dp"
+                    android:layout_marginTop="20dp"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/tv_my_chart_title" />
+
                 <TextView
-                    android:id="@+id/tv_win_count"
-                    style="@style/TextView.Pretendard.Bold.32"
+                    android:id="@+id/tv_winning_percentage"
+                    style="@style/TextView.Pretendard.Bold.40"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_marginTop="6dp"
-                    android:text="@{String.valueOf(myStatsUiModel.winCount)}"
+                    android:includeFontPadding="false"
+                    android:text="@{@string/stats_pie_chart_winning_percentage(myStatsUiModel.winningPercentage)}"
                     android:textColor="@color/primary500"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@id/tv_win_title"
-                    tools:text="18" />
-            </androidx.constraintlayout.widget.ConstraintLayout>
-
-            <androidx.constraintlayout.widget.ConstraintLayout
-                android:id="@+id/constraint_draw_count"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="30dp"
-                app:layout_constraintEnd_toStartOf="@id/constraint_lose_count"
-                app:layout_constraintStart_toEndOf="@id/constraint_win_count"
-                app:layout_constraintTop_toBottomOf="@id/pie_chart">
+                    app:layout_constraintBottom_toTopOf="@id/tv_total_attendance_count"
+                    app:layout_constraintEnd_toEndOf="@id/pie_chart"
+                    app:layout_constraintStart_toStartOf="@id/pie_chart"
+                    app:layout_constraintTop_toTopOf="@id/pie_chart"
+                    app:layout_constraintVertical_chainStyle="packed"
+                    tools:text="58%" />
 
                 <TextView
-                    android:id="@+id/tv_draw_title"
+                    android:id="@+id/tv_total_attendance_count"
                     style="@style/TextView.Pretendard.Medium.16"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:text="@string/stats_my_pie_chart_draw"
+                    android:includeFontPadding="false"
+                    android:text="@{@string/stats_my_pie_chart_attendance_count(myStatsUiModel.totalCount)}"
+                    android:textColor="@color/gray500"
+                    app:layout_constraintBottom_toBottomOf="@id/pie_chart"
+                    app:layout_constraintEnd_toEndOf="@id/pie_chart"
+                    app:layout_constraintStart_toStartOf="@id/pie_chart"
+                    app:layout_constraintTop_toBottomOf="@id/tv_winning_percentage"
+                    tools:text="24 경기" />
+
+                <androidx.constraintlayout.widget.ConstraintLayout
+                    android:id="@+id/constraint_win_count"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="30dp"
+                    app:layout_constraintEnd_toStartOf="@id/constraint_draw_count"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/pie_chart">
+
+                    <TextView
+                        android:id="@+id/tv_win_title"
+                        style="@style/TextView.Pretendard.Medium.16"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/stats_my_pie_chart_win"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toTopOf="parent" />
+
+                    <TextView
+                        android:id="@+id/tv_win_count"
+                        style="@style/TextView.Pretendard.Bold.32"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="6dp"
+                        android:text="@{String.valueOf(myStatsUiModel.winCount)}"
+                        android:textColor="@color/primary500"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toBottomOf="@id/tv_win_title"
+                        tools:text="18" />
+                </androidx.constraintlayout.widget.ConstraintLayout>
+
+                <androidx.constraintlayout.widget.ConstraintLayout
+                    android:id="@+id/constraint_draw_count"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="30dp"
+                    app:layout_constraintEnd_toStartOf="@id/constraint_lose_count"
+                    app:layout_constraintStart_toEndOf="@id/constraint_win_count"
+                    app:layout_constraintTop_toBottomOf="@id/pie_chart">
+
+                    <TextView
+                        android:id="@+id/tv_draw_title"
+                        style="@style/TextView.Pretendard.Medium.16"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/stats_my_pie_chart_draw"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toTopOf="parent" />
+
+                    <TextView
+                        android:id="@+id/tv_draw_count"
+                        style="@style/TextView.Pretendard.Bold.32"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="6dp"
+                        android:text="@{String.valueOf(myStatsUiModel.drawCount)}"
+                        android:textColor="@color/gray400"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toBottomOf="@id/tv_draw_title"
+                        tools:text="1" />
+                </androidx.constraintlayout.widget.ConstraintLayout>
+
+                <androidx.constraintlayout.widget.ConstraintLayout
+                    android:id="@+id/constraint_lose_count"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="30dp"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toEndOf="@id/constraint_draw_count"
+                    app:layout_constraintTop_toBottomOf="@id/pie_chart">
+
+                    <TextView
+                        android:id="@+id/tv_lose_title"
+                        style="@style/TextView.Pretendard.Medium.16"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/stats_my_pie_chart_lose"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toTopOf="parent" />
+
+                    <TextView
+                        android:id="@+id/tv_lose_count"
+                        style="@style/TextView.Pretendard.Bold.32"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="6dp"
+                        android:text="@{String.valueOf(myStatsUiModel.loseCount)}"
+                        android:textColor="@color/red"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toBottomOf="@id/tv_lose_title"
+                        tools:text="5" />
+                </androidx.constraintlayout.widget.ConstraintLayout>
+            </androidx.constraintlayout.widget.ConstraintLayout>
+
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:id="@+id/constraint_my_team"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="20dp"
+                android:layout_marginTop="20dp"
+                android:layout_marginEnd="10dp"
+                android:background="@drawable/bg_white_radius_12dp"
+                app:layout_constraintEnd_toStartOf="@id/constraint_lucky_stadium"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/constraint_my_stats">
+
+                <TextView
+                    android:id="@+id/tv_my_team_emoji"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="20dp"
+                    android:text="@string/stats_my_team_emoji"
+                    android:textSize="28sp"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toTopOf="parent" />
 
                 <TextView
-                    android:id="@+id/tv_draw_count"
-                    style="@style/TextView.Pretendard.Bold.32"
+                    android:id="@+id/tv_my_team_name"
+                    style="@style/TextView.Pretendard.SemiBold.20"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_marginTop="6dp"
-                    android:text="@{String.valueOf(myStatsUiModel.drawCount)}"
-                    android:textColor="@color/gray400"
+                    android:layout_marginTop="16dp"
+                    android:text="KIA"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@id/tv_draw_title"
-                    tools:text="1" />
+                    app:layout_constraintTop_toBottomOf="@id/tv_my_team_emoji"
+                    tools:text="KIA" />
+
+                <TextView
+                    style="@style/TextView.Pretendard.Regular.12"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="4dp"
+                    android:layout_marginBottom="20dp"
+                    android:text="@string/stats_my_team"
+                    android:textColor="@color/gray500"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/tv_my_team_name" />
             </androidx.constraintlayout.widget.ConstraintLayout>
 
             <androidx.constraintlayout.widget.ConstraintLayout
-                android:id="@+id/constraint_lose_count"
+                android:id="@+id/constraint_lucky_stadium"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
-                android:layout_marginTop="30dp"
+                android:layout_marginStart="10dp"
+                android:layout_marginEnd="20dp"
+                android:background="@drawable/bg_white_radius_12dp"
+                app:layout_constraintBottom_toBottomOf="@id/constraint_my_team"
                 app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toEndOf="@id/constraint_draw_count"
-                app:layout_constraintTop_toBottomOf="@id/pie_chart">
+                app:layout_constraintStart_toEndOf="@id/constraint_my_team"
+                app:layout_constraintTop_toBottomOf="@id/constraint_my_stats"
+                app:layout_constraintTop_toTopOf="@id/constraint_my_team">
 
                 <TextView
-                    android:id="@+id/tv_lose_title"
-                    style="@style/TextView.Pretendard.Medium.16"
+                    android:id="@+id/tv_lucky_stadium_emoji"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:text="@string/stats_my_pie_chart_lose"
+                    android:layout_marginTop="20dp"
+                    android:text="@string/stats_my_lucky_stadium_emoji"
+                    android:textSize="28sp"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toTopOf="parent" />
 
                 <TextView
-                    android:id="@+id/tv_lose_count"
-                    style="@style/TextView.Pretendard.Bold.32"
+                    android:id="@+id/tv_lucky_stadium_name"
+                    style="@style/TextView.Pretendard.SemiBold.20"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_marginTop="6dp"
-                    android:text="@{String.valueOf(myStatsUiModel.loseCount)}"
-                    android:textColor="@color/red"
+                    android:layout_marginTop="16dp"
+                    android:text="@{myStatsUiModel.luckyStadium}"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@id/tv_lose_title"
-                    tools:text="5" />
+                    app:layout_constraintTop_toBottomOf="@id/tv_lucky_stadium_emoji"
+                    tools:text="챔피언스필드" />
+
+                <TextView
+                    style="@style/TextView.Pretendard.Regular.12"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="4dp"
+                    android:layout_marginBottom="20dp"
+                    android:text="@string/stats_my_lucky_stadium"
+                    android:textColor="@color/gray500"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/tv_lucky_stadium_name" />
             </androidx.constraintlayout.widget.ConstraintLayout>
+
         </androidx.constraintlayout.widget.ConstraintLayout>
-    </androidx.constraintlayout.widget.ConstraintLayout>
+    </ScrollView>
 </layout>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -33,4 +33,8 @@
     <string name="stats_my_pie_chart_win">승리</string>
     <string name="stats_my_pie_chart_draw">무승부</string>
     <string name="stats_my_pie_chart_lose">패배</string>
+    <string name="stats_my_team">최다 응원팀</string>
+    <string name="stats_my_lucky_stadium">행운의 구장</string>
+    <string name="stats_my_team_emoji">🏆</string>
+    <string name="stats_my_lucky_stadium_emoji">🍀</string>
 </resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -37,6 +37,7 @@
     <string name="stats_my_lucky_stadium">행운의 구장</string>
     <string name="stats_my_team_emoji">🏆</string>
     <string name="stats_my_lucky_stadium_emoji">🍀</string>
+    <string name="stats_my_no_lucky_stadium">없어요..</string>
 
     <string name="stats_stadium_pie_chart_title">%s 현황</string>
     <string name="stats_stadium_refresh_time">%02d:%02d 기준</string>

--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -42,6 +42,10 @@
         <item name="android:textSize">16sp</item>
     </style>
 
+    <style name="TextView.Pretendard.SemiBold.20" parent="TextView.Pretendard.SemiBold">
+        <item name="android:textSize">20sp</item>
+    </style>
+
     <style name="TextView.Pretendard.Bold" parent="TextView.Pretendard">
         <item name="android:fontFamily">@font/pretendard_bold</item>
         <item name="android:textColor">@color/black</item>


### PR DESCRIPTION
## 📌 관련 이슈
- close #73 

## ✨ 변경 내용
- 직관 승률 조회: GET `/api/stats/win-rate?memberId={memberId}&year={year}`
- 승/패/무, 총 내 팀 직관 횟수 조회: GET `/api/stats/counts?memberId={memberId}&year={year}`
- 행운의 구장 조회: GET `/api/stats/lucky-stadiums?memberId={memberId={memberId}&year={year}`
- 내 통계 관련 API 연결 및 DataSource, Repository, ViewModel 구현
- 내 통계 화면 행운의 구장, 최다 응원팀 UI 구현

## 🎸 기타 참고 사항
- 스크린샷, 참고 링크, 추가 설명 등 (없으면 생략 가능)
<img width="35%" alt="Screenshot_20250724_154143" src="https://github.com/user-attachments/assets/8329964b-9e4f-40d7-ba53-09640ca503a8" />
