### PR TITLE
feat: 구장별 팬 점유율 조회 시 응답 데이터 추가

### DIFF
--- a/backend/src/main/java/com/yagubogu/stadium/dto/TeamOccupancyRatesResponse.java
+++ b/backend/src/main/java/com/yagubogu/stadium/dto/TeamOccupancyRatesResponse.java
@@ -3,6 +3,7 @@ package com.yagubogu.stadium.dto;
 import java.util.List;
 
 public record TeamOccupancyRatesResponse(
+        String stadiumShortName,
         List<TeamOccupancyRate> teams
 ) {
     public record TeamOccupancyRate(

--- a/backend/src/main/java/com/yagubogu/stadium/service/StadiumService.java
+++ b/backend/src/main/java/com/yagubogu/stadium/service/StadiumService.java
@@ -33,7 +33,7 @@ public class StadiumService {
         Game game = getGame(stadium, date);
         int checkInPeople = checkInRepository.countByGame(game);
 
-        return getOccupancyRateTotalResponse(game, checkInPeople);
+        return getOccupancyRateTotalResponse(stadium, game, checkInPeople);
     }
 
     private Stadium getStadiumById(final long stadiumId) {
@@ -46,18 +46,24 @@ public class StadiumService {
                 .orElseThrow(() -> new NotFoundException("Game is not found"));
     }
 
-    private TeamOccupancyRatesResponse getOccupancyRateTotalResponse(final Game game, final int checkInPeople) {
+    private TeamOccupancyRatesResponse getOccupancyRateTotalResponse(
+            final Stadium stadium,
+            final Game game,
+            final int checkInPeople
+    ) {
         List<TeamCheckInCountResponse> teamCheckIns = checkInRepository.countCheckInGroupByTeam(game);
 
-        return new TeamOccupancyRatesResponse(teamCheckIns.stream()
-                .map(response -> {
-                    long teamId = response.id();
-                    String teamName = response.name();
-                    double occupancyRate = (1.0 * response.count()) / checkInPeople * 100;
-                    double roundedOccupancyRate = calculateRoundRate(occupancyRate);
-                    return new TeamOccupancyRate(teamId, teamName, roundedOccupancyRate);
-                })
-                .toList());
+        return new TeamOccupancyRatesResponse(
+                stadium.getShortName(),
+                teamCheckIns.stream()
+                        .map(response -> {
+                            long teamId = response.id();
+                            String teamName = response.name();
+                            double occupancyRate = (1.0 * response.count()) / checkInPeople * 100;
+                            double roundedOccupancyRate = calculateRoundRate(occupancyRate);
+                            return new TeamOccupancyRate(teamId, teamName, roundedOccupancyRate);
+                        })
+                        .toList());
     }
 
     private double calculateRoundRate(final double rate) {

--- a/backend/src/test/java/com/yagubogu/stadium/StadiumIntegrationTest.java
+++ b/backend/src/test/java/com/yagubogu/stadium/StadiumIntegrationTest.java
@@ -1,5 +1,8 @@
 package com.yagubogu.stadium;
 
+import static com.yagubogu.fixture.TestFixture.getToday;
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.yagubogu.stadium.dto.StadiumResponse;
 import com.yagubogu.stadium.dto.StadiumsResponse;
 import com.yagubogu.stadium.dto.TeamOccupancyRatesResponse;
@@ -16,9 +19,6 @@ import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.annotation.DirtiesContext.ClassMode;
 import org.springframework.test.context.TestPropertySource;
-
-import static com.yagubogu.fixture.TestFixture.getToday;
-import static org.assertj.core.api.Assertions.assertThat;
 
 @TestPropertySource(properties = {
         "spring.sql.init.data-locations=classpath:test-data.sql"
@@ -60,6 +60,7 @@ public class StadiumIntegrationTest {
     void findStatCounts() {
         // given
         TeamOccupancyRatesResponse expected = new TeamOccupancyRatesResponse(
+                "잠실구장",
                 List.of(
                         new TeamOccupancyRate(1L, "기아", 66.7),
                         new TeamOccupancyRate(2L, "롯데", 33.3)


### PR DESCRIPTION
## 📌 관련 이슈
- close #106 

## ✨ 변경 내용
- 구장별 팬 점유율 조회 시 구장 별명 응답 데이터 추가

## 🎸 기타 참고 사항
- 스크린샷, 참고 링크, 추가 설명 등 (없으면 생략 가능)