### PR TITLE
feat: 경기하는 모든 구장, 팀 조회 기능 구현

### DIFF
--- a/backend/src/main/java/com/yagubogu/game/controller/GameController.java
+++ b/backend/src/main/java/com/yagubogu/game/controller/GameController.java
@@ -1,0 +1,28 @@
+package com.yagubogu.game.controller;
+
+import com.yagubogu.game.dto.GamesResponse;
+import com.yagubogu.game.service.GameService;
+import java.time.LocalDate;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RequestMapping("/api/games")
+@RestController
+public class GameController {
+
+    private final GameService gameService;
+
+    @GetMapping
+    public ResponseEntity<GamesResponse> findGamesByDate(
+            @RequestParam(name = "date") final LocalDate date
+    ) {
+        GamesResponse gamesResponse = gameService.findGamesByDate(date);
+
+        return ResponseEntity.ok(gamesResponse);
+    }
+}

--- a/backend/src/main/java/com/yagubogu/game/dto/GamesResponse.java
+++ b/backend/src/main/java/com/yagubogu/game/dto/GamesResponse.java
@@ -1,0 +1,49 @@
+package com.yagubogu.game.dto;
+
+import com.yagubogu.game.domain.Game;
+import java.util.List;
+
+public record GamesResponse(List<GameResponse> games) {
+
+    public static GamesResponse from(List<Game> games) {
+        return new GamesResponse(
+                games.stream()
+                        .map(GameResponse::from)
+                        .toList()
+        );
+    }
+
+    public record GameResponse(
+            StadiumInfoResponse stadium,
+            TeamInfoResponse homeTeam,
+            TeamInfoResponse awayTeam
+    ) {
+        public static GameResponse from(Game game) {
+
+            return new GameResponse(
+                    new StadiumInfoResponse(
+                            game.getStadium().getId(),
+                            game.getStadium().getFullName()
+                    ),
+                    new TeamInfoResponse(
+                            game.getHomeTeam().getId(),
+                            game.getHomeTeam().getName(),
+                            game.getHomeTeam().getTeamCode()
+                    ),
+                    new TeamInfoResponse(
+                            game.getAwayTeam().getId(),
+                            game.getAwayTeam().getName(),
+                            game.getAwayTeam().getTeamCode()
+                    )
+            );
+        }
+    }
+
+    public record StadiumInfoResponse(Long id, String name) {
+    }
+
+    public record TeamInfoResponse(Long id, String name, String code) {
+    }
+}
+
+

--- a/backend/src/main/java/com/yagubogu/game/repository/GameRepository.java
+++ b/backend/src/main/java/com/yagubogu/game/repository/GameRepository.java
@@ -3,6 +3,7 @@ package com.yagubogu.game.repository;
 import com.yagubogu.game.domain.Game;
 import com.yagubogu.stadium.domain.Stadium;
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -11,4 +12,6 @@ import org.springframework.stereotype.Repository;
 public interface GameRepository extends JpaRepository<Game, Long> {
 
     Optional<Game> findByStadiumAndDate(Stadium stadium, LocalDate date);
+
+    List<Game> findByDate(LocalDate date);
 }

--- a/backend/src/main/java/com/yagubogu/game/service/GameService.java
+++ b/backend/src/main/java/com/yagubogu/game/service/GameService.java
@@ -1,11 +1,13 @@
 package com.yagubogu.game.service;
 
 import com.yagubogu.game.domain.Game;
+import com.yagubogu.game.dto.GamesResponse;
 import com.yagubogu.game.dto.KboClientResponse;
 import com.yagubogu.game.dto.KboGameResponse;
 import com.yagubogu.game.repository.GameRepository;
 import com.yagubogu.game.service.client.KboClient;
 import com.yagubogu.global.exception.ClientException;
+import com.yagubogu.global.exception.UnprocessableEntityException;
 import com.yagubogu.stadium.domain.Stadium;
 import com.yagubogu.stadium.repository.StadiumRepository;
 import com.yagubogu.team.domain.Team;
@@ -57,6 +59,19 @@ public class GameService {
             games.add(game);
         }
         gameRepository.saveAll(games);
+    }
+
+    public GamesResponse findGamesByDate(final LocalDate date) {
+        validateIsNotFuture(date);
+        List<Game> games = gameRepository.findByDate(date);
+
+        return GamesResponse.from(games);
+    }
+
+    private void validateIsNotFuture(final LocalDate date) {
+        if (date.isAfter(LocalDate.now())) {
+            throw new UnprocessableEntityException("Future dates cannot be retrieved.");
+        }
     }
 
     private Stadium getStadiumByName(final String stadiumName) {

--- a/backend/src/main/java/com/yagubogu/global/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/yagubogu/global/GlobalExceptionHandler.java
@@ -2,6 +2,7 @@ package com.yagubogu.global;
 
 import com.yagubogu.global.exception.ForbiddenException;
 import com.yagubogu.global.exception.NotFoundException;
+import com.yagubogu.global.exception.UnprocessableEntityException;
 import com.yagubogu.global.exception.YaguBoguException;
 import com.yagubogu.global.exception.dto.ExceptionResponse;
 import org.springframework.http.HttpStatus;
@@ -27,6 +28,15 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(value = NotFoundException.class)
     @ResponseStatus(HttpStatus.NOT_FOUND)
     public ExceptionResponse handleNotFoundException(final NotFoundException e) {
+        return new ExceptionResponse(e.getMessage());
+    }
+
+    /**
+     * 422 UnprocessableEntity
+     */
+    @ExceptionHandler(value = UnprocessableEntityException.class)
+    @ResponseStatus(HttpStatus.UNPROCESSABLE_ENTITY)
+    public ExceptionResponse handleUnprocessableException(final UnprocessableEntityException e) {
         return new ExceptionResponse(e.getMessage());
     }
 

--- a/backend/src/main/java/com/yagubogu/global/exception/UnprocessableEntityException.java
+++ b/backend/src/main/java/com/yagubogu/global/exception/UnprocessableEntityException.java
@@ -1,0 +1,7 @@
+package com.yagubogu.global.exception;
+
+public class UnprocessableEntityException extends YaguBoguException {
+    public UnprocessableEntityException(final String message) {
+        super(message);
+    }
+}

--- a/backend/src/test/java/com/yagubogu/game/GameIntegrationTest.java
+++ b/backend/src/test/java/com/yagubogu/game/GameIntegrationTest.java
@@ -1,0 +1,80 @@
+package com.yagubogu.game;
+
+import com.yagubogu.fixture.TestFixture;
+import com.yagubogu.game.dto.GamesResponse;
+import com.yagubogu.game.dto.GamesResponse.GameResponse;
+import com.yagubogu.game.dto.GamesResponse.StadiumInfoResponse;
+import com.yagubogu.game.dto.GamesResponse.TeamInfoResponse;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import java.time.LocalDate;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.DirtiesContext.ClassMode;
+import org.springframework.test.context.TestPropertySource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@TestPropertySource(properties = {
+        "spring.sql.init.data-locations=classpath:test-data.sql"
+})
+@DirtiesContext(classMode = ClassMode.AFTER_EACH_TEST_METHOD)
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+public class GameIntegrationTest {
+
+    @LocalServerPort
+    private int port;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+    }
+
+    @DisplayName("경기하고 있는 모든 구장, 팀을 조회한다")
+    @Test
+    void findGamesByDate() {
+        // given
+        LocalDate date = TestFixture.getToday();
+        List<GameResponse> expected = List.of(
+                new GameResponse(
+                        new StadiumInfoResponse(1L, "잠실 야구장"),
+                        new TeamInfoResponse(1L, "기아 타이거즈", "HT"),
+                        new TeamInfoResponse(2L, "롯데 자이언츠", "LT")
+                )
+        );
+
+        // when
+        GamesResponse actual = RestAssured.given().log().all()
+                .contentType(ContentType.JSON)
+                .queryParam("date", date.toString())
+                .when().get("/api/games")
+                .then().log().all()
+                .statusCode(200)
+                .extract()
+                .as(GamesResponse.class);
+
+        // then
+        assertThat(actual.games()).containsExactlyElementsOf(expected);
+    }
+
+    @DisplayName("예외: 미래 날짜를 조회하려고 하면 예외가 발생한다")
+    @Test
+    void findGamesByDate_WhenDateIsInFuture() {
+        // given
+        LocalDate invalidDate = LocalDate.of(3000, 12, 12);
+
+        // when & then
+        RestAssured.given().log().all()
+                .contentType(ContentType.JSON)
+                .queryParam("date", invalidDate.toString())
+                .when().get("/api/games")
+                .then().log().all()
+                .statusCode(422);
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈
- close #159 

## ✨ 변경 내용
- 경기하는 모든 구장, 팀 조회 기능 구현

## 🎸 기타 참고 사항
미래 날짜에 대해 조회를 하려고 하면 422번 예외 상태를 반환하도록 했습니다.
그 이유는, 
컨트롤러는 요청 문법상 문제 없어서 통과,
서비스 레이어에서 비즈니스 룰(미래 날짜 불가) 위반으로 막음,
그래서 400 Bad Request는 ‘문법적 잘못된 요청’ 느낌이라 적합하지 않다고 생각됨.

결국, 요청 형식은 맞지만(컨트롤러 통과), 의미상 처리가 불가능하다는 점을 명확히 표현해줌 -> 그래서,, 422가 아닐까? 했습니다