### PR TITLE
feat: 현장톡 구장 선택 API 연동

### DIFF
--- a/android/app/src/main/java/com/yagubogu/YaguBoguApplication.kt
+++ b/android/app/src/main/java/com/yagubogu/YaguBoguApplication.kt
@@ -6,12 +6,14 @@ import com.google.firebase.crashlytics.FirebaseCrashlytics
 import com.yagubogu.common.YaguBoguDebugTree
 import com.yagubogu.common.YaguBoguReleaseTree
 import com.yagubogu.data.datasource.CheckInsRemoteDataSource
+import com.yagubogu.data.datasource.GamesRemoteDataSource
 import com.yagubogu.data.datasource.LocationLocalDataSource
 import com.yagubogu.data.datasource.MemberRemoteDataSource
 import com.yagubogu.data.datasource.StadiumRemoteDataSource
 import com.yagubogu.data.datasource.StatsRemoteDataSource
 import com.yagubogu.data.network.RetrofitInstance
 import com.yagubogu.data.repository.CheckInsDefaultRepository
+import com.yagubogu.data.repository.GamesDefaultRepository
 import com.yagubogu.data.repository.LocationDefaultRepository
 import com.yagubogu.data.repository.MemberDefaultRepository
 import com.yagubogu.data.repository.StadiumDefaultRepository
@@ -34,6 +36,9 @@ class YaguBoguApplication : Application() {
 
     private val statsDataSource by lazy { StatsRemoteDataSource(RetrofitInstance.statsApiService) }
     val statsRepository by lazy { StatsDefaultRepository(statsDataSource) }
+
+    private val gamesDataSource by lazy { GamesRemoteDataSource(RetrofitInstance.gamesApiService) }
+    val gamesRepository by lazy { GamesDefaultRepository(gamesDataSource) }
 
     override fun onCreate() {
         super.onCreate()

--- a/android/app/src/main/java/com/yagubogu/data/datasource/GamesDataSource.kt
+++ b/android/app/src/main/java/com/yagubogu/data/datasource/GamesDataSource.kt
@@ -1,0 +1,11 @@
+package com.yagubogu.data.datasource
+
+import com.yagubogu.data.dto.response.games.GamesResponse
+import java.time.LocalDate
+
+interface GamesDataSource {
+    suspend fun getGames(
+        token: String,
+        date: LocalDate,
+    ): Result<GamesResponse>
+}

--- a/android/app/src/main/java/com/yagubogu/data/datasource/GamesRemoteDataSource.kt
+++ b/android/app/src/main/java/com/yagubogu/data/datasource/GamesRemoteDataSource.kt
@@ -1,0 +1,18 @@
+package com.yagubogu.data.datasource
+
+import com.yagubogu.data.dto.response.games.GamesResponse
+import com.yagubogu.data.service.GamesApiService
+import com.yagubogu.data.util.safeApiCall
+import java.time.LocalDate
+
+class GamesRemoteDataSource(
+    private val gamesApiService: GamesApiService,
+) : GamesDataSource {
+    override suspend fun getGames(
+        token: String,
+        date: LocalDate,
+    ): Result<GamesResponse> =
+        safeApiCall {
+            gamesApiService.getGames(token, date.toString())
+        }
+}

--- a/android/app/src/main/java/com/yagubogu/data/dto/response/games/GameDto.kt
+++ b/android/app/src/main/java/com/yagubogu/data/dto/response/games/GameDto.kt
@@ -1,0 +1,28 @@
+package com.yagubogu.data.dto.response.games
+
+import com.yagubogu.presentation.livetalk.stadium.LivetalkStadiumItem
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class GameDto(
+    @SerialName("totalCheckIns")
+    val totalCheckIns: Int, // 경기장에 인증한 사람 수
+    @SerialName("isMyCheckIn")
+    val isMyCheckIn: Boolean, // 인증 여부
+    @SerialName("stadium")
+    val stadiumDto: StadiumDto,
+    @SerialName("homeTeam")
+    val homeTeam: TeamDto,
+    @SerialName("awayTeam")
+    val awayTeam: TeamDto,
+) {
+    fun toPresentation(): LivetalkStadiumItem =
+        LivetalkStadiumItem(
+            stadiumName = stadiumDto.name,
+            userCount = totalCheckIns,
+            awayTeam = awayTeam.toDomain(),
+            homeTeam = homeTeam.toDomain(),
+            isVerified = isMyCheckIn,
+        )
+}

--- a/android/app/src/main/java/com/yagubogu/data/dto/response/games/GamesResponse.kt
+++ b/android/app/src/main/java/com/yagubogu/data/dto/response/games/GamesResponse.kt
@@ -1,0 +1,10 @@
+package com.yagubogu.data.dto.response.games
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class GamesResponse(
+    @SerialName("games")
+    val games: List<GameDto>,
+)

--- a/android/app/src/main/java/com/yagubogu/data/dto/response/games/StadiumDto.kt
+++ b/android/app/src/main/java/com/yagubogu/data/dto/response/games/StadiumDto.kt
@@ -1,0 +1,12 @@
+package com.yagubogu.data.dto.response.games
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class StadiumDto(
+    @SerialName("id")
+    val id: Int, // 경기장 식별자
+    @SerialName("name")
+    val name: String, // 경기장 이름
+)

--- a/android/app/src/main/java/com/yagubogu/data/dto/response/games/TeamDto.kt
+++ b/android/app/src/main/java/com/yagubogu/data/dto/response/games/TeamDto.kt
@@ -1,0 +1,17 @@
+package com.yagubogu.data.dto.response.games
+
+import com.yagubogu.domain.model.Team
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class TeamDto(
+    @SerialName("id")
+    val id: Int, // 팀 식별자
+    @SerialName("name")
+    val name: String, // 팀 이름
+    @SerialName("code")
+    val code: String, // 팀 코드
+) {
+    fun toDomain(): Team = Team.getByCode(code)
+}

--- a/android/app/src/main/java/com/yagubogu/data/network/RetrofitInstance.kt
+++ b/android/app/src/main/java/com/yagubogu/data/network/RetrofitInstance.kt
@@ -2,6 +2,7 @@ package com.yagubogu.data.network
 
 import com.yagubogu.BuildConfig
 import com.yagubogu.data.service.CheckInsApiService
+import com.yagubogu.data.service.GamesApiService
 import com.yagubogu.data.service.MemberApiService
 import com.yagubogu.data.service.StadiumApiService
 import com.yagubogu.data.service.StatsApiService
@@ -55,5 +56,9 @@ object RetrofitInstance {
 
     val statsApiService: StatsApiService by lazy {
         retrofit.create(StatsApiService::class.java)
+    }
+
+    val gamesApiService: GamesApiService by lazy {
+        retrofit.create(GamesApiService::class.java)
     }
 }

--- a/android/app/src/main/java/com/yagubogu/data/repository/GamesDefaultRepository.kt
+++ b/android/app/src/main/java/com/yagubogu/data/repository/GamesDefaultRepository.kt
@@ -1,0 +1,19 @@
+package com.yagubogu.data.repository
+
+import com.yagubogu.data.datasource.GamesDataSource
+import com.yagubogu.data.dto.response.games.GamesResponse
+import com.yagubogu.domain.repository.GamesRepository
+import com.yagubogu.presentation.livetalk.stadium.LivetalkStadiumItem
+import java.time.LocalDate
+
+class GamesDefaultRepository(
+    private val gamesDataSource: GamesDataSource,
+) : GamesRepository {
+    override suspend fun getGames(
+        token: String,
+        date: LocalDate,
+    ): Result<List<LivetalkStadiumItem>> =
+        gamesDataSource.getGames(token, date).map { gamesResponse: GamesResponse ->
+            gamesResponse.games.map { it.toPresentation() }
+        }
+}

--- a/android/app/src/main/java/com/yagubogu/data/service/GamesApiService.kt
+++ b/android/app/src/main/java/com/yagubogu/data/service/GamesApiService.kt
@@ -1,0 +1,15 @@
+package com.yagubogu.data.service
+
+import com.yagubogu.data.dto.response.games.GamesResponse
+import retrofit2.Response
+import retrofit2.http.GET
+import retrofit2.http.Header
+import retrofit2.http.Query
+
+interface GamesApiService {
+    @GET("/api/games")
+    suspend fun getGames(
+        @Header("Authorization") authorization: String,
+        @Query("date") date: String,
+    ): Response<GamesResponse>
+}

--- a/android/app/src/main/java/com/yagubogu/domain/repository/GamesRepository.kt
+++ b/android/app/src/main/java/com/yagubogu/domain/repository/GamesRepository.kt
@@ -1,0 +1,11 @@
+package com.yagubogu.domain.repository
+
+import com.yagubogu.presentation.livetalk.stadium.LivetalkStadiumItem
+import java.time.LocalDate
+
+interface GamesRepository {
+    suspend fun getGames(
+        token: String,
+        date: LocalDate,
+    ): Result<List<LivetalkStadiumItem>>
+}

--- a/android/app/src/main/java/com/yagubogu/presentation/livetalk/LivetalkFragment.kt
+++ b/android/app/src/main/java/com/yagubogu/presentation/livetalk/LivetalkFragment.kt
@@ -6,9 +6,10 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
 import androidx.recyclerview.widget.LinearLayoutManager
+import com.yagubogu.YaguBoguApplication
 import com.yagubogu.databinding.FragmentLivetalkBinding
-import com.yagubogu.domain.model.Team
 import com.yagubogu.presentation.livetalk.chat.LivetalkChatActivity
 import com.yagubogu.presentation.livetalk.stadium.LivetalkStadiumAdapter
 import com.yagubogu.presentation.livetalk.stadium.LivetalkStadiumItem
@@ -18,6 +19,23 @@ import com.yagubogu.presentation.livetalk.stadium.LivetalkStadiumViewHolder
 class LivetalkFragment : Fragment() {
     private var _binding: FragmentLivetalkBinding? = null
     private val binding get() = _binding!!
+
+    private val viewModel: LivetalkViewModel by viewModels {
+        val app = requireActivity().application as YaguBoguApplication
+        LivetalkViewModelFactory(app.gamesRepository)
+    }
+
+    private val livetalkStadiumAdapter by lazy {
+        LivetalkStadiumAdapter(
+            object : LivetalkStadiumViewHolder.Handler {
+                override fun onItemClick(item: LivetalkStadiumItem) {
+                    // Todo: 구장별 채팅 연동 필요
+                    val intent = Intent(binding.root.context, LivetalkChatActivity::class.java)
+                    binding.root.context.startActivity(intent)
+                }
+            },
+        )
+    }
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -34,25 +52,7 @@ class LivetalkFragment : Fragment() {
     ) {
         super.onViewCreated(view, savedInstanceState)
         setupBindings()
-    }
-
-    private fun setupBindings() {
-        val livetalkStadiumAdapter =
-            LivetalkStadiumAdapter(
-                object : LivetalkStadiumViewHolder.Handler {
-                    override fun onItemClick(item: LivetalkStadiumItem) {
-                        // Todo: 구장별 채팅 연동 필요
-                        val intent = Intent(binding.root.context, LivetalkChatActivity::class.java)
-                        binding.root.context.startActivity(intent)
-                    }
-                },
-            )
-        val linearLayoutManager = LinearLayoutManager(requireContext())
-        binding.rvLivetalkStadium.apply {
-            adapter = livetalkStadiumAdapter
-            layoutManager = linearLayoutManager
-        }
-        livetalkStadiumAdapter.submitList(DUMMY_LIVETALK_STADIUM_ITEMS)
+        setupObservers()
     }
 
     override fun onDestroyView() {
@@ -60,44 +60,17 @@ class LivetalkFragment : Fragment() {
         _binding = null
     }
 
-    companion object {
-        private val DUMMY_LIVETALK_STADIUM_ITEMS: List<LivetalkStadiumItem> =
-            listOf(
-                LivetalkStadiumItem(
-                    stadiumName = "고척 스카이돔",
-                    userCount = 120,
-                    awayTeam = Team.OB,
-                    homeTeam = Team.WO,
-                    isVerified = true,
-                ),
-                LivetalkStadiumItem(
-                    stadiumName = "잠실 야구장",
-                    userCount = 58,
-                    awayTeam = Team.LT,
-                    homeTeam = Team.LG,
-                    isVerified = false,
-                ),
-                LivetalkStadiumItem(
-                    stadiumName = "인천 SSG 랜더스필드",
-                    userCount = 44,
-                    awayTeam = Team.HT,
-                    homeTeam = Team.SK,
-                    isVerified = false,
-                ),
-                LivetalkStadiumItem(
-                    stadiumName = "대전 한화생명 볼파크",
-                    userCount = 26,
-                    awayTeam = Team.SS,
-                    homeTeam = Team.HH,
-                    isVerified = false,
-                ),
-                LivetalkStadiumItem(
-                    stadiumName = "창원 NC 파크",
-                    userCount = 10,
-                    awayTeam = Team.KT,
-                    homeTeam = Team.NC,
-                    isVerified = false,
-                ),
-            )
+    private fun setupBindings() {
+        val linearLayoutManager = LinearLayoutManager(requireContext())
+        binding.rvLivetalkStadium.apply {
+            adapter = livetalkStadiumAdapter
+            layoutManager = linearLayoutManager
+        }
+    }
+
+    private fun setupObservers() {
+        viewModel.livetalkStadiumItems.observe(viewLifecycleOwner) { value: List<LivetalkStadiumItem> ->
+            livetalkStadiumAdapter.submitList(value)
+        }
     }
 }

--- a/android/app/src/main/java/com/yagubogu/presentation/livetalk/LivetalkViewModel.kt
+++ b/android/app/src/main/java/com/yagubogu/presentation/livetalk/LivetalkViewModel.kt
@@ -1,0 +1,40 @@
+package com.yagubogu.presentation.livetalk
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.yagubogu.domain.repository.GamesRepository
+import com.yagubogu.presentation.livetalk.stadium.LivetalkStadiumItem
+import kotlinx.coroutines.launch
+import timber.log.Timber
+import java.time.LocalDate
+
+class LivetalkViewModel(
+    private val gamesRepository: GamesRepository,
+) : ViewModel() {
+    private val _livetalkStadiumItems = MutableLiveData<List<LivetalkStadiumItem>>()
+    val livetalkStadiumItems: LiveData<List<LivetalkStadiumItem>> get() = _livetalkStadiumItems
+
+    init {
+        fetchGames()
+    }
+
+    fun fetchGames() {
+        viewModelScope.launch {
+            val gamesResult: Result<List<LivetalkStadiumItem>> =
+                gamesRepository.getGames(TOKEN, DATE)
+            gamesResult
+                .onSuccess { livetalkStadiumItems: List<LivetalkStadiumItem> ->
+                    _livetalkStadiumItems.value = livetalkStadiumItems
+                }.onFailure { exception: Throwable ->
+                    Timber.w(exception, "API 호출 실패")
+                }
+        }
+    }
+
+    companion object {
+        private val DATE = LocalDate.of(2025, 7, 25) // TODO: LocalDate.now()로 변경
+        private const val TOKEN = "액세스 토큰"
+    }
+}

--- a/android/app/src/main/java/com/yagubogu/presentation/livetalk/LivetalkViewModelFactory.kt
+++ b/android/app/src/main/java/com/yagubogu/presentation/livetalk/LivetalkViewModelFactory.kt
@@ -1,0 +1,17 @@
+package com.yagubogu.presentation.livetalk
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import com.yagubogu.domain.repository.GamesRepository
+
+class LivetalkViewModelFactory(
+    private val gamesRepository: GamesRepository,
+) : ViewModelProvider.Factory {
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        if (modelClass.isAssignableFrom(LivetalkViewModel::class.java)) {
+            @Suppress("UNCHECKED_CAST")
+            return LivetalkViewModel(gamesRepository) as T
+        }
+        throw IllegalArgumentException()
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈
- close #227 

## ✨ 변경 내용
- 오늘 경기하는 모든 구장, 팀 조회: `/api/games?date={yyyy-MM-dd}`

## 🎸 기타 참고 사항
- 스크린샷, 참고 링크, 추가 설명 등 (없으면 생략 가능)
<img width="40%" alt="Screenshot_20250807_160320" src="https://github.com/user-attachments/assets/59d9f210-a511-4620-b065-981a2e76e01a" />
