### PR TITLE
feat: 회원가입 시 응원팀 선택 기능 구현

### DIFF
--- a/android/app/src/main/java/com/yagubogu/data/dto/response/MemberDto.kt
+++ b/android/app/src/main/java/com/yagubogu/data/dto/response/MemberDto.kt
@@ -6,7 +6,7 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class MemberDto(
     @SerialName("id")
-    val id: Int, // 사용자 id
+    val id: Long, // 사용자 id
     @SerialName("nickname")
     val nickname: String, // 사용자 닉네임
     @SerialName("profileImageUrl")

--- a/android/app/src/main/java/com/yagubogu/data/dto/response/MemberFavoriteResponse.kt
+++ b/android/app/src/main/java/com/yagubogu/data/dto/response/MemberFavoriteResponse.kt
@@ -6,5 +6,5 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class MemberFavoriteResponse(
     @SerialName("favorite")
-    val favorite: String, // 팀 이름
+    val favorite: String?, // 팀 이름
 )

--- a/android/app/src/main/java/com/yagubogu/data/dto/response/MemberFavoriteResponse.kt
+++ b/android/app/src/main/java/com/yagubogu/data/dto/response/MemberFavoriteResponse.kt
@@ -6,5 +6,5 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class MemberFavoriteResponse(
     @SerialName("favorite")
-    val favorite: String?, // 팀 이름
+    val favorite: String? = null, // 팀 이름
 )

--- a/android/app/src/main/java/com/yagubogu/data/repository/AuthDefaultRepository.kt
+++ b/android/app/src/main/java/com/yagubogu/data/repository/AuthDefaultRepository.kt
@@ -1,16 +1,23 @@
 package com.yagubogu.data.repository
 
 import com.yagubogu.data.datasource.AuthDataSource
+import com.yagubogu.data.dto.response.LoginResponse
 import com.yagubogu.data.network.TokenManager
+import com.yagubogu.domain.model.LoginResult
 import com.yagubogu.domain.repository.AuthRepository
 
 class AuthDefaultRepository(
     private val authDataSource: AuthDataSource,
     private val tokenManager: TokenManager,
 ) : AuthRepository {
-    override suspend fun login(idToken: String): Result<Unit> =
-        authDataSource.login(idToken).map { (accessToken, refreshToken) ->
-            tokenManager.saveTokens(accessToken, refreshToken)
+    override suspend fun login(idToken: String): Result<LoginResult> =
+        authDataSource.login(idToken).map { loginResponse: LoginResponse ->
+            tokenManager.saveTokens(loginResponse.accessToken, loginResponse.refreshToken)
+            if (loginResponse.isNew) {
+                LoginResult.SignUp
+            } else {
+                LoginResult.SignIn
+            }
         }
 
     override suspend fun refreshTokens(): Result<Unit> {

--- a/android/app/src/main/java/com/yagubogu/data/repository/MemberDefaultRepository.kt
+++ b/android/app/src/main/java/com/yagubogu/data/repository/MemberDefaultRepository.kt
@@ -10,25 +10,24 @@ class MemberDefaultRepository(
 ) : MemberRepository {
     private var cachedFavoriteTeam: String? = null
 
-    override suspend fun getFavoriteTeam(): Result<String> {
+    override suspend fun getFavoriteTeam(): Result<String?> {
         cachedFavoriteTeam?.let { favoriteTeam: String ->
             return Result.success(favoriteTeam)
         }
         return memberDataSource
             .getFavoriteTeam()
             .map { memberFavoriteResponse: MemberFavoriteResponse ->
-                val favoriteTeam = memberFavoriteResponse.favorite
+                val favoriteTeam: String? = memberFavoriteResponse.favorite
                 cachedFavoriteTeam = favoriteTeam
                 favoriteTeam
             }
     }
 
-    override suspend fun updateFavoriteTeam(team: Team): Result<String> =
+    override suspend fun updateFavoriteTeam(team: Team): Result<Unit> =
         memberDataSource
             .updateFavoriteTeam(team)
             .map { memberFavoriteResponse: MemberFavoriteResponse ->
-                val favoriteTeam = memberFavoriteResponse.favorite
+                val favoriteTeam: String? = memberFavoriteResponse.favorite
                 cachedFavoriteTeam = favoriteTeam
-                favoriteTeam
             }
 }

--- a/android/app/src/main/java/com/yagubogu/domain/model/LoginResult.kt
+++ b/android/app/src/main/java/com/yagubogu/domain/model/LoginResult.kt
@@ -1,7 +1,9 @@
 package com.yagubogu.domain.model
 
 sealed class LoginResult {
-    data object Success : LoginResult()
+    data object SignUp : LoginResult()
+
+    data object SignIn : LoginResult()
 
     data object Cancel : LoginResult()
 

--- a/android/app/src/main/java/com/yagubogu/domain/repository/AuthRepository.kt
+++ b/android/app/src/main/java/com/yagubogu/domain/repository/AuthRepository.kt
@@ -1,7 +1,9 @@
 package com.yagubogu.domain.repository
 
+import com.yagubogu.domain.model.LoginResult
+
 interface AuthRepository {
-    suspend fun login(idToken: String): Result<Unit>
+    suspend fun login(idToken: String): Result<LoginResult>
 
     suspend fun refreshTokens(): Result<Unit>
 }

--- a/android/app/src/main/java/com/yagubogu/domain/repository/MemberRepository.kt
+++ b/android/app/src/main/java/com/yagubogu/domain/repository/MemberRepository.kt
@@ -3,7 +3,7 @@ package com.yagubogu.domain.repository
 import com.yagubogu.domain.model.Team
 
 interface MemberRepository {
-    suspend fun getFavoriteTeam(): Result<String>
+    suspend fun getFavoriteTeam(): Result<String?>
 
-    suspend fun updateFavoriteTeam(team: Team): Result<String>
+    suspend fun updateFavoriteTeam(team: Team): Result<Unit>
 }

--- a/android/app/src/main/java/com/yagubogu/presentation/favorite/FavoriteTeamActivity.kt
+++ b/android/app/src/main/java/com/yagubogu/presentation/favorite/FavoriteTeamActivity.kt
@@ -1,5 +1,6 @@
 package com.yagubogu.presentation.favorite
 
+import android.content.Intent
 import android.os.Bundle
 import androidx.activity.enableEdgeToEdge
 import androidx.activity.viewModels
@@ -9,6 +10,7 @@ import androidx.core.view.WindowInsetsCompat
 import com.yagubogu.YaguBoguApplication
 import com.yagubogu.databinding.ActivityFavoriteTeamBinding
 import com.yagubogu.domain.model.Team
+import com.yagubogu.presentation.MainActivity
 
 class FavoriteTeamActivity : AppCompatActivity() {
     private val binding: ActivityFavoriteTeamBinding by lazy {
@@ -60,10 +62,16 @@ class FavoriteTeamActivity : AppCompatActivity() {
             FavoriteTeamConfirmFragment.KEY_REQUEST_SUCCESS,
             this,
         ) { _, bundle ->
-            val result: Boolean = bundle.getBoolean(FavoriteTeamConfirmFragment.KEY_CONFIRM)
-            if (result) {
+            val isConfirmed: Boolean = bundle.getBoolean(FavoriteTeamConfirmFragment.KEY_CONFIRM)
+            if (isConfirmed) {
                 selectedTeam?.let { viewModel.saveFavoriteTeam(it) }
+                navigateToMain()
             }
         }
+    }
+
+    private fun navigateToMain() {
+        startActivity(Intent(this, MainActivity::class.java))
+        finish()
     }
 }

--- a/android/app/src/main/java/com/yagubogu/presentation/favorite/FavoriteTeamActivity.kt
+++ b/android/app/src/main/java/com/yagubogu/presentation/favorite/FavoriteTeamActivity.kt
@@ -22,12 +22,11 @@ class FavoriteTeamActivity : AppCompatActivity() {
         FavoriteTeamViewModelFactory(app.memberRepository)
     }
 
-    private var selectedTeam: Team? = null
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setupView()
         setupRecyclerView()
+        setupObservers()
         setupFragmentResultListener()
     }
 
@@ -48,13 +47,19 @@ class FavoriteTeamActivity : AppCompatActivity() {
                     override fun onItemClick(item: FavoriteTeamItem) {
                         val dialog = FavoriteTeamConfirmFragment.newInstance(item)
                         dialog.show(supportFragmentManager, dialog.tag)
-                        selectedTeam = item.team
+                        viewModel.selectTeam(item.team)
                     }
                 },
             )
         binding.rvFavoriteTeamList.adapter = adapter
         val favoriteTeamItems: List<FavoriteTeamItem> = Team.entries.map { FavoriteTeamItem.of(it) }
         adapter.submitList(favoriteTeamItems)
+    }
+
+    private fun setupObservers() {
+        viewModel.favoriteTeamUpdateEvent.observe(this) {
+            navigateToMain()
+        }
     }
 
     private fun setupFragmentResultListener() {
@@ -64,8 +69,7 @@ class FavoriteTeamActivity : AppCompatActivity() {
         ) { _, bundle ->
             val isConfirmed: Boolean = bundle.getBoolean(FavoriteTeamConfirmFragment.KEY_CONFIRM)
             if (isConfirmed) {
-                selectedTeam?.let { viewModel.saveFavoriteTeam(it) }
-                navigateToMain()
+                viewModel.saveFavoriteTeam()
             }
         }
     }

--- a/android/app/src/main/java/com/yagubogu/presentation/favorite/FavoriteTeamAdapter.kt
+++ b/android/app/src/main/java/com/yagubogu/presentation/favorite/FavoriteTeamAdapter.kt
@@ -6,7 +6,7 @@ import androidx.recyclerview.widget.ListAdapter
 
 class FavoriteTeamAdapter(
     private val handler: FavoriteTeamViewHolder.Handler,
-) : ListAdapter<FavoriteTeamUiModel, FavoriteTeamViewHolder>(diffCallback) {
+) : ListAdapter<FavoriteTeamItem, FavoriteTeamViewHolder>(diffCallback) {
     override fun onCreateViewHolder(
         parent: ViewGroup,
         viewType: Int,
@@ -16,21 +16,21 @@ class FavoriteTeamAdapter(
         holder: FavoriteTeamViewHolder,
         position: Int,
     ) {
-        val item = getItem(position)
+        val item: FavoriteTeamItem = getItem(position)
         holder.bind(item)
     }
 
     companion object {
         private val diffCallback =
-            object : DiffUtil.ItemCallback<FavoriteTeamUiModel>() {
+            object : DiffUtil.ItemCallback<FavoriteTeamItem>() {
                 override fun areItemsTheSame(
-                    oldItem: FavoriteTeamUiModel,
-                    newItem: FavoriteTeamUiModel,
-                ): Boolean = oldItem.id == newItem.id
+                    oldItem: FavoriteTeamItem,
+                    newItem: FavoriteTeamItem,
+                ): Boolean = oldItem.team == newItem.team
 
                 override fun areContentsTheSame(
-                    oldItem: FavoriteTeamUiModel,
-                    newItem: FavoriteTeamUiModel,
+                    oldItem: FavoriteTeamItem,
+                    newItem: FavoriteTeamItem,
                 ): Boolean = oldItem == newItem
             }
     }

--- a/android/app/src/main/java/com/yagubogu/presentation/favorite/FavoriteTeamConfirmFragment.kt
+++ b/android/app/src/main/java/com/yagubogu/presentation/favorite/FavoriteTeamConfirmFragment.kt
@@ -4,20 +4,22 @@ import android.app.AlertDialog
 import android.app.Dialog
 import android.os.Bundle
 import androidx.fragment.app.DialogFragment
+import androidx.fragment.app.setFragmentResult
 import com.yagubogu.databinding.FragmentFavoriteTeamConfirmBinding
 import com.yagubogu.presentation.util.getParcelableCompat
 
 class FavoriteTeamConfirmFragment : DialogFragment() {
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
-        val favoriteTeam: FavoriteTeamUiModel =
+        val favoriteTeam: FavoriteTeamItem =
             arguments?.getParcelableCompat(ARG_FAVORITE_TEAM)
                 ?: return super.onCreateDialog(savedInstanceState)
 
         val binding: FragmentFavoriteTeamConfirmBinding =
             FragmentFavoriteTeamConfirmBinding.inflate(layoutInflater)
 
-        binding.favoriteTeamUiModel = favoriteTeam
-        binding.tvNegativeBtn.setOnClickListener { dialog?.cancel() }
+        binding.favoriteTeamItem = favoriteTeam
+        binding.tvPositiveBtn.setOnClickListener { setResultAndDismiss(true) }
+        binding.tvNegativeBtn.setOnClickListener { setResultAndDismiss(false) }
 
         return AlertDialog
             .Builder(requireActivity())
@@ -25,10 +27,18 @@ class FavoriteTeamConfirmFragment : DialogFragment() {
             .create()
     }
 
+    private fun setResultAndDismiss(isConfirmed: Boolean) {
+        val bundle = Bundle().apply { putBoolean(KEY_CONFIRM, isConfirmed) }
+        setFragmentResult(KEY_REQUEST_SUCCESS, bundle)
+        dismiss()
+    }
+
     companion object {
         private const val ARG_FAVORITE_TEAM = "favorite_team"
+        const val KEY_REQUEST_SUCCESS = "success"
+        const val KEY_CONFIRM = "confirm"
 
-        fun newInstance(favoriteTeam: FavoriteTeamUiModel): FavoriteTeamConfirmFragment =
+        fun newInstance(favoriteTeam: FavoriteTeamItem): FavoriteTeamConfirmFragment =
             FavoriteTeamConfirmFragment().apply {
                 arguments =
                     Bundle().apply {

--- a/android/app/src/main/java/com/yagubogu/presentation/favorite/FavoriteTeamConfirmFragment.kt
+++ b/android/app/src/main/java/com/yagubogu/presentation/favorite/FavoriteTeamConfirmFragment.kt
@@ -11,7 +11,7 @@ import com.yagubogu.presentation.util.getParcelableCompat
 class FavoriteTeamConfirmFragment : DialogFragment() {
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         val favoriteTeam: FavoriteTeamItem =
-            arguments?.getParcelableCompat(ARG_FAVORITE_TEAM)
+            arguments?.getParcelableCompat(KEY_FAVORITE_TEAM)
                 ?: return super.onCreateDialog(savedInstanceState)
 
         val binding: FragmentFavoriteTeamConfirmBinding =
@@ -34,7 +34,7 @@ class FavoriteTeamConfirmFragment : DialogFragment() {
     }
 
     companion object {
-        private const val ARG_FAVORITE_TEAM = "favorite_team"
+        private const val KEY_FAVORITE_TEAM = "favorite_team"
         const val KEY_REQUEST_SUCCESS = "success"
         const val KEY_CONFIRM = "confirm"
 
@@ -42,7 +42,7 @@ class FavoriteTeamConfirmFragment : DialogFragment() {
             FavoriteTeamConfirmFragment().apply {
                 arguments =
                     Bundle().apply {
-                        putParcelable(ARG_FAVORITE_TEAM, favoriteTeam)
+                        putParcelable(KEY_FAVORITE_TEAM, favoriteTeam)
                     }
             }
     }

--- a/android/app/src/main/java/com/yagubogu/presentation/favorite/FavoriteTeamItem.kt
+++ b/android/app/src/main/java/com/yagubogu/presentation/favorite/FavoriteTeamItem.kt
@@ -6,17 +6,14 @@ import com.yagubogu.presentation.util.getEmoji
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
-data class FavoriteTeamUiModel(
-    val id: Long,
-    val name: String,
+data class FavoriteTeamItem(
+    val team: Team,
     val emoji: String,
 ) : Parcelable {
     companion object {
-        fun of(team: Team): FavoriteTeamUiModel {
-            val id: Long = team.ordinal.toLong()
-            val name: String = team.nickname
+        fun of(team: Team): FavoriteTeamItem {
             val emoji: String = team.getEmoji()
-            return FavoriteTeamUiModel(id, name, emoji)
+            return FavoriteTeamItem(team, emoji)
         }
     }
 }

--- a/android/app/src/main/java/com/yagubogu/presentation/favorite/FavoriteTeamViewHolder.kt
+++ b/android/app/src/main/java/com/yagubogu/presentation/favorite/FavoriteTeamViewHolder.kt
@@ -7,18 +7,18 @@ import com.yagubogu.databinding.ItemFavoriteTeamBinding
 
 class FavoriteTeamViewHolder(
     private val binding: ItemFavoriteTeamBinding,
-    private val handler: Handler,
+    handler: Handler,
 ) : RecyclerView.ViewHolder(binding.root) {
     init {
         binding.handler = handler
     }
 
-    fun bind(favoriteTeamUiModel: FavoriteTeamUiModel) {
-        binding.favoriteTeamUiModel = favoriteTeamUiModel
+    fun bind(favoriteTeamItem: FavoriteTeamItem) {
+        binding.favoriteTeamItem = favoriteTeamItem
     }
 
     interface Handler {
-        fun onItemClick(item: FavoriteTeamUiModel)
+        fun onItemClick(item: FavoriteTeamItem)
     }
 
     companion object {

--- a/android/app/src/main/java/com/yagubogu/presentation/favorite/FavoriteTeamViewModel.kt
+++ b/android/app/src/main/java/com/yagubogu/presentation/favorite/FavoriteTeamViewModel.kt
@@ -1,0 +1,17 @@
+package com.yagubogu.presentation.favorite
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.yagubogu.domain.model.Team
+import com.yagubogu.domain.repository.MemberRepository
+import kotlinx.coroutines.launch
+
+class FavoriteTeamViewModel(
+    private val memberRepository: MemberRepository,
+) : ViewModel() {
+    fun saveFavoriteTeam(team: Team) {
+        viewModelScope.launch {
+            memberRepository.updateFavoriteTeam(team)
+        }
+    }
+}

--- a/android/app/src/main/java/com/yagubogu/presentation/favorite/FavoriteTeamViewModel.kt
+++ b/android/app/src/main/java/com/yagubogu/presentation/favorite/FavoriteTeamViewModel.kt
@@ -4,14 +4,34 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.yagubogu.domain.model.Team
 import com.yagubogu.domain.repository.MemberRepository
+import com.yagubogu.presentation.util.livedata.MutableSingleLiveData
+import com.yagubogu.presentation.util.livedata.SingleLiveData
 import kotlinx.coroutines.launch
+import timber.log.Timber
 
 class FavoriteTeamViewModel(
     private val memberRepository: MemberRepository,
 ) : ViewModel() {
-    fun saveFavoriteTeam(team: Team) {
+    private var selectedTeam: Team? = null
+
+    private val _favoriteTeamUpdateEvent = MutableSingleLiveData<Unit>()
+    val favoriteTeamUpdateEvent: SingleLiveData<Unit> get() = _favoriteTeamUpdateEvent
+
+    fun saveFavoriteTeam() {
         viewModelScope.launch {
-            memberRepository.updateFavoriteTeam(team)
+            selectedTeam?.let { team: Team ->
+                memberRepository
+                    .updateFavoriteTeam(team)
+                    .onSuccess {
+                        _favoriteTeamUpdateEvent.setValue(Unit)
+                    }.onFailure { exception: Throwable ->
+                        Timber.w(exception, "API 호출 실패")
+                    }
+            }
         }
+    }
+
+    fun selectTeam(team: Team) {
+        selectedTeam = team
     }
 }

--- a/android/app/src/main/java/com/yagubogu/presentation/favorite/FavoriteTeamViewModelFactory.kt
+++ b/android/app/src/main/java/com/yagubogu/presentation/favorite/FavoriteTeamViewModelFactory.kt
@@ -1,0 +1,17 @@
+package com.yagubogu.presentation.favorite
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import com.yagubogu.domain.repository.MemberRepository
+
+class FavoriteTeamViewModelFactory(
+    private val memberRepository: MemberRepository,
+) : ViewModelProvider.Factory {
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        if (modelClass.isAssignableFrom(FavoriteTeamViewModel::class.java)) {
+            @Suppress("UNCHECKED_CAST")
+            return FavoriteTeamViewModel(memberRepository) as T
+        }
+        throw IllegalArgumentException()
+    }
+}

--- a/android/app/src/main/java/com/yagubogu/presentation/home/HomeViewModel.kt
+++ b/android/app/src/main/java/com/yagubogu/presentation/home/HomeViewModel.kt
@@ -97,19 +97,19 @@ class HomeViewModel(
 
     private fun fetchMemberStats(year: Int = LocalDate.now().year) {
         viewModelScope.launch {
-            val myTeamDeferred: Deferred<Result<String>> =
+            val myTeamDeferred: Deferred<Result<String?>> =
                 async { memberRepository.getFavoriteTeam() }
             val attendanceCountDeferred: Deferred<Result<Int>> =
                 async { checkInsRepository.getCheckInCounts(year) }
             val winRateDeferred: Deferred<Result<Double>> =
                 async { statsRepository.getStatsWinRate(year) }
 
-            val myTeamResult: Result<String> = myTeamDeferred.await()
+            val myTeamResult: Result<String?> = myTeamDeferred.await()
             val attendanceCountResult: Result<Int> = attendanceCountDeferred.await()
             val winRateResult: Result<Double> = winRateDeferred.await()
 
             if (myTeamResult.isSuccess && attendanceCountResult.isSuccess && winRateResult.isSuccess) {
-                val myTeam: String = myTeamResult.getOrThrow()
+                val myTeam: String? = myTeamResult.getOrThrow()
                 val attendanceCount: Int = attendanceCountResult.getOrThrow()
                 val winRate: Double = winRateResult.getOrThrow()
 

--- a/android/app/src/main/java/com/yagubogu/presentation/home/model/MemberStatsUiModel.kt
+++ b/android/app/src/main/java/com/yagubogu/presentation/home/model/MemberStatsUiModel.kt
@@ -1,7 +1,7 @@
 package com.yagubogu.presentation.home.model
 
 data class MemberStatsUiModel(
-    val myTeam: String,
+    val myTeam: String?,
     val attendanceCount: Int,
     val winRate: Int,
 )

--- a/android/app/src/main/java/com/yagubogu/presentation/login/LoginActivity.kt
+++ b/android/app/src/main/java/com/yagubogu/presentation/login/LoginActivity.kt
@@ -19,8 +19,8 @@ import com.yagubogu.YaguBoguApplication
 import com.yagubogu.data.auth.GoogleCredentialManager
 import com.yagubogu.databinding.ActivityLoginBinding
 import com.yagubogu.domain.model.LoginResult
-import com.yagubogu.domain.model.Team
 import com.yagubogu.presentation.MainActivity
+import com.yagubogu.presentation.favorite.FavoriteTeamActivity
 import kotlinx.coroutines.launch
 
 class LoginActivity : AppCompatActivity() {
@@ -74,17 +74,17 @@ class LoginActivity : AppCompatActivity() {
 
         viewModel.loginResult.observe(this) { value: LoginResult ->
             when (value) {
-                LoginResult.Success -> {
-                    // TODO: 회원가입일 때 팀 선택 화면으로 이동
-                    val app = application as YaguBoguApplication
-                    lifecycleScope.launch { app.memberRepository.updateFavoriteTeam(Team.LG) }
-                    navigateToMain()
-                }
-
+                LoginResult.SignUp -> navigateToFavoriteTeam()
+                LoginResult.SignIn -> navigateToMain()
                 is LoginResult.Failure -> showSnackbar(R.string.login_failed_message)
                 LoginResult.Cancel -> Unit
             }
         }
+    }
+
+    private fun navigateToFavoriteTeam() {
+        startActivity(Intent(this, FavoriteTeamActivity::class.java))
+        finish()
     }
 
     private fun navigateToMain() {

--- a/android/app/src/main/java/com/yagubogu/presentation/login/LoginActivity.kt
+++ b/android/app/src/main/java/com/yagubogu/presentation/login/LoginActivity.kt
@@ -33,7 +33,7 @@ class LoginActivity : AppCompatActivity() {
         val googleCredentialManager =
             GoogleCredentialManager(this, BuildConfig.WEB_CLIENT_ID, "")
         val app = application as YaguBoguApplication
-        LoginViewModelFactory(app.authRepository, googleCredentialManager)
+        LoginViewModelFactory(app.authRepository, app.memberRepository, googleCredentialManager)
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -51,8 +51,14 @@ class LoginActivity : AppCompatActivity() {
 
     private fun handleAutoLogin() {
         lifecycleScope.launch {
-            val isTokenValid: Boolean = viewModel.isTokenValid()
-            if (isTokenValid) {
+            if (!viewModel.isTokenValid()) {
+                isAppInitialized = true
+                return@launch
+            }
+
+            if (viewModel.isNewUser()) {
+                navigateToFavoriteTeam()
+            } else {
                 navigateToMain()
             }
             isAppInitialized = true

--- a/android/app/src/main/java/com/yagubogu/presentation/login/LoginViewModel.kt
+++ b/android/app/src/main/java/com/yagubogu/presentation/login/LoginViewModel.kt
@@ -32,7 +32,7 @@ class LoginViewModel(
                         authRepository
                             .login(idToken)
                             .fold(
-                                onSuccess = { LoginResult.Success },
+                                onSuccess = { it },
                                 onFailure = { exception: Throwable ->
                                     Timber.w(exception, "API 호출 실패")
                                     LoginResult.Failure(exception)

--- a/android/app/src/main/java/com/yagubogu/presentation/login/LoginViewModel.kt
+++ b/android/app/src/main/java/com/yagubogu/presentation/login/LoginViewModel.kt
@@ -8,17 +8,21 @@ import com.yagubogu.data.auth.GoogleCredentialManager
 import com.yagubogu.data.auth.GoogleCredentialResult
 import com.yagubogu.domain.model.LoginResult
 import com.yagubogu.domain.repository.AuthRepository
+import com.yagubogu.domain.repository.MemberRepository
 import kotlinx.coroutines.launch
 import timber.log.Timber
 
 class LoginViewModel(
     private val authRepository: AuthRepository,
+    private val memberRepository: MemberRepository,
     private val googleCredentialManager: GoogleCredentialManager,
 ) : ViewModel() {
     private val _loginResult = MutableLiveData<LoginResult>()
     val loginResult: LiveData<LoginResult> get() = _loginResult
 
     suspend fun isTokenValid(): Boolean = authRepository.refreshTokens().isSuccess
+
+    suspend fun isNewUser(): Boolean = memberRepository.getFavoriteTeam().getOrNull() == null
 
     fun signInWithGoogle() {
         viewModelScope.launch {

--- a/android/app/src/main/java/com/yagubogu/presentation/login/LoginViewModel.kt
+++ b/android/app/src/main/java/com/yagubogu/presentation/login/LoginViewModel.kt
@@ -36,7 +36,7 @@ class LoginViewModel(
                         authRepository
                             .login(idToken)
                             .fold(
-                                onSuccess = { it },
+                                onSuccess = { result: LoginResult -> result },
                                 onFailure = { exception: Throwable ->
                                     Timber.w(exception, "API 호출 실패")
                                     LoginResult.Failure(exception)

--- a/android/app/src/main/java/com/yagubogu/presentation/login/LoginViewModelFactory.kt
+++ b/android/app/src/main/java/com/yagubogu/presentation/login/LoginViewModelFactory.kt
@@ -4,15 +4,17 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import com.yagubogu.data.auth.GoogleCredentialManager
 import com.yagubogu.domain.repository.AuthRepository
+import com.yagubogu.domain.repository.MemberRepository
 
 class LoginViewModelFactory(
     private val authRepository: AuthRepository,
+    private val memberRepository: MemberRepository,
     private val googleCredentialManager: GoogleCredentialManager,
 ) : ViewModelProvider.Factory {
     override fun <T : ViewModel> create(modelClass: Class<T>): T {
         if (modelClass.isAssignableFrom(LoginViewModel::class.java)) {
             @Suppress("UNCHECKED_CAST")
-            return LoginViewModel(authRepository, googleCredentialManager) as T
+            return LoginViewModel(authRepository, memberRepository, googleCredentialManager) as T
         }
         throw IllegalArgumentException()
     }

--- a/android/app/src/main/java/com/yagubogu/presentation/stats/my/MyStatsUiModel.kt
+++ b/android/app/src/main/java/com/yagubogu/presentation/stats/my/MyStatsUiModel.kt
@@ -6,7 +6,7 @@ data class MyStatsUiModel(
     val loseCount: Int,
     val totalCount: Int,
     val winningPercentage: Int,
-    val myTeam: String,
+    val myTeam: String?,
     val luckyStadium: String?,
 ) {
     val etcPercentage: Int get() = FULL_PERCENTAGE - winningPercentage

--- a/android/app/src/main/java/com/yagubogu/presentation/stats/my/MyStatsViewModel.kt
+++ b/android/app/src/main/java/com/yagubogu/presentation/stats/my/MyStatsViewModel.kt
@@ -38,20 +38,20 @@ class MyStatsViewModel(
                 async { statsRepository.getStatsCounts(year) }
             val winRateDeferred: Deferred<Result<Double>> =
                 async { statsRepository.getStatsWinRate(year) }
-            val myTeamDeferred: Deferred<Result<String>> =
+            val myTeamDeferred: Deferred<Result<String?>> =
                 async { memberRepository.getFavoriteTeam() }
             val luckyStadiumDeferred: Deferred<Result<String?>> =
                 async { statsRepository.getLuckyStadiums(year) }
 
             val statsCountsResult: Result<StatsCounts> = statsCountsDeferred.await()
             val winRateResult: Result<Double> = winRateDeferred.await()
-            val myTeamResult: Result<String> = myTeamDeferred.await()
+            val myTeamResult: Result<String?> = myTeamDeferred.await()
             val luckyStadiumResult: Result<String?> = luckyStadiumDeferred.await()
 
             if (statsCountsResult.isSuccess && winRateResult.isSuccess && myTeamResult.isSuccess && luckyStadiumResult.isSuccess) {
                 val statsCounts: StatsCounts = statsCountsResult.getOrThrow()
                 val winRate: Double = winRateResult.getOrThrow()
-                val myTeam: String = myTeamResult.getOrThrow()
+                val myTeam: String? = myTeamResult.getOrThrow()
                 val luckyStadium: String? = luckyStadiumResult.getOrThrow()
 
                 val myStatsUiModel =

--- a/android/app/src/main/java/com/yagubogu/presentation/stats/my/MyStatsViewModel.kt
+++ b/android/app/src/main/java/com/yagubogu/presentation/stats/my/MyStatsViewModel.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.async
 import kotlinx.coroutines.launch
 import timber.log.Timber
+import java.time.LocalDate
 import kotlin.math.roundToInt
 
 class MyStatsViewModel(
@@ -28,11 +29,11 @@ class MyStatsViewModel(
     }
 
     fun fetchAll() {
-        fetchMyStats(YEAR)
+        fetchMyStats()
         fetchMyAverageStats()
     }
 
-    private fun fetchMyStats(year: Int) {
+    private fun fetchMyStats(year: Int = LocalDate.now().year) {
         viewModelScope.launch {
             val statsCountsDeferred: Deferred<Result<StatsCounts>> =
                 async { statsRepository.getStatsCounts(year) }
@@ -77,17 +78,13 @@ class MyStatsViewModel(
 
     private fun fetchMyAverageStats() {
         viewModelScope.launch {
-            val averageStats: Result<AverageStats> = statsRepository.getAverageStats()
-            averageStats
+            val averageStatsResult: Result<AverageStats> = statsRepository.getAverageStats()
+            averageStatsResult
                 .onSuccess { averageStats: AverageStats ->
                     _averageStats.value = averageStats
                 }.onFailure { exception: Throwable ->
                     Timber.w(exception, "API 호출 실패")
                 }
         }
-    }
-
-    companion object {
-        private const val YEAR = 2025
     }
 }

--- a/android/app/src/main/res/layout/fragment_favorite_team_confirm.xml
+++ b/android/app/src/main/res/layout/fragment_favorite_team_confirm.xml
@@ -6,8 +6,8 @@
     <data>
 
         <variable
-            name="favoriteTeamUiModel"
-            type="com.yagubogu.presentation.favorite.FavoriteTeamUiModel" />
+            name="favoriteTeamItem"
+            type="com.yagubogu.presentation.favorite.FavoriteTeamItem" />
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
@@ -31,7 +31,7 @@
             android:id="@+id/tv_favorite_team_emoji"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="@{favoriteTeamUiModel.emoji}"
+            android:text="@{favoriteTeamItem.emoji}"
             android:textSize="32sp"
             app:layout_constraintBottom_toTopOf="@id/tv_favorite_team_name"
             app:layout_constraintEnd_toEndOf="@id/tv_selection_confirm_message"
@@ -45,7 +45,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginVertical="16dp"
-            android:text="@{favoriteTeamUiModel.name}"
+            android:text="@{favoriteTeamItem.team.nickname}"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/tv_favorite_team_emoji"

--- a/android/app/src/main/res/layout/item_favorite_team.xml
+++ b/android/app/src/main/res/layout/item_favorite_team.xml
@@ -6,8 +6,8 @@
     <data>
 
         <variable
-            name="favoriteTeamUiModel"
-            type="com.yagubogu.presentation.favorite.FavoriteTeamUiModel" />
+            name="favoriteTeamItem"
+            type="com.yagubogu.presentation.favorite.FavoriteTeamItem" />
 
         <variable
             name="handler"
@@ -19,14 +19,14 @@
         android:layout_height="wrap_content"
         android:layout_margin="6dp"
         android:background="@drawable/bg_white_stroke_gray100_radius_12dp"
-        android:onClick="@{() -> handler.onItemClick(favoriteTeamUiModel)}">
+        android:onClick="@{() -> handler.onItemClick(favoriteTeamItem)}">
 
         <TextView
             android:id="@+id/tv_team_emoji"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="24dp"
-            android:text="@{favoriteTeamUiModel.emoji}"
+            android:text="@{favoriteTeamItem.emoji}"
             android:textSize="32sp"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
@@ -40,7 +40,7 @@
             android:layout_height="wrap_content"
             android:layout_marginTop="8dp"
             android:layout_marginBottom="24dp"
-            android:text="@{favoriteTeamUiModel.name}"
+            android:text="@{favoriteTeamItem.team.nickname}"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"


### PR DESCRIPTION
## 📌 관련 이슈
- close #305 

## ✨ 변경 내용
- 회원가입인 경우, 응원팀 선택 화면으로 이동하여 응원팀 선택 후 메인 화면으로 이동합니다.
- 로그인인 경우, 메인 화면으로 바로 이동합니다.

## 🎸 기타 참고 사항
- 스크린샷, 참고 링크, 추가 설명 등 (없으면 생략 가능)


https://github.com/user-attachments/assets/12cb0c3d-4724-4434-8756-e216bef77085

