### PR TITLE
fix: 응원팀 조회 시 team이 null일 때 null 반환하도록 수정

### DIFF
--- a/backend/src/main/java/com/yagubogu/member/service/MemberService.java
+++ b/backend/src/main/java/com/yagubogu/member/service/MemberService.java
@@ -44,6 +44,10 @@ public class MemberService {
         Member member = getMember(memberId);
         Team team = member.getTeam();
 
+        if (team == null) {
+            return null;
+        }
+
         return MemberFavoriteResponse.from(team);
     }
 


### PR DESCRIPTION
## 📌 관련 이슈
- close #316 

## ✨ 변경 내용
- 응원팀 조회 시 team이 null일 때 null 반환하도록 수정

## 🎸 기타 참고 사항
- 스크린샷, 참고 링크, 추가 설명 등 (없으면 생략 가능)