### PR TITLE
fix: 토큰 재발급 로직 개선

### DIFF
--- a/android/app/src/main/java/com/yagubogu/data/network/TokenAuthenticator.kt
+++ b/android/app/src/main/java/com/yagubogu/data/network/TokenAuthenticator.kt
@@ -14,19 +14,36 @@ import okhttp3.Request
 import okhttp3.Response
 import okhttp3.Route
 
+/**
+ * OkHttp의 Authenticator 구현체
+ * - 서버에서 401(Unauthorized) 응답이 왔을 때 호출됨
+ * - AccessToken이 만료되었을 경우 RefreshToken을 사용해 새로운 AccessToken을 발급받고
+ *   동일한 요청을 재시도함
+ *
+ * 주의:
+ * - Authenticator는 실패한 요청마다 호출되므로, 동시에 여러 요청이 실패하면
+ *   토큰 재발급이 중복으로 일어날 수 있음 → Mutex로 동기화 필요
+ */
 class TokenAuthenticator(
     private val tokenManager: TokenManager,
     private val authApiService: AuthApiService,
 ) : Authenticator {
     private val mutex = Mutex()
 
+    /**
+     * OkHttp가 401 응답을 받으면 호출되는 메서드
+     * - 새로운 Request를 반환하면 OkHttp가 재시도함
+     * - null을 반환하면 재시도하지 않음
+     */
     override fun authenticate(
         route: Route?,
         response: Response,
     ): Request? {
+        // 이미 두 번 이상 시도했으면, 무한 재시도 방지를 위해 중단함
         if (responseCount(response) >= 2) return null
 
         val request: Request = response.request
+        // 요청이 토큰 갱신 API(/auth/refresh)였다면, 재귀 호출 방지를 위해 재시도하지 않음
         if (request.url.encodedPath.endsWith(AUTH_REFRESH_ENDPOINT)) return null
 
         return runBlocking {
@@ -34,6 +51,7 @@ class TokenAuthenticator(
                 val invalidToken: String? = request.getTokenFromHeader()
                 val currentToken: String? = tokenManager.getAccessToken()
 
+                // 이미 다른 요청이 토큰을 새로 발급 받아 토큰이 바뀌었다면, 새 토큰으로 교체
                 if (currentToken != null && currentToken != invalidToken) {
                     return@withLock request.addTokenHeader(currentToken)
                 }
@@ -46,6 +64,10 @@ class TokenAuthenticator(
         }
     }
 
+    /**
+     * RefreshToken을 사용해 AccessToken 재발급
+     * - 실패 시 로컬 토큰을 삭제하고 null 반환
+     */
     private suspend fun refreshAccessToken(): TokenResponse? {
         val refreshToken: String = tokenManager.getRefreshToken() ?: return null
         return safeApiCall {
@@ -56,6 +78,10 @@ class TokenAuthenticator(
         }
     }
 
+    /**
+     * 이전 응답 체인을 따라가면서 재시도 횟수 계산
+     * (OkHttp에서 무한 루프 방지용)
+     */
     private fun responseCount(response: Response): Int {
         var count = 1
         var priorResponse: Response? = response.priorResponse

--- a/android/app/src/main/java/com/yagubogu/data/util/RequestExt.kt
+++ b/android/app/src/main/java/com/yagubogu/data/util/RequestExt.kt
@@ -5,5 +5,7 @@ import okhttp3.Request
 fun Request.addTokenHeader(accessToken: String): Request =
     this
         .newBuilder()
-        .addHeader("Authorization", "Bearer $accessToken")
+        .header("Authorization", "Bearer $accessToken")
         .build()
+
+fun Request.getTokenFromHeader(): String? = this.header("Authorization")?.removePrefix("Bearer ")

--- a/android/app/src/main/java/com/yagubogu/presentation/stats/attendance/AttendanceHistoryFragment.kt
+++ b/android/app/src/main/java/com/yagubogu/presentation/stats/attendance/AttendanceHistoryFragment.kt
@@ -45,7 +45,9 @@ class AttendanceHistoryFragment : Fragment() {
 
     override fun onHiddenChanged(hidden: Boolean) {
         super.onHiddenChanged(hidden)
-        viewModel.fetchAttendanceHistoryItems()
+        if (!hidden) {
+            viewModel.fetchAttendanceHistoryItems()
+        }
     }
 
     override fun onDestroyView() {

--- a/android/app/src/main/java/com/yagubogu/presentation/stats/attendance/AttendanceHistoryViewModel.kt
+++ b/android/app/src/main/java/com/yagubogu/presentation/stats/attendance/AttendanceHistoryViewModel.kt
@@ -16,10 +16,6 @@ class AttendanceHistoryViewModel(
     private val _attendanceHistoryItems = MutableLiveData<List<AttendanceHistoryItem>>()
     val attendanceHistoryItems: LiveData<List<AttendanceHistoryItem>> get() = _attendanceHistoryItems
 
-    init {
-        fetchAttendanceHistoryItems()
-    }
-
     fun fetchAttendanceHistoryItems(
         year: Int = LocalDate.now().year,
         filter: AttendanceHistoryFilter = AttendanceHistoryFilter.ALL,


### PR DESCRIPTION
## 📌 관련 이슈
- close #313 

## ✨ 변경 내용
`Authenticator` 호출 시 동시성 문제로 인해 토큰 재발급이 중복 실행되는 문제를 해결했습니다.

기존 구현에서는 여러 요청이 동시에 401 응답을 받으면 각 요청이 개별적으로 API를 호출했고,
이로 인해 토큰이 중복 발급되거나 덮어쓰여 인증 오류가 발생하는 경우가 있었습니다.

`Mutex`를 사용해 동시에 여러 요청이 401 응답을 받아도 한 번만 토큰 재발급이 이루어지도록 동기화 처리를 했습니다.
이미 다른 요청이 토큰을 재발급한 경우, 저장된 최신 토큰으로 request 헤더를 교체 후 재시도합니다.

## 🎸 기타 참고 사항
- 스크린샷, 참고 링크, 추가 설명 등 (없으면 생략 가능)