### PR TITLE
fix: 응원하는 팀이 없을 때 favorite 필드에 null이 들어가도록 수정

### DIFF
--- a/backend/src/main/java/com/yagubogu/member/dto/MemberFavoriteResponse.java
+++ b/backend/src/main/java/com/yagubogu/member/dto/MemberFavoriteResponse.java
@@ -9,4 +9,8 @@ public record MemberFavoriteResponse(
     public static MemberFavoriteResponse from(final Team team) {
         return new MemberFavoriteResponse(team.getShortName());
     }
+
+    public static MemberFavoriteResponse empty() {
+        return new MemberFavoriteResponse(null);
+    }
 }

--- a/backend/src/main/java/com/yagubogu/member/service/MemberService.java
+++ b/backend/src/main/java/com/yagubogu/member/service/MemberService.java
@@ -45,7 +45,7 @@ public class MemberService {
         Team team = member.getTeam();
 
         if (team == null) {
-            return null;
+            return MemberFavoriteResponse.empty();
         }
 
         return MemberFavoriteResponse.from(team);

--- a/backend/src/test/java/com/yagubogu/member/service/MemberServiceTest.java
+++ b/backend/src/test/java/com/yagubogu/member/service/MemberServiceTest.java
@@ -58,6 +58,20 @@ public class MemberServiceTest {
         assertThat(actual.favorite()).isEqualTo(expected);
     }
 
+    @DisplayName("멤버가 응원하는 팀이 없다면 null을 반환한다")
+    @Test
+    void findFavorite_null() {
+        // given
+        Team team = null;
+        Member member = memberFactory.save(builder -> builder.team(team));
+
+        // when
+        MemberFavoriteResponse actual = memberService.findFavorite(member.getId());
+
+        // then
+        assertThat(actual.favorite()).isEqualTo(null);
+    }
+
     @DisplayName("멤버의 닉네임을 조회한다")
     @Test
     void findNickname() {


### PR DESCRIPTION
## 📌 관련 이슈
- close #316 

## ✨ 변경 내용
- 응원하는 팀이 없을 때 favorite 필드에 null이 들어가도록 수정
- 

## 🎸 기타 참고 사항
- 스크린샷, 참고 링크, 추가 설명 등 (없으면 생략 가능)