### PR TITLE
fix: 회원 탈퇴 후 재가입이 안되던 문제 해결

### DIFF
--- a/backend/src/main/java/com/yagubogu/auth/domain/RefreshToken.java
+++ b/backend/src/main/java/com/yagubogu/auth/domain/RefreshToken.java
@@ -16,7 +16,7 @@ import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-@Table(name = "refresh_token")
+@Table(name = "refresh_tokens")
 @Entity
 public class RefreshToken {
 

--- a/backend/src/main/java/com/yagubogu/member/domain/Member.java
+++ b/backend/src/main/java/com/yagubogu/member/domain/Member.java
@@ -12,23 +12,17 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
-import jakarta.persistence.UniqueConstraint;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLDelete;
-import org.hibernate.annotations.Where;
+import org.hibernate.annotations.SQLRestriction;
 
 @SQLDelete(sql = "UPDATE members SET is_deleted = true WHERE member_id = ?")
-@Where(clause = "is_deleted = false")
+@SQLRestriction("is_deleted = false")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-@Table(
-        name = "members",
-        uniqueConstraints = {
-                @UniqueConstraint(columnNames = {"oauth_id", "provider"})
-        }
-)
+@Table(name = "members")
 @Entity
 public class Member {
 
@@ -44,7 +38,7 @@ public class Member {
     @Column(name = "nickname", nullable = false)
     private String nickname;
 
-    @Column(name = "email", nullable = false, unique = true)
+    @Column(name = "email", nullable = false)
     private String email;
 
     @Column(name = "provider", nullable = false)


### PR DESCRIPTION
* feat: `refresh_token` 테이블 명 복수형으로 수정

* feat: `@Where`을 `@SQLRestriction`으로 수정

* feat: email, oauth_id에 대한 unique 제거


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Allows multiple user accounts to share the same email address.

- Refactor
  - Updated member record filtering to consistently exclude deleted accounts.
  - Standardized naming for the refresh token storage table.

- Chores
  - Simplified database constraints on member records to reduce strict uniqueness requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->