### PR TITLE
fix: 로그아웃 시 캐시된 데이터 무효화

### DIFF
--- a/android/app/src/main/java/com/yagubogu/data/repository/MemberDefaultRepository.kt
+++ b/android/app/src/main/java/com/yagubogu/data/repository/MemberDefaultRepository.kt
@@ -9,8 +9,8 @@ import com.yagubogu.domain.repository.MemberRepository
 class MemberDefaultRepository(
     private val memberDataSource: MemberDataSource,
 ) : MemberRepository {
-    private var cachedFavoriteTeam: String? = null
     private var cachedNickname: String? = null
+    private var cachedFavoriteTeam: String? = null
 
     override suspend fun getNickname(): Result<String> {
         cachedNickname?.let { nickname: String ->
@@ -57,4 +57,9 @@ class MemberDefaultRepository(
             }
 
     override suspend fun deleteMember(): Result<Unit> = memberDataSource.deleteMember()
+
+    override fun invalidateCache() {
+        cachedNickname = null
+        cachedFavoriteTeam = null
+    }
 }

--- a/android/app/src/main/java/com/yagubogu/domain/repository/MemberRepository.kt
+++ b/android/app/src/main/java/com/yagubogu/domain/repository/MemberRepository.kt
@@ -12,4 +12,6 @@ interface MemberRepository {
     suspend fun updateFavoriteTeam(team: Team): Result<Unit>
 
     suspend fun deleteMember(): Result<Unit>
+
+    fun invalidateCache()
 }

--- a/android/app/src/main/java/com/yagubogu/presentation/setting/SettingViewModel.kt
+++ b/android/app/src/main/java/com/yagubogu/presentation/setting/SettingViewModel.kt
@@ -59,6 +59,7 @@ class SettingViewModel(
             authRepository
                 .logout()
                 .onSuccess {
+                    memberRepository.invalidateCache()
                     _logoutEvent.setValue(Unit)
                 }.onFailure { exception: Throwable ->
                     Timber.w(exception, "로그아웃 API 호출 실패")


### PR DESCRIPTION
## 📌 관련 이슈
- close #427 

## ✨ 변경 내용
- 로그아웃을 하는 경우, 다음 로그인 시 잘못된 정보가 남지 않도록 `MemberRepository`에 캐시된 정보를 무효화했습니다.

## 🎸 기타 참고 사항
- 스크린샷, 참고 링크, 추가 설명 등 (없으면 생략 가능)