### PR TITLE
fix: 회원 탈퇴 시 DataStore에 저장된 데이터 삭제

### DIFF
--- a/android/app/src/main/java/com/yagubogu/YaguBoguApplication.kt
+++ b/android/app/src/main/java/com/yagubogu/YaguBoguApplication.kt
@@ -46,7 +46,7 @@ class YaguBoguApplication : Application() {
     val authRepository by lazy { AuthDefaultRepository(authDataSource, tokenManager) }
 
     private val memberDataSource by lazy { MemberRemoteDataSource(retrofit.memberApiService) }
-    val memberRepository by lazy { MemberDefaultRepository(memberDataSource) }
+    val memberRepository by lazy { MemberDefaultRepository(memberDataSource, tokenManager) }
 
     private val stadiumDataSource by lazy { StadiumRemoteDataSource(retrofit.stadiumApiService) }
     val stadiumRepository by lazy { StadiumDefaultRepository(stadiumDataSource) }

--- a/android/app/src/main/java/com/yagubogu/data/repository/MemberDefaultRepository.kt
+++ b/android/app/src/main/java/com/yagubogu/data/repository/MemberDefaultRepository.kt
@@ -3,11 +3,13 @@ package com.yagubogu.data.repository
 import com.yagubogu.data.datasource.member.MemberDataSource
 import com.yagubogu.data.dto.response.member.MemberFavoriteResponse
 import com.yagubogu.data.dto.response.member.MemberNicknameResponse
+import com.yagubogu.data.network.TokenManager
 import com.yagubogu.domain.model.Team
 import com.yagubogu.domain.repository.MemberRepository
 
 class MemberDefaultRepository(
     private val memberDataSource: MemberDataSource,
+    private val tokenManager: TokenManager,
 ) : MemberRepository {
     private var cachedNickname: String? = null
     private var cachedFavoriteTeam: String? = null
@@ -56,7 +58,10 @@ class MemberDefaultRepository(
                 cachedFavoriteTeam = newFavoriteTeam
             }
 
-    override suspend fun deleteMember(): Result<Unit> = memberDataSource.deleteMember()
+    override suspend fun deleteMember(): Result<Unit> =
+        memberDataSource.deleteMember().map {
+            tokenManager.clearTokens()
+        }
 
     override fun invalidateCache() {
         cachedNickname = null


### PR DESCRIPTION
## 📌 관련 이슈
- close #456 

## ✨ 변경 내용
- 회원탈퇴 시 `DataStore`에 저장된 토큰 정보를 삭제합니다.

## 🎸 기타 참고 사항
- 스크린샷, 참고 링크, 추가 설명 등 (없으면 생략 가능)