### PR TITLE
feat: 회원 탈퇴시 refresh 토큰 만료 구현

### DIFF
--- a/backend/src/main/java/com/yagubogu/auth/repository/RefreshTokenRepository.java
+++ b/backend/src/main/java/com/yagubogu/auth/repository/RefreshTokenRepository.java
@@ -1,9 +1,12 @@
 package com.yagubogu.auth.repository;
 
 import com.yagubogu.auth.domain.RefreshToken;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, String> {
+
+    List<RefreshToken> findAllByMemberId(Long memberId);
 }

--- a/backend/src/main/java/com/yagubogu/auth/service/AuthService.java
+++ b/backend/src/main/java/com/yagubogu/auth/service/AuthService.java
@@ -92,6 +92,14 @@ public class AuthService {
         return refreshToken.getId();
     }
 
+    @Transactional
+    public void removeAllRefreshTokens(final Long memberId) {
+        List<RefreshToken> refreshTokens = refreshTokenRepository.findAllByMemberId(memberId);
+        for (RefreshToken refreshToken : refreshTokens) {
+            refreshToken.revoke();
+        }
+    }
+
     private Member findOrCreateMember(
             final boolean isNew,
             final AuthResponse response,
@@ -150,4 +158,5 @@ public class AuthService {
             throw new UnAuthorizedException("Refresh token is invalid or expired");
         }
     }
+
 }

--- a/backend/src/main/java/com/yagubogu/member/controller/MemberController.java
+++ b/backend/src/main/java/com/yagubogu/member/controller/MemberController.java
@@ -2,6 +2,7 @@ package com.yagubogu.member.controller;
 
 import com.yagubogu.auth.annotation.RequireRole;
 import com.yagubogu.auth.dto.MemberClaims;
+import com.yagubogu.auth.service.AuthService;
 import com.yagubogu.member.dto.MemberFavoriteRequest;
 import com.yagubogu.member.dto.MemberFavoriteResponse;
 import com.yagubogu.member.dto.MemberInfoResponse;
@@ -19,6 +20,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class MemberController implements MemberControllerInterface {
 
     private final MemberService memberService;
+    private final AuthService authService;
 
     public ResponseEntity<MemberNicknameResponse> patchNickname(
             @RequestBody final MemberNicknameRequest request,
@@ -32,7 +34,9 @@ public class MemberController implements MemberControllerInterface {
     public ResponseEntity<Void> removeMember(
             final MemberClaims memberClaims
     ) {
-        memberService.removeMember(memberClaims.id());
+        Long memberId = memberClaims.id();
+        memberService.removeMember(memberId);
+        authService.removeAllRefreshTokens(memberId);
 
         return ResponseEntity.noContent().build();
     }


### PR DESCRIPTION
## 📌 관련 이슈
- close #460 

## ✨ 변경 내용
- 회원 탈퇴시 refresh 토큰 만료 구현

## 🎸 기타 참고 사항
- 스크린샷, 참고 링크, 추가 설명 등 (없으면 생략 가능)