### PR TITLE
fix: DialogFragment 연타할경우의 crash 수정

### DIFF
--- a/android/app/src/main/java/com/yagubogu/presentation/home/HomeFragment.kt
+++ b/android/app/src/main/java/com/yagubogu/presentation/home/HomeFragment.kt
@@ -47,7 +47,6 @@ class HomeFragment : Fragment() {
 
     private val stadiumFanRateAdapter: StadiumFanRateAdapter by lazy { StadiumFanRateAdapter() }
     private val victoryFairyAdapter: VictoryFairyAdapter by lazy { VictoryFairyAdapter() }
-    private var checkInDialog: DefaultDialogFragment? = null
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -212,18 +211,18 @@ class HomeFragment : Fragment() {
     }
 
     private fun showCheckInConfirmDialog() {
-        if (checkInDialog == null) {
+        if (parentFragmentManager.findFragmentByTag(KEY_CHECK_IN_REQUEST_DIALOG) == null) {
             val dialogUiModel =
                 DefaultDialogUiModel(
                     title = getString(R.string.home_check_in_confirm),
                     emoji = getString(R.string.home_check_in_stadium_emoji),
                     message = getString(R.string.home_check_in_caution),
                 )
-            checkInDialog =
+            val dialog =
                 DefaultDialogFragment.newInstance(KEY_CHECK_IN_REQUEST_DIALOG, dialogUiModel)
-        }
 
-        checkInDialog?.show(parentFragmentManager, KEY_CHECK_IN_REQUEST_DIALOG)
+            dialog.show(parentFragmentManager, KEY_CHECK_IN_REQUEST_DIALOG)
+        }
     }
 
     companion object {

--- a/android/app/src/main/java/com/yagubogu/presentation/livetalk/chat/LivetalkChatActivity.kt
+++ b/android/app/src/main/java/com/yagubogu/presentation/livetalk/chat/LivetalkChatActivity.kt
@@ -32,8 +32,6 @@ class LivetalkChatActivity : AppCompatActivity() {
         )
     }
 
-    private var talkDeleteDialog: DefaultDialogFragment? = null
-
     private var pendingDeleteMessageId: Long? = null
     private var pendingReportMessageId: Long? = null
 
@@ -56,18 +54,17 @@ class LivetalkChatActivity : AppCompatActivity() {
     }
 
     private fun showTalkDeleteDialog() {
-        if (talkDeleteDialog == null) {
+        if (supportFragmentManager.findFragmentByTag(KEY_TALK_DELETE_DIALOG) == null) {
             val dialogUiModel =
                 DefaultDialogUiModel(
                     title = getString(R.string.livetalk_trash_btn),
                     message = getString(R.string.livetalk_trash_dialog_message),
                     positiveText = getString(R.string.livetalk_trash_btn),
                 )
-            talkDeleteDialog =
+            val dialog =
                 DefaultDialogFragment.newInstance(KEY_TALK_DELETE_DIALOG, dialogUiModel)
+            dialog.show(supportFragmentManager, KEY_TALK_DELETE_DIALOG)
         }
-
-        talkDeleteDialog?.show(supportFragmentManager, KEY_TALK_DELETE_DIALOG)
     }
 
     private fun showTalkReportDialog(reportTalkNickName: String) {

--- a/android/app/src/main/java/com/yagubogu/presentation/setting/SettingAccountFragment.kt
+++ b/android/app/src/main/java/com/yagubogu/presentation/setting/SettingAccountFragment.kt
@@ -17,7 +17,6 @@ class SettingAccountFragment : Fragment() {
     private val binding get() = _binding!!
 
     private val viewModel: SettingViewModel by activityViewModels()
-    private var logoutDialog: DefaultDialogFragment? = null
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -48,18 +47,17 @@ class SettingAccountFragment : Fragment() {
 
     private fun setupListeners() {
         binding.layoutLogout.root.setOnClickListener {
-            if (logoutDialog == null) {
+            if (parentFragmentManager.findFragmentByTag(KEY_LOGOUT_REQUEST_DIALOG) == null) {
                 val dialogUiModel =
                     DefaultDialogUiModel(
                         title = getString(R.string.setting_logout),
                         message = getString(R.string.setting_logout_dialog_message),
                         positiveText = getString(R.string.setting_logout),
                     )
-                logoutDialog =
+                val dialog =
                     DefaultDialogFragment.newInstance(KEY_LOGOUT_REQUEST_DIALOG, dialogUiModel)
+                dialog.show(parentFragmentManager, KEY_LOGOUT_REQUEST_DIALOG)
             }
-
-            logoutDialog?.show(parentFragmentManager, KEY_LOGOUT_REQUEST_DIALOG)
         }
 
         binding.layoutDeleteAccount.root.setOnClickListener {

--- a/android/app/src/main/java/com/yagubogu/presentation/setting/SettingDeleteAccountFragment.kt
+++ b/android/app/src/main/java/com/yagubogu/presentation/setting/SettingDeleteAccountFragment.kt
@@ -17,7 +17,6 @@ class SettingDeleteAccountFragment : Fragment() {
     private val binding get() = _binding!!
 
     private val viewModel: SettingViewModel by activityViewModels()
-    private var deleteAccountDialog: DefaultDialogFragment? = null
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -50,19 +49,18 @@ class SettingDeleteAccountFragment : Fragment() {
 
     private fun setupListeners() {
         binding.btnConfirm.setOnClickListener {
-            if (deleteAccountDialog == null) {
+            if (parentFragmentManager.findFragmentByTag(KEY_DELETE_ACCOUNT_REQUEST_DIALOG) == null) {
                 val dialogUiModel =
                     DefaultDialogUiModel(
                         title = getString(R.string.setting_delete_account_dialog_title),
                         message = getString(R.string.setting_delete_account_dialog_message),
                         positiveText = getString(R.string.setting_delete_account),
                     )
-                deleteAccountDialog =
+                val dialog =
                     DefaultDialogFragment
                         .newInstance(KEY_DELETE_ACCOUNT_REQUEST_DIALOG, dialogUiModel)
+                dialog.show(parentFragmentManager, KEY_DELETE_ACCOUNT_REQUEST_DIALOG)
             }
-
-            deleteAccountDialog?.show(parentFragmentManager, KEY_DELETE_ACCOUNT_REQUEST_DIALOG)
         }
     }
 


### PR DESCRIPTION
## 📌 관련 이슈
- close #471 

## ✨ 변경 내용
- 다이얼로그 중복 생성으로 크래시되는 버그 정상화

## 🎸 기타 참고 사항
1. 다이얼로그를 닫으면 DialogFragment는 FragmentManager의 관리 목록에서 제거
2. Fragment의 생명주기에 따라 인스턴스와 뷰가 파괴
3. 버튼을 다시 눌렀을 때 `parentFragmentManager.findFragmentByTag(DIALOG_TAG)`를 호출하면, FragmentManager는 더 이상 해당 태그를 가진 프래그먼트를 찾을 수 없으므로 null 반환
4. 새로운 DialogFragment 인스턴스가 생성되어 표시

![ezgif-20028e5c711519](https://github.com/user-attachments/assets/c44ddc5b-69b6-4186-b802-bead2daa1452)
