### PR TITLE
fix: 상대팀별 승률 조회 버그 수정

### DIFF
--- a/backend/src/main/java/com/yagubogu/checkin/repository/CheckInRepository.java
+++ b/backend/src/main/java/com/yagubogu/checkin/repository/CheckInRepository.java
@@ -272,14 +272,18 @@ public interface CheckInRepository extends JpaRepository<CheckIn, Long> {
                 sum(case when g.homeScore < g.awayScore then 1 else 0 end),
                 sum(case when g.homeScore = g.awayScore then 1 else 0 end)
             )
-            from Game g
+            from CheckIn ci
+            join ci.game g
             join Team away on away.id = g.awayTeam.id
-            where g.homeTeam.id = :myTeamId
+            where ci.member.id = :memberId
+              and ci.team.id = :myTeamId
+              and g.homeTeam.id = :myTeamId
               and g.date between :start and :end
               and g.gameState = 'COMPLETED'
             group by away.id, away.name, away.shortName, away.teamCode
             """)
     List<OpponentWinRateRow> findOpponentWinRatesWhenHome(
+            @Param("memberId") Long memberId,
             @Param("myTeamId") Long myTeamId,
             @Param("start") LocalDate start,
             @Param("end") LocalDate end
@@ -292,14 +296,18 @@ public interface CheckInRepository extends JpaRepository<CheckIn, Long> {
                 sum(case when g.awayScore < g.homeScore then 1 else 0 end),
                 sum(case when g.awayScore = g.homeScore then 1 else 0 end)
             )
-            from Game g
+            from CheckIn ci
+            join ci.game g
             join Team home on home.id = g.homeTeam.id
-            where g.awayTeam.id = :myTeamId
+            where ci.member.id = :memberId
+              and ci.team.id = :myTeamId
+              and g.awayTeam.id = :myTeamId
               and g.date between :start and :end
               and g.gameState = 'COMPLETED'
             group by home.id, home.name, home.shortName, home.teamCode
             """)
     List<OpponentWinRateRow> findOpponentWinRatesWhenAway(
+            @Param("memberId") Long memberId,
             @Param("myTeamId") Long myTeamId,
             @Param("start") LocalDate start,
             @Param("end") LocalDate end

--- a/backend/src/main/java/com/yagubogu/stat/service/StatService.java
+++ b/backend/src/main/java/com/yagubogu/stat/service/StatService.java
@@ -98,8 +98,8 @@ public class StatService {
         Long myTeamId = getTeamIdByMemberId(memberId);
         LocalDate start = LocalDate.of(year, 1, 1);
         LocalDate end = LocalDate.of(year, 12, 31);
-        List<OpponentWinRateRow> home = checkInRepository.findOpponentWinRatesWhenHome(myTeamId, start, end);
-        List<OpponentWinRateRow> away = checkInRepository.findOpponentWinRatesWhenAway(myTeamId, start, end);
+        List<OpponentWinRateRow> home = checkInRepository.findOpponentWinRatesWhenHome(memberId, myTeamId, start, end);
+        List<OpponentWinRateRow> away = checkInRepository.findOpponentWinRatesWhenAway(memberId, myTeamId, start, end);
         Map<Long, OpponentWinRateRow> mergedWinRate = mergeByTeamId(home, away);
 
         List<Team> opponents = teamRepository.findOpponentsExcluding(myTeamId);

--- a/backend/src/main/resources/application-local.yml
+++ b/backend/src/main/resources/application-local.yml
@@ -15,6 +15,3 @@ spring:
       hibernate:
         format_sql: true
         dialect: org.hibernate.dialect.MySQLDialect
-#    hibernate:
-#      ddl-auto: none
-#    defer-datasource-initialization: true


### PR DESCRIPTION
## 📌 관련 이슈
- close #473 

## ✨ 변경 내용
- 상대팀별 승률 조회 버그를 수정했습니다.
  - 게임이 아닌 인증 기반 승률 계산으로 변경했습니다.

## 🎸 기타 참고 사항
- 스크린샷, 참고 링크, 추가 설명 등 (없으면 생략 가능)