### PR TITLE
design: 승리요정 랭킹에서 내 랭킹을 상단에 표시

### DIFF
--- a/android/app/src/main/res/layout/fragment_home.xml
+++ b/android/app/src/main/res/layout/fragment_home.xml
@@ -302,6 +302,7 @@
                     android:id="@+id/divider"
                     android:layout_width="match_parent"
                     android:layout_height="0.4dp"
+                    android:layout_marginTop="4dp"
                     app:dividerColor="@color/gray300"
                     app:layout_constraintTop_toBottomOf="@id/layout_my_victory_fairy" />
 
@@ -309,6 +310,7 @@
                     android:id="@+id/rv_victory_fairy"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
+                    android:layout_marginTop="4dp"
                     android:nestedScrollingEnabled="false"
                     app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
                     app:layout_constraintTop_toBottomOf="@id/divider" />


### PR DESCRIPTION
## 📌 관련 이슈
- close #481 

## ✨ 변경 내용
- 홈 화면의 승리요정 랭킹에서 내 랭킹을 맨위로 이동했습니다.

## 🎸 기타 참고 사항
- 스크린샷, 참고 링크, 추가 설명 등 (없으면 생략 가능)

<img width="300" alt="Screenshot_20250906_124646" src="https://github.com/user-attachments/assets/f8a1ed6e-3678-4735-b93c-b503170d1af5" />
