### PR TITLE
design: BottomNavigation 아이콘 순서 변경 (홈, 현장톡, 통계, 직관내역 순)

### DIFF
--- a/android/app/src/main/res/menu/menu_bottom_navigation.xml
+++ b/android/app/src/main/res/menu/menu_bottom_navigation.xml
@@ -5,6 +5,10 @@
         android:icon="@drawable/ic_home"
         android:title="@string/bottom_navigation_home" />
     <item
+        android:id="@+id/item_livetalk"
+        android:icon="@drawable/ic_livetalk"
+        android:title="@string/bottom_navigation_livetalk" />
+    <item
         android:id="@+id/item_stats"
         android:icon="@drawable/ic_stats"
         android:title="@string/bottom_navigation_stats" />
@@ -12,9 +16,5 @@
         android:id="@+id/item_attendance_history"
         android:icon="@drawable/ic_attendance_history"
         android:title="@string/bottom_navigation_attendance_history" />
-    <item
-        android:id="@+id/item_livetalk"
-        android:icon="@drawable/ic_livetalk"
-        android:title="@string/bottom_navigation_livetalk" />
 
 </menu>


### PR DESCRIPTION
## 📌 관련 이슈
- close #483 

## ✨ 변경 내용
- BottomNavigation 아이콘 순서 변경 (홈, 현장톡, 통계, 직관내역 순)

## 🎸 기타 참고 사항
<img width="30%" src="https://github.com/user-attachments/assets/750d43ae-dd7c-4e68-8e9b-376fbd46748f" />
