### PR TITLE
refactor: 현장톡 경기 목록 조회 시 날짜를 동적으로 받도록 수정

### DIFF
--- a/android/app/src/main/java/com/yagubogu/presentation/livetalk/LivetalkViewModel.kt
+++ b/android/app/src/main/java/com/yagubogu/presentation/livetalk/LivetalkViewModel.kt
@@ -20,10 +20,9 @@ class LivetalkViewModel(
         fetchGames()
     }
 
-    fun fetchGames() {
+    fun fetchGames(date: LocalDate = LocalDate.now()) {
         viewModelScope.launch {
-            val gamesResult: Result<List<LivetalkStadiumItem>> =
-                gameRepository.getGames(DATE)
+            val gamesResult: Result<List<LivetalkStadiumItem>> = gameRepository.getGames(date)
             gamesResult
                 .onSuccess { livetalkStadiumItems: List<LivetalkStadiumItem> ->
                     _livetalkStadiumItems.value = livetalkStadiumItems
@@ -31,9 +30,5 @@ class LivetalkViewModel(
                     Timber.w(exception, "API 호출 실패")
                 }
         }
-    }
-
-    companion object {
-        private val DATE = LocalDate.now()
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈
- close #491 

## ✨ 변경 내용
현장톡 경기 목록 조회 시 날짜를 동적으로 받도록 수정했습니다.

## 🎸 기타 참고 사항
- 스크린샷, 참고 링크, 추가 설명 등 (없으면 생략 가능)