### PR TITLE
feat: 현장톡 UiState 추가 및 ShimmerLayout 적용

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -117,6 +117,7 @@ dependencies {
     implementation(libs.androidx.datastore.preferences)
     implementation(libs.glide)
     implementation(libs.play.services.oss.licenses)
+    implementation(libs.shimmer)
 
     // firebase
     implementation(platform(libs.firebase.bom))

--- a/android/app/src/main/java/com/yagubogu/presentation/livetalk/chat/LivetalkChatActivity.kt
+++ b/android/app/src/main/java/com/yagubogu/presentation/livetalk/chat/LivetalkChatActivity.kt
@@ -163,7 +163,7 @@ class LivetalkChatActivity : AppCompatActivity() {
     }
 
     private fun setupObservers() {
-        viewModel.livetalkResponseUiState.observe(this, ::handleLivetalkResponseUiState)
+        viewModel.livetalkUiState.observe(this, ::handleLivetalkResponseUiState)
         viewModel.liveTalkChatBubbleItem.observe(this, ::handleLiveTalkChatBubbleItem)
         viewModel.livetalkReportEvent.observe(this, ::handleLivetalkReportEvent)
         viewModel.livetalkDeleteEvent.observe(this) {
@@ -171,8 +171,8 @@ class LivetalkChatActivity : AppCompatActivity() {
         }
     }
 
-    private fun handleLivetalkResponseUiState(uiState: LivetalkResponseUiState) {
-        if (uiState is LivetalkResponseUiState.Error) {
+    private fun handleLivetalkResponseUiState(uiState: LivetalkUiState) {
+        if (uiState is LivetalkUiState.Error) {
             this.showToast(R.string.livetalk_loading_error)
             finish()
         }

--- a/android/app/src/main/java/com/yagubogu/presentation/livetalk/chat/LivetalkChatActivity.kt
+++ b/android/app/src/main/java/com/yagubogu/presentation/livetalk/chat/LivetalkChatActivity.kt
@@ -3,7 +3,6 @@ package com.yagubogu.presentation.livetalk.chat
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
-import android.widget.Toast
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.WindowCompat
@@ -175,6 +174,7 @@ class LivetalkChatActivity : AppCompatActivity() {
     private fun handleLivetalkResponseUiState(uiState: LivetalkResponseUiState) {
         if (uiState is LivetalkResponseUiState.Error) {
             this.showToast(R.string.livetalk_loading_error)
+            finish()
         }
     }
 

--- a/android/app/src/main/java/com/yagubogu/presentation/livetalk/chat/LivetalkChatActivity.kt
+++ b/android/app/src/main/java/com/yagubogu/presentation/livetalk/chat/LivetalkChatActivity.kt
@@ -3,11 +3,14 @@ package com.yagubogu.presentation.livetalk.chat
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
+import android.view.View
+import android.widget.Toast
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.WindowCompat
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
+import com.facebook.shimmer.ShimmerFrameLayout
 import com.yagubogu.R
 import com.yagubogu.YaguBoguApplication
 import com.yagubogu.databinding.ActivityLivetalkChatBinding
@@ -162,6 +165,44 @@ class LivetalkChatActivity : AppCompatActivity() {
     }
 
     private fun setupObservers() {
+        viewModel.livetalkResponseUiState.observe(this) { livetalkResponseUiState: LivetalkResponseUiState ->
+            val shimmerLayouts: List<ShimmerFrameLayout> =
+                listOf(binding.shimmerStadiumName, binding.shimmerAwayVsHomeName)
+            val views: List<View> = listOf(binding.tvAwayVsHomeName, binding.rvChatMessages)
+
+            when (livetalkResponseUiState) {
+                is LivetalkResponseUiState.LivetalkResponse -> {
+                    binding.livetalkResponseItem = livetalkResponseUiState.livetalkResponseItem
+                    views.forEach {
+                        it.visibility = View.VISIBLE
+                    }
+                    shimmerLayouts.forEach {
+                        it.visibility = View.INVISIBLE
+                        it.stopShimmer()
+                    }
+                }
+
+                LivetalkResponseUiState.Loading -> {
+                    binding.editMessage.hint = ""
+                    views.forEach {
+                        it.visibility = View.INVISIBLE
+                    }
+                    shimmerLayouts.forEach {
+                        it.startShimmer()
+                    }
+                }
+
+                LivetalkResponseUiState.Error -> {
+                    views.forEach {
+                        it.visibility = View.INVISIBLE
+                    }
+                    shimmerLayouts.forEach {
+                        it.startShimmer()
+                    }
+                    Toast.makeText(this, getString(R.string.livetalk_loading_error), Toast.LENGTH_SHORT).show()
+                }
+            }
+        }
         viewModel.liveTalkChatBubbleItem.observe(this) { livetalkChatBubbleItems: List<LivetalkChatBubbleItem> ->
 
             val oldFirstItemId =

--- a/android/app/src/main/java/com/yagubogu/presentation/livetalk/chat/LivetalkChatActivity.kt
+++ b/android/app/src/main/java/com/yagubogu/presentation/livetalk/chat/LivetalkChatActivity.kt
@@ -165,81 +165,87 @@ class LivetalkChatActivity : AppCompatActivity() {
     }
 
     private fun setupObservers() {
-        viewModel.livetalkResponseUiState.observe(this) { livetalkResponseUiState: LivetalkResponseUiState ->
-            val shimmerLayouts: List<ShimmerFrameLayout> =
-                listOf(binding.shimmerStadiumName, binding.shimmerAwayVsHomeName)
-            val views: List<View> = listOf(binding.tvAwayVsHomeName, binding.rvChatMessages)
-
-            when (livetalkResponseUiState) {
-                is LivetalkResponseUiState.LivetalkResponse -> {
-                    binding.livetalkResponseItem = livetalkResponseUiState.livetalkResponseItem
-                    views.forEach {
-                        it.visibility = View.VISIBLE
-                    }
-                    shimmerLayouts.forEach {
-                        it.visibility = View.INVISIBLE
-                        it.stopShimmer()
-                    }
-                }
-
-                LivetalkResponseUiState.Loading -> {
-                    binding.editMessage.hint = ""
-                    views.forEach {
-                        it.visibility = View.INVISIBLE
-                    }
-                    shimmerLayouts.forEach {
-                        it.startShimmer()
-                    }
-                }
-
-                LivetalkResponseUiState.Error -> {
-                    views.forEach {
-                        it.visibility = View.INVISIBLE
-                    }
-                    shimmerLayouts.forEach {
-                        it.startShimmer()
-                    }
-                    Toast.makeText(this, getString(R.string.livetalk_loading_error), Toast.LENGTH_SHORT).show()
-                }
-            }
-        }
-        viewModel.liveTalkChatBubbleItem.observe(this) { livetalkChatBubbleItems: List<LivetalkChatBubbleItem> ->
-
-            val oldFirstItemId =
-                livetalkChatAdapter.currentList
-                    .firstOrNull()
-                    ?.livetalkChatItem
-                    ?.chatId
-
-            val firstVisibleItemPosition = chatLinearLayoutManager.findFirstVisibleItemPosition()
-
-            livetalkChatAdapter.submitList(livetalkChatBubbleItems) {
-                val newFirstItemId = livetalkChatBubbleItems.firstOrNull()?.livetalkChatItem?.chatId
-                val isNewMessageArrived = oldFirstItemId != null && oldFirstItemId != newFirstItemId
-
-                if (isNewMessageArrived && firstVisibleItemPosition == 0) {
-                    chatLinearLayoutManager.scrollToPosition(0)
-                }
-            }
-        }
-        viewModel.livetalkReportEvent.observe(this) { livetalkReportEvent: LivetalkReportEvent ->
-            when (livetalkReportEvent) {
-                LivetalkReportEvent.DuplicatedReport ->
-                    binding.root.showSnackbar(
-                        R.string.livetalk_already_reported,
-                        R.id.divider,
-                    )
-
-                LivetalkReportEvent.Success ->
-                    binding.root.showSnackbar(
-                        R.string.livetalk_report_succeed,
-                        R.id.divider,
-                    )
-            }
-        }
-
+        viewModel.livetalkResponseUiState.observe(this, ::handleLivetalkResponseUiState)
+        viewModel.liveTalkChatBubbleItem.observe(this, ::handleLiveTalkChatBubbleItem)
+        viewModel.livetalkReportEvent.observe(this, ::handleLivetalkReportEvent)
         viewModel.livetalkDeleteEvent.observe(this) {
             binding.root.showSnackbar(R.string.livetalk_delete_succeed, R.id.divider)
+        }
+    }
+
+    private fun handleLivetalkResponseUiState(uiState: LivetalkResponseUiState) {
+        val shimmerLayouts: List<ShimmerFrameLayout> =
+            listOf(binding.shimmerStadiumName, binding.shimmerAwayVsHomeName)
+        val views: List<View> = listOf(binding.tvAwayVsHomeName, binding.rvChatMessages)
+
+        when (uiState) {
+            is LivetalkResponseUiState.LivetalkResponse -> {
+                binding.livetalkResponseItem = uiState.livetalkResponseItem
+                views.forEach {
+                    it.visibility = View.VISIBLE
+                }
+                shimmerLayouts.forEach {
+                    it.visibility = View.INVISIBLE
+                    it.stopShimmer()
+                }
+            }
+
+            LivetalkResponseUiState.Loading -> {
+                binding.editMessage.hint = ""
+                views.forEach {
+                    it.visibility = View.INVISIBLE
+                }
+                shimmerLayouts.forEach {
+                    it.startShimmer()
+                }
+            }
+
+            LivetalkResponseUiState.Error -> {
+                views.forEach {
+                    it.visibility = View.INVISIBLE
+                }
+                shimmerLayouts.forEach {
+                    it.startShimmer()
+                }
+                Toast
+                    .makeText(this, getString(R.string.livetalk_loading_error), Toast.LENGTH_SHORT)
+                    .show()
+            }
+        }
+    }
+
+    private fun handleLiveTalkChatBubbleItem(livetalkChatBubbleItems: List<LivetalkChatBubbleItem>) {
+        val oldFirstItemId =
+            livetalkChatAdapter.currentList
+                .firstOrNull()
+                ?.livetalkChatItem
+                ?.chatId
+
+        val firstVisibleItemPosition = chatLinearLayoutManager.findFirstVisibleItemPosition()
+
+        livetalkChatAdapter.submitList(livetalkChatBubbleItems) {
+            val newFirstItemId = livetalkChatBubbleItems.firstOrNull()?.livetalkChatItem?.chatId
+            val isNewMessageArrived = oldFirstItemId != null && oldFirstItemId != newFirstItemId
+
+            if (isNewMessageArrived && firstVisibleItemPosition == 0) {
+                chatLinearLayoutManager.scrollToPosition(0)
+            }
+        }
+    }
+
+    private fun handleLivetalkReportEvent(livetalkReportEvent: LivetalkReportEvent) {
+        when (livetalkReportEvent) {
+            LivetalkReportEvent.DuplicatedReport ->
+                binding.root.showSnackbar(
+                    R.string.livetalk_already_reported,
+                    R.id.divider,
+                )
+
+            LivetalkReportEvent.Success ->
+                binding.root.showSnackbar(
+                    R.string.livetalk_report_succeed,
+                    R.id.divider,
+                )
         }
     }
 

--- a/android/app/src/main/java/com/yagubogu/presentation/livetalk/chat/LivetalkChatViewModel.kt
+++ b/android/app/src/main/java/com/yagubogu/presentation/livetalk/chat/LivetalkChatViewModel.kt
@@ -22,8 +22,9 @@ class LivetalkChatViewModel(
     private val talkRepository: TalkRepository,
     private val isVerified: Boolean,
 ) : ViewModel() {
-    private val _livetalkResponseItem = MutableLiveData<LivetalkResponseItem>()
-    val livetalkResponseItem: LiveData<LivetalkResponseItem> get() = _livetalkResponseItem
+    private val _livetalkResponseUiState =
+        MutableLiveData<LivetalkResponseUiState>(LivetalkResponseUiState.Loading)
+    val livetalkResponseUiState: LiveData<LivetalkResponseUiState> get() = _livetalkResponseUiState
 
     private val _liveTalkChatBubbleItem = MutableLiveData<List<LivetalkChatBubbleItem>>()
     val liveTalkChatBubbleItem: LiveData<List<LivetalkChatBubbleItem>> get() = _liveTalkChatBubbleItem
@@ -186,7 +187,9 @@ class LivetalkChatViewModel(
                 val result = talkRepository.getBeforeTalks(gameId, null, CHAT_LOAD_LIMIT)
                 result
                     .onSuccess { livetalkResponseItem: LivetalkResponseItem ->
-                        _livetalkResponseItem.value = livetalkResponseItem
+                        _livetalkResponseUiState.value =
+                            LivetalkResponseUiState.LivetalkResponse(livetalkResponseItem)
+
                         val livetalkChatBubbleItem: List<LivetalkChatBubbleItem> =
                             livetalkResponseItem.cursor.chats.map { LivetalkChatBubbleItem.of(it) }
                         _liveTalkChatBubbleItem.value = livetalkChatBubbleItem
@@ -197,6 +200,7 @@ class LivetalkChatViewModel(
                             livetalkChatBubbleItem.firstOrNull()?.livetalkChatItem?.chatId
                     }.onFailure { exception ->
                         Timber.w(exception, "초기 메시지 API 호출 실패")
+                        _livetalkResponseUiState.value = LivetalkResponseUiState.Error
                     }
             }
         }

--- a/android/app/src/main/java/com/yagubogu/presentation/livetalk/chat/LivetalkChatViewModel.kt
+++ b/android/app/src/main/java/com/yagubogu/presentation/livetalk/chat/LivetalkChatViewModel.kt
@@ -22,13 +22,13 @@ class LivetalkChatViewModel(
     private val talkRepository: TalkRepository,
     private val isVerified: Boolean,
 ) : ViewModel() {
-    private val _livetalkResponseUiState =
-        MutableLiveData<LivetalkResponseUiState>(LivetalkResponseUiState.Loading)
-    val livetalkResponseUiState: LiveData<LivetalkResponseUiState> get() = _livetalkResponseUiState
+    private val _livetalkUiState =
+        MutableLiveData<LivetalkUiState>(LivetalkUiState.Loading)
+    val livetalkUiState: LiveData<LivetalkUiState> get() = _livetalkUiState
 
     val isStadiumLoading =
         MediatorLiveData<Boolean>().apply {
-            addSource(livetalkResponseUiState) { value = it !is LivetalkResponseUiState.Success }
+            addSource(livetalkUiState) { value = it !is LivetalkUiState.Success }
         }
 
     private val _livetalkResponseItem = MutableLiveData<LivetalkResponseItem>()
@@ -195,7 +195,7 @@ class LivetalkChatViewModel(
                 val result = talkRepository.getBeforeTalks(gameId, null, CHAT_LOAD_LIMIT)
                 result
                     .onSuccess { livetalkResponseItem: LivetalkResponseItem ->
-                        _livetalkResponseUiState.value = LivetalkResponseUiState.Success
+                        _livetalkUiState.value = LivetalkUiState.Success
                         _livetalkResponseItem.value = livetalkResponseItem
 
                         val livetalkChatBubbleItem: List<LivetalkChatBubbleItem> =
@@ -208,7 +208,7 @@ class LivetalkChatViewModel(
                             livetalkChatBubbleItem.firstOrNull()?.livetalkChatItem?.chatId
                     }.onFailure { exception ->
                         Timber.w(exception, "초기 메시지 API 호출 실패")
-                        _livetalkResponseUiState.value = LivetalkResponseUiState.Error
+                        _livetalkUiState.value = LivetalkUiState.Error
                     }
             }
         }

--- a/android/app/src/main/java/com/yagubogu/presentation/livetalk/chat/LivetalkResponseUiState.kt
+++ b/android/app/src/main/java/com/yagubogu/presentation/livetalk/chat/LivetalkResponseUiState.kt
@@ -1,0 +1,11 @@
+package com.yagubogu.presentation.livetalk.chat
+
+sealed interface LivetalkResponseUiState {
+    data class LivetalkResponse(
+        val livetalkResponseItem: LivetalkResponseItem,
+    ) : LivetalkResponseUiState
+
+    data object Loading : LivetalkResponseUiState
+
+    data object Error : LivetalkResponseUiState
+}

--- a/android/app/src/main/java/com/yagubogu/presentation/livetalk/chat/LivetalkResponseUiState.kt
+++ b/android/app/src/main/java/com/yagubogu/presentation/livetalk/chat/LivetalkResponseUiState.kt
@@ -1,9 +1,0 @@
-package com.yagubogu.presentation.livetalk.chat
-
-sealed interface LivetalkResponseUiState {
-    data object Success : LivetalkResponseUiState
-
-    data object Loading : LivetalkResponseUiState
-
-    data object Error : LivetalkResponseUiState
-}

--- a/android/app/src/main/java/com/yagubogu/presentation/livetalk/chat/LivetalkUiState.kt
+++ b/android/app/src/main/java/com/yagubogu/presentation/livetalk/chat/LivetalkUiState.kt
@@ -1,0 +1,9 @@
+package com.yagubogu.presentation.livetalk.chat
+
+sealed interface LivetalkUiState {
+    data object Success : LivetalkUiState
+
+    data object Loading : LivetalkUiState
+
+    data object Error : LivetalkUiState
+}

--- a/android/app/src/main/res/layout/activity_livetalk_chat.xml
+++ b/android/app/src/main/res/layout/activity_livetalk_chat.xml
@@ -10,6 +10,10 @@
             type="com.yagubogu.presentation.livetalk.chat.LivetalkChatViewModel" />
 
         <variable
+            name="livetalkResponseItem"
+            type="com.yagubogu.presentation.livetalk.chat.LivetalkResponseItem" />
+
+        <variable
             name="isVerified"
             type="boolean" />
 
@@ -23,18 +27,50 @@
         android:fitsSystemWindows="true"
         tools:context=".presentation.livetalk.chat.LivetalkChatActivity">
 
+        <com.facebook.shimmer.ShimmerFrameLayout
+            android:id="@+id/shimmer_stadium_name"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="12dp"
+            app:layout_constraintLeft_toLeftOf="parent"
+            app:layout_constraintRight_toRightOf="parent"
+            app:layout_constraintTop_toTopOf="parent">
+
+            <View
+                android:layout_width="120dp"
+                android:layout_height="20dp"
+                android:background="@drawable/bg_radius_4dp"
+                android:backgroundTint="@color/gray300" />
+        </com.facebook.shimmer.ShimmerFrameLayout>
+
         <TextView
             android:id="@+id/tv_stadium_name"
             style="@style/TextView.Pretendard.Bold"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="12dp"
-            android:text="@{viewModel.livetalkResponseItem.stadiumName}"
+            android:text="@{livetalkResponseItem.stadiumName}"
             android:textSize="18sp"
             app:layout_constraintLeft_toLeftOf="parent"
             app:layout_constraintRight_toRightOf="parent"
             app:layout_constraintTop_toTopOf="parent"
             tools:text="고척 스카이돔" />
+
+        <com.facebook.shimmer.ShimmerFrameLayout
+            android:id="@+id/shimmer_away_vs_home_name"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="2dp"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tv_stadium_name">
+
+            <View
+                android:layout_width="60dp"
+                android:layout_height="16dp"
+                android:background="@drawable/bg_radius_4dp"
+                android:backgroundTint="@color/gray300" />
+        </com.facebook.shimmer.ShimmerFrameLayout>
 
         <TextView
             android:id="@+id/tv_away_vs_home_name"
@@ -42,7 +78,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="2dp"
-            android:text="@{@string/livetalk_away_home_name(viewModel.livetalkResponseItem.awayTeamName, viewModel.livetalkResponseItem.homeTeamName)}"
+            android:text="@{@string/livetalk_away_home_name(livetalkResponseItem.awayTeamName, livetalkResponseItem.homeTeamName)}"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/tv_stadium_name"
@@ -108,7 +144,7 @@
                 android:background="@null"
                 android:enabled="@{isVerified}"
                 android:gravity="center_vertical"
-                android:hint="@{isVerified? @string/livetalk_chat_input_hint(viewModel.livetalkResponseItem.stadiumName) : @string/livetalk_chat_input_hint_unverified}"
+                android:hint="@{isVerified? @string/livetalk_chat_input_hint(livetalkResponseItem.stadiumName) : @string/livetalk_chat_input_hint_unverified}"
                 android:importantForAutofill="no"
                 android:inputType="textMultiLine"
                 android:maxLength="200"

--- a/android/app/src/main/res/layout/activity_livetalk_chat.xml
+++ b/android/app/src/main/res/layout/activity_livetalk_chat.xml
@@ -32,8 +32,8 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="12dp"
-            app:layout_constraintLeft_toLeftOf="parent"
-            app:layout_constraintRight_toRightOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent">
 
             <View
@@ -51,8 +51,8 @@
             android:layout_marginTop="12dp"
             android:text="@{livetalkResponseItem.stadiumName}"
             android:textSize="18sp"
-            app:layout_constraintLeft_toLeftOf="parent"
-            app:layout_constraintRight_toRightOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
             tools:text="고척 스카이돔" />
 

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -115,7 +115,7 @@
     <string name="livetalk_user_report_dialog_message">정말 %1$s님의 현장톡을 신고할까요?</string>
     <string name="livetalk_already_reported">이미 신고한 현장톡입니다.</string>
     <string name="livetalk_report_succeed">정상 신고 되었습니다.</string>
-    <string name="livetalk_loading_error">해당 경기 현장톡을 불러오는 데 실패했습니다.</string>
+    <string name="livetalk_loading_error">현장톡을 불러오는 데 실패했습니다.</string>
 
     <string name="setting_main_title">설정</string>
     <string name="setting_main_sign_up_date">가입한 날 : %s</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -90,15 +90,15 @@
     <string name="attendance_history_errors">실책</string>
     <string name="attendance_history_balls">사사구</string>
 
-    <string name="livetalk_user_icon_description">직관 인증 수 사람 아이콘</string>
-    <string name="livetalk_stadium_select_arrow_description">현장톡 구장 선택 진입 아이콘</string>
-    <string name="livetalk_empty_game_description">오늘은 경기가 없어요</string>
-    <string name="livetalk_empty_game_illustration_description">야구공을 놓치는 일러스트</string>
-
     <string name="login_failed_message">로그인에 실패했습니다.</string>
 
     <string name="favorite_team_selection">응원하는 팀을\n선택해 주세요!</string>
     <string name="favorite_team_selection_confirm">응원하는 팀으로 선택할까요?</string>
+
+    <string name="livetalk_user_icon_description">직관 인증 수 사람 아이콘</string>
+    <string name="livetalk_stadium_select_arrow_description">현장톡 구장 선택 진입 아이콘</string>
+    <string name="livetalk_empty_game_description">오늘은 경기가 없어요</string>
+    <string name="livetalk_empty_game_illustration_description">야구공을 놓치는 일러스트</string>
 
     <string name="livetalk_send_btn_description">메시지 전송 버튼 비행기 아이콘</string>
     <string name="livetalk_away_home_name">%s vs %s</string>
@@ -115,6 +115,7 @@
     <string name="livetalk_user_report_dialog_message">정말 %1$s님의 현장톡을 신고할까요?</string>
     <string name="livetalk_already_reported">이미 신고한 현장톡입니다.</string>
     <string name="livetalk_report_succeed">정상 신고 되었습니다.</string>
+    <string name="livetalk_loading_error">해당 경기 현장톡을 불러오는 데 실패했습니다.</string>
 
     <string name="setting_main_title">설정</string>
     <string name="setting_main_sign_up_date">가입한 날 : %s</string>

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -20,6 +20,7 @@ constraintlayout = "2.2.1"
 ktlint = "13.0.0"
 playServicesOssLicenses = "17.2.2"
 retrofit = "3.0.0"
+shimmer = "0.5.0"
 timber = "5.0.1"
 viewpager2 = "1.1.0"
 playServicesLocation = "21.3.0"
@@ -56,6 +57,7 @@ play-services-location = { group = "com.google.android.gms", name = "play-servic
 mpandroidchart = { module = "com.github.PhilJay:MPAndroidChart", version.ref = "mpandroidchart" }
 play-services-oss-licenses = { module = "com.google.android.gms:play-services-oss-licenses", version.ref = "playServicesOssLicenses" }
 retrofit = { module = "com.squareup.retrofit2:retrofit", version.ref = "retrofit" }
+shimmer = { module = "com.facebook.shimmer:shimmer", version.ref = "shimmer" }
 timber = { module = "com.jakewharton.timber:timber", version.ref = "timber" }
 google-googleid = { group = "com.google.android.libraries.identity.googleid", name = "googleid", version.ref = "googleidVersion" }
 glide = { module = "com.github.bumptech.glide:glide", version.ref = "glide" }


### PR DESCRIPTION
## 📌 관련 이슈
- close #497 

## ✨ 변경 내용
- shimmer 라이브러리 의존성 추가
- 현장톡 UiState 추가
- 상태별 ShimmerLayout 적용

## 🎸 기타 참고 사항
- 스크린샷, 참고 링크, 추가 설명 등 (없으면 생략 가능)


https://github.com/user-attachments/assets/cac9e282-4d7c-4711-be22-89cbb98bcc56



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added shimmer loading placeholders to the LiveTalk chat header for a smoother loading experience.
  - Introduced clear loading and error states with user-facing feedback when chat data fails to load.
  - Improved chat list behavior: auto-scrolls to show new messages when at the top.
  - Enhanced reporting and deletion feedback with concise snackbars.
- Chores
  - Included Shimmer library to support loading skeletons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->