### PR TITLE
design: 직관 내역 필터와 정렬을 항상 표시하도록 변경

### DIFF
--- a/android/app/src/main/java/com/yagubogu/presentation/attendance/AttendanceHistoryFragment.kt
+++ b/android/app/src/main/java/com/yagubogu/presentation/attendance/AttendanceHistoryFragment.kt
@@ -105,7 +105,10 @@ class AttendanceHistoryFragment : Fragment() {
                     binding.rvAttendanceHistory.smoothScrollToPosition(it)
                 }
             }
-            updateEmptyHistoryState(value.isEmpty())
+
+            val isEmpty: Boolean = value.isEmpty()
+            binding.ivEmptyHistory.isVisible = isEmpty
+            binding.tvEmptyHistory.isVisible = isEmpty
         }
 
         viewModel.attendanceHistoryOrder.observe(viewLifecycleOwner) { value: AttendanceHistoryOrder ->
@@ -117,13 +120,5 @@ class AttendanceHistoryFragment : Fragment() {
                     },
                 )
         }
-    }
-
-    private fun updateEmptyHistoryState(isEmpty: Boolean) {
-        binding.ivEmptyHistory.isVisible = isEmpty
-        binding.tvEmptyHistory.isVisible = isEmpty
-
-        binding.constraintFilter.isVisible = !isEmpty
-        binding.constraintOrder.isVisible = !isEmpty
     }
 }

--- a/android/app/src/main/res/layout/fragment_attendance_history.xml
+++ b/android/app/src/main/res/layout/fragment_attendance_history.xml
@@ -18,66 +18,50 @@
         android:paddingBottom="12dp"
         tools:context=".presentation.attendance.AttendanceHistoryFragment">
 
-        <androidx.constraintlayout.widget.ConstraintLayout
-            android:id="@+id/constraint_filter"
+        <Spinner
+            android:id="@+id/spinner_attendance_history_filter"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:background="@android:color/transparent"
+            android:overlapAnchor="false"
+            android:paddingEnd="20dp"
+            android:spinnerMode="dropdown"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent">
+            app:layout_constraintTop_toTopOf="parent" />
 
-            <Spinner
-                android:id="@+id/spinner_attendance_history_filter"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:background="@android:color/transparent"
-                android:overlapAnchor="false"
-                android:paddingEnd="20dp"
-                android:spinnerMode="dropdown"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent" />
+        <ImageView
+            android:layout_width="20dp"
+            android:layout_height="20dp"
+            android:src="@drawable/ic_arrow_down"
+            app:layout_constraintBottom_toBottomOf="@id/spinner_attendance_history_filter"
+            app:layout_constraintEnd_toEndOf="@id/spinner_attendance_history_filter"
+            app:layout_constraintTop_toTopOf="@id/spinner_attendance_history_filter"
+            app:tint="@color/gray500" />
 
-            <ImageView
-                android:layout_width="20dp"
-                android:layout_height="20dp"
-                android:src="@drawable/ic_arrow_down"
-                app:layout_constraintBottom_toBottomOf="@id/spinner_attendance_history_filter"
-                app:layout_constraintEnd_toEndOf="@id/spinner_attendance_history_filter"
-                app:layout_constraintTop_toTopOf="@id/spinner_attendance_history_filter"
-                app:tint="@color/gray500" />
-        </androidx.constraintlayout.widget.ConstraintLayout>
-
-        <androidx.constraintlayout.widget.ConstraintLayout
-            android:id="@+id/constraint_order"
+        <TextView
+            android:id="@+id/tv_attendance_history_order"
+            style="@style/TextView.Pretendard.Regular"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            app:layout_constraintBottom_toBottomOf="@id/constraint_filter"
+            android:layout_marginEnd="8dp"
+            android:onClick="@{() -> viewModel.switchAttendanceHistoryOrder()}"
+            android:paddingEnd="20dp"
+            android:textColor="@color/gray500"
+            android:textSize="14sp"
+            app:layout_constraintBottom_toBottomOf="@id/spinner_attendance_history_filter"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toTopOf="@id/constraint_filter">
+            app:layout_constraintTop_toTopOf="@id/spinner_attendance_history_filter"
+            tools:text="최신순" />
 
-            <TextView
-                android:id="@+id/tv_attendance_history_order"
-                style="@style/TextView.Pretendard.Regular"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginEnd="8dp"
-                android:onClick="@{() -> viewModel.switchAttendanceHistoryOrder()}"
-                android:paddingEnd="20dp"
-                android:textColor="@color/gray500"
-                android:textSize="14sp"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent"
-                tools:text="최신순" />
-
-            <ImageView
-                android:id="@+id/iv_attendance_history_switch"
-                android:layout_width="16dp"
-                android:layout_height="16dp"
-                android:src="@drawable/ic_switch"
-                app:layout_constraintBottom_toBottomOf="@id/tv_attendance_history_order"
-                app:layout_constraintEnd_toEndOf="@id/tv_attendance_history_order"
-                app:layout_constraintTop_toTopOf="@id/tv_attendance_history_order"
-                app:tint="@color/gray500" />
-        </androidx.constraintlayout.widget.ConstraintLayout>
+        <ImageView
+            android:id="@+id/iv_attendance_history_switch"
+            android:layout_width="16dp"
+            android:layout_height="16dp"
+            android:src="@drawable/ic_switch"
+            app:layout_constraintBottom_toBottomOf="@id/tv_attendance_history_order"
+            app:layout_constraintEnd_toEndOf="@id/tv_attendance_history_order"
+            app:layout_constraintTop_toTopOf="@id/tv_attendance_history_order"
+            app:tint="@color/gray500" />
 
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/rv_attendance_history"
@@ -86,7 +70,7 @@
             android:layout_marginTop="8dp"
             app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
             app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/constraint_filter" />
+            app:layout_constraintTop_toBottomOf="@id/spinner_attendance_history_filter" />
 
         <ImageView
             android:id="@+id/iv_empty_history"


### PR DESCRIPTION
## 📌 관련 이슈
- close #499 

## ✨ 변경 내용
승리한 경기가 없을 때, 전체 경기 -> 승리한 경기로 필터를 변경하면 필터와 정렬이 아예 사라지는 문제가 있었습니다. (동영상 참고)
직관 내역에서 필터(전체 경기/승리한 경기)와 정렬(최신순/오래된순)을 항상 표시하도록 변경했습니다.

## 🎸 기타 참고 사항
- 스크린샷, 참고 링크, 추가 설명 등 (없으면 생략 가능)

https://github.com/user-attachments/assets/9e42a044-7938-41a3-8821-e79a0aaf71ce

