### PR TITLE
feat: adaptive polling 구현

### DIFF
--- a/backend/src/main/java/com/yagubogu/auth/gateway/AuthGateway.java
+++ b/backend/src/main/java/com/yagubogu/auth/gateway/AuthGateway.java
@@ -1,7 +1,7 @@
 package com.yagubogu.auth.gateway;
 
-import com.yagubogu.auth.dto.LoginRequest;
 import com.yagubogu.auth.dto.AuthResponse;
+import com.yagubogu.auth.dto.LoginRequest;
 
 public interface AuthGateway {
 

--- a/backend/src/main/java/com/yagubogu/checkin/repository/CheckInRepository.java
+++ b/backend/src/main/java/com/yagubogu/checkin/repository/CheckInRepository.java
@@ -171,7 +171,7 @@ public interface CheckInRepository extends JpaRepository<CheckIn, Long> {
             WHERE g.date = :date
             GROUP BY g
             """)
-    List<GameWithFanCountsResponse> findGamesWithFanCountsByDate(LocalDate date);
+    List<GameWithFanCountsResponse> findGamesWithFanCountsByDate(@Param("date") LocalDate date);
 
     @Query("""
             SELECT new com.yagubogu.checkin.dto.CheckInGameResponse(

--- a/backend/src/main/java/com/yagubogu/game/domain/AdaptivePoller.java
+++ b/backend/src/main/java/com/yagubogu/game/domain/AdaptivePoller.java
@@ -1,0 +1,294 @@
+package com.yagubogu.game.domain;
+
+import static com.yagubogu.game.domain.GameState.FINALIZED_GAME_STATES;
+
+import com.yagubogu.game.dto.KboGameResponse;
+import com.yagubogu.game.dto.KboGamesResponse;
+import com.yagubogu.game.exception.GameSyncException;
+import com.yagubogu.game.repository.GameRepository;
+import com.yagubogu.game.service.GameResultSyncService;
+import com.yagubogu.game.service.client.KboGameSyncClient;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.ZonedDateTime;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AdaptivePoller {
+
+    // MAX_FAIL_COUNT: 경기별 실패 횟수 카운트 상한 (이후에도 카운트되지만 경고 기준)
+    // DEFAULT_START_TIME: KBO 시작 시간이 null일 때 사용할 기본 킥오프 시간
+    // MAX_FAIL_MINUTE: 경기별/전역 지수 백오프의 최대 상한(분)
+    // (요구사항: LIVE=8분, SCHEDULED=20분, 전역=5~8분 → 여기선 전역/경기별 공통 cap=8분)
+
+    private static final int MAX_FAIL_COUNT = 3;
+    private static final LocalTime DEFAULT_START_TIME = LocalTime.of(18, 30);
+    private static final int MAX_FAIL_MINUTE = 8;
+
+    private final GameRepository gameRepository;
+    private final KboGameSyncClient kboGameSyncClient;
+    private final GameResultSyncService gameResultSyncService;
+    private final Clock clock;
+
+    // 경기별 실패 횟수 (지수 백오프 계산용)
+    private final Map<Long, Integer> failureCount = new ConcurrentHashMap<>();
+
+    // 전역 fetch 실패 시, 이 시각까지는 tick을 중단
+    private volatile Instant globalBackoffUntil = Instant.EPOCH;
+
+    // 오늘 더 이상 처리할 due가 없을 때, 다음 전체 깨울 시각(대개 자정)
+    private volatile Instant globalWakeAt = Instant.EPOCH;
+
+    // 경기별 다음 실행 예정 시각 (due)
+    private final Map<Long, Instant> nextRunAt = new ConcurrentHashMap<>();
+
+    // 앱 재시작/자정 이후 초기화: 오늘자 경기만 가지고 nextRunAt를 재구성
+    // - FINALIZED 상태 경기는 스케줄 잡지 않음
+    // - 각 경기의 next due를 계산 후, 전체적으로 가장 이른 due를 globalWakeAt으로 세팅
+    public void initializeTodaySchedule(LocalDate today) {
+        List<Game> games = gameRepository.findAllByDate(today);
+        nextRunAt.clear();
+
+        if (games.isEmpty()) {
+            // 오늘 경기가 없다면 다음 자정까지 전체 슬립
+            globalWakeAt = calculateTomorrow(today);
+            return;
+        }
+
+        Instant earliestDue = null;
+        Instant now = Instant.now(clock);
+
+        for (Game g : games) {
+            // 이미 끝난 경기는 스케줄 잡지 않음
+            if (FINALIZED_GAME_STATES.contains(g.getGameState())) {
+                continue;
+            }
+
+            // 시작 시각/현재 상태를 기준으로 첫 폴링 due 계산
+            Instant planned = computeStartInstant(g.getDate(), g.getStartAt());
+            Duration interval = computePollingInterval(g.getDate(), g.getStartAt(), now, g.getGameState());
+            Instant due = computeInitialDue(planned, now, interval);
+
+            nextRunAt.put(g.getId(), due);
+            earliestDue = earliestOf(earliestDue, due);
+        }
+
+        // globalWakeAt = earliestDue(있으면) vs now
+        globalWakeAt = Optional.ofNullable(earliestDue)
+                .filter(d -> d.isAfter(now))
+                .orElse(now);
+    }
+
+    // 1분 간격으로 깨어나 폴링을 수행
+    // - 전역 백오프/웨이크업 시각 검사
+    // - 오늘 처리할 경기 존재 여부 확인
+    // - KBO 일괄 조회(오늘자) → 실패 시 전역 백오프, 성공 시 캐시로 사용
+    // - 각 경기별 due 도달 판단 후 세부 업데이트 및 다음 due 재설정
+    @Scheduled(fixedDelay = 60_000)
+    public void pollGameWhenReachDue() {
+        Instant now = Instant.now(clock);
+
+        // 전역 백오프 중이면 쉬고 복귀
+        if (now.isBefore(globalBackoffUntil)) {
+            return;
+        }
+
+        // 아직 깰 시간이 아니면 복귀
+        if (now.isBefore(globalWakeAt)) {
+            return;
+        }
+
+        LocalDate today = LocalDate.now(clock);
+        // 오늘 남은 경기(미종료)가 없으면 자정까지 슬립
+        if (!existsRemainGames(today)) {
+            globalWakeAt = calculateTomorrow(today);
+            return;
+        }
+
+        // 오늘자 경기 목록 1회 일괄 fetch (캐시처럼 활용)
+        Map<String, KboGameResponse> dailyGames = fetchGames(today);
+        if (dailyGames.isEmpty()) {
+            return;
+        }
+
+        // 성공 시 전역 백오프 해제
+        clearGlobalBackoff();
+
+        // 경기별 처리 루프
+        for (Game game : gameRepository.findAllByDate(today)) {
+            Long gameId = game.getId();
+
+            // 종료된 경기는 스케줄 및 실패 카운트 제거
+            if (FINALIZED_GAME_STATES.contains(game.getGameState())) {
+                nextRunAt.remove(gameId);
+                failureCount.remove(gameId);
+                continue;
+            }
+
+            // 아직 due가 안 왔으면 skip
+            Instant dueAt = nextRunAt.getOrDefault(gameId, Instant.EPOCH);
+            if (now.isBefore(dueAt)) {
+                continue;
+            }
+
+            try {
+                // 오늘자 캐시에서 해당 경기 행 추출(없으면 실패 처리)
+                KboGameResponse row = dailyGames.get(game.getGameCode());
+                if (row == null) {
+                    applyPerGameBackOff(gameId);
+                    continue;
+                }
+
+                gameResultSyncService.updateGameDetails(game.getGameCode(), row);
+                resetGameFailureCount(gameId);
+
+                // 동기화 결과가 종료 상태면 스케줄 제거
+                GameState newState = row.gameState();
+                if (isFinalState(newState)) {
+                    nextRunAt.remove(gameId);
+                    failureCount.remove(gameId);
+                    continue;
+                }
+
+                // 다음 due 산정 (상태/경과 시간 기반)
+                Duration base = computePollingInterval(game.getDate(), game.getStartAt(), now, newState);
+                scheduleNextRuns(gameId, base);
+
+            } catch (Exception e) {
+                // 개별 경기 처리 실패 시: 경기별 지수 백오프
+                applyPerGameBackOff(gameId);
+            }
+        }
+    }
+
+    // 첫 due 계산:
+    // - 아직 킥오프 전이면 planned(킥오프 시각)
+    // - 시작 이후면 now + interval
+    private Instant computeInitialDue(final Instant planned, final Instant now, final Duration interval) {
+        return Optional.of(now)
+                .filter(t -> !t.isBefore(planned))
+                .map(t -> t.plus(interval))
+                .orElse(planned);
+    }
+
+    // 오늘자 경기 목록 일괄 조회
+    // - 예외 시 전역 백오프(지수) 적용 후 빈 맵 반환
+    // - 성공 시 gameCode → 응답 매핑
+    private Map<String, KboGameResponse> fetchGames(LocalDate date) {
+        try {
+            KboGamesResponse response = kboGameSyncClient.fetchGames(date);
+            Map<String, KboGameResponse> games = new HashMap<>();
+            for (KboGameResponse g : response.games()) {
+                games.put(g.gameCode(), g);
+            }
+            return games;
+        } catch (GameSyncException e) {
+            applyGlobalBackOff();
+            log.warn("fetchGames failed for {}: {}", date, e.toString());
+            return Map.of();
+        }
+    }
+
+    // 다음 실행 예정시각(due) 설정:
+    // - 현재 시각 + 계산된 interval
+    // - (지터 제거 정책 반영: 랜덤 오프셋 없음)
+    private void scheduleNextRuns(Long gameId, Duration base) {
+        Instant now = Instant.now(clock);
+        Instant due = now.plus(base);
+        nextRunAt.put(gameId, due);
+    }
+
+    private void clearGlobalBackoff() {
+        globalBackoffUntil = Instant.EPOCH;
+    }
+
+    private boolean existsRemainGames(final LocalDate today) {
+        return gameRepository.existsByDateAndGameStateIn(today, List.of(GameState.SCHEDULED, GameState.LIVE));
+    }
+
+    private Instant calculateTomorrow(LocalDate base) {
+        return ZonedDateTime.of(base.plusDays(1), LocalTime.MIDNIGHT, clock.getZone()).toInstant();
+    }
+
+    // 자정(내일 00:00) Instant 계산
+    private Instant computeStartInstant(LocalDate date, LocalTime startAt) {
+        LocalTime effectiveStart = Objects.requireNonNullElse(startAt, DEFAULT_START_TIME);
+
+        return ZonedDateTime.of(date, effectiveStart, clock.getZone()).toInstant();
+    }
+
+    // 폴링 주기 산정 로직
+    // - SCHEDULED: 킥오프 전·지연 보호(10~15분)
+    // - LIVE: 5분
+    private Duration computePollingInterval(LocalDate date, LocalTime startAt, Instant now, GameState state) {
+        Instant plannedStart = computeStartInstant(date, startAt);
+        long elapsedMin = Duration.between(plannedStart, now).toMinutes();
+
+        if (state == GameState.SCHEDULED) {
+            if (elapsedMin < 120) {
+                return Duration.ofMinutes(10);
+            }
+            return Duration.ofMinutes(15);
+        }
+
+        return Duration.ofMinutes(5);
+    }
+
+    private boolean isFinalState(GameState state) {
+        return (state == GameState.COMPLETED || state == GameState.CANCELED);
+    }
+
+    private static Instant earliestOf(Instant a, Instant b) {
+        if (a == null) {
+            return b;
+        }
+        if (a.isBefore(b)) {
+            return a;
+        }
+        return b;
+    }
+
+    private void resetGameFailureCount(Long gameId) {
+        if (gameId != null) {
+            failureCount.remove(gameId);
+        }
+    }
+
+    // 개별 경기 실패 처리(지수 백오프):
+    // - 실패 횟수에 따라 1,2,4,8분 … 단, cap=MAX_FAIL_MINUTE(8분)
+    // - 다음 due를 백오프 후로 미룸
+    // - 다회 실패 시 경고 로그
+    private void applyPerGameBackOff(Long gameId) {
+        int fail = failureCount.merge(gameId, 1, Integer::sum);
+        int minutes = Math.min(MAX_FAIL_MINUTE, 1 << Math.min(fail, MAX_FAIL_COUNT));
+        Instant due = Instant.now(clock).plus(Duration.ofMinutes(minutes));
+        nextRunAt.put(gameId, due);
+        if (fail > MAX_FAIL_COUNT) {
+            log.warn("Poll repeatedly failed: gameId={}, failCount={}", gameId, fail);
+        }
+    }
+
+    // 전역 fetch 실패 처리(전역 지수 백오프):
+    // - 직전 남은 백오프(remain)를 기준으로 2배 증가(1 → 2 → 4 → 8)하되 cap=8분
+    private void applyGlobalBackOff() {
+        Instant now = Instant.now(clock);
+        long remain = Math.max(0, Duration.between(now, globalBackoffUntil).toMinutes());
+        long next = Math.min(MAX_FAIL_MINUTE, Math.max(1, remain == 0 ? 1 : remain * 2));
+        globalBackoffUntil = now.plus(Duration.ofMinutes(next));
+        log.warn("Daily fetch failed. Global backoff {} min until {}", next, globalBackoffUntil);
+    }
+}

--- a/backend/src/main/java/com/yagubogu/game/domain/GameState.java
+++ b/backend/src/main/java/com/yagubogu/game/domain/GameState.java
@@ -2,6 +2,7 @@ package com.yagubogu.game.domain;
 
 import com.yagubogu.game.exception.GameSyncException;
 import java.util.Arrays;
+import java.util.EnumSet;
 
 public enum GameState {
 
@@ -10,6 +11,8 @@ public enum GameState {
     COMPLETED(3),
     CANCELED(4),
     ;
+
+    public static final EnumSet<GameState> FINALIZED_GAME_STATES = EnumSet.of(GameState.COMPLETED, GameState.CANCELED);
 
     private final Integer stateNumber;
 
@@ -26,9 +29,5 @@ public enum GameState {
 
     public boolean isCompleted() {
         return this == COMPLETED;
-    }
-
-    public boolean isNotCompleted() {
-        return !isCompleted();
     }
 }

--- a/backend/src/main/java/com/yagubogu/game/repository/GameRepository.java
+++ b/backend/src/main/java/com/yagubogu/game/repository/GameRepository.java
@@ -1,6 +1,7 @@
 package com.yagubogu.game.repository;
 
 import com.yagubogu.game.domain.Game;
+import com.yagubogu.game.domain.GameState;
 import com.yagubogu.game.dto.GameWithCheckIn;
 import com.yagubogu.member.domain.Member;
 import com.yagubogu.stadium.domain.Stadium;
@@ -17,11 +18,6 @@ public interface GameRepository extends JpaRepository<Game, Long> {
     Optional<Game> findByStadiumAndDate(Stadium stadium, LocalDate date);
 
     Optional<Game> findByGameCode(String gameCode);
-
-    List<Game> findByDate(LocalDate date);
-
-    List<Game> findGameByDate(LocalDate date);
-
 
     @Query("""
             SELECT new com.yagubogu.game.dto.GameWithCheckIn(
@@ -50,4 +46,10 @@ public interface GameRepository extends JpaRepository<Game, Long> {
             GROUP BY g.id
             """)
     List<GameWithCheckIn> findGamesWithCheckInsByDate(LocalDate date, Member member);
+
+    List<Game> findAllByDate(LocalDate today);
+
+    boolean existsByDateAndGameStateIn(LocalDate today, List<GameState> scheduled);
+
+    boolean existsByDate(LocalDate date);
 }

--- a/backend/src/main/java/com/yagubogu/game/schedule/GameScheduler.java
+++ b/backend/src/main/java/com/yagubogu/game/schedule/GameScheduler.java
@@ -1,11 +1,14 @@
 package com.yagubogu.game.schedule;
 
+import com.yagubogu.game.domain.AdaptivePoller;
 import com.yagubogu.game.exception.GameSyncException;
-import com.yagubogu.game.service.GameResultSyncService;
 import com.yagubogu.game.service.GameScheduleSyncService;
+import java.time.Clock;
 import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
@@ -15,23 +18,21 @@ import org.springframework.stereotype.Component;
 public class GameScheduler {
 
     private final GameScheduleSyncService gameScheduleSyncService;
-    private final GameResultSyncService gameResultSyncService;
+    private final AdaptivePoller adaptivePoller;
+    private final Clock clock;
 
+    /**
+     * 매일 0시 or 부팅시에 경기 일정을 가져온다.
+     * 이미 경기가 db에 존재하면 pass, 스케줄을 항상 재구성된다.
+     */
     @Scheduled(cron = "0 0 0 * * *")
+    @EventListener(ApplicationReadyEvent.class)
     public void fetchDailyGameSchedule() {
-        LocalDate today = LocalDate.now();
-        try {
-            gameScheduleSyncService.syncGameSchedule(today);
-        } catch (GameSyncException e) {
-            log.error("[GameSyncException]- {}", e.getMessage());
-        }
-    }
+        LocalDate today = LocalDate.now(clock);
 
-    @Scheduled(cron = "0 40 2 * * *")
-    public void fetchDailyGameResult() {
-        LocalDate yesterday = LocalDate.now().minusDays(1);
         try {
-            gameResultSyncService.syncGameResult(yesterday);
+            gameScheduleSyncService.fetchGameSchedule(today);
+            adaptivePoller.initializeTodaySchedule(today);
         } catch (GameSyncException e) {
             log.error("[GameSyncException]- {}", e.getMessage());
         }

--- a/backend/src/main/java/com/yagubogu/game/service/GameResultSyncService.java
+++ b/backend/src/main/java/com/yagubogu/game/service/GameResultSyncService.java
@@ -1,51 +1,47 @@
 package com.yagubogu.game.service;
 
 import com.yagubogu.game.domain.Game;
+import com.yagubogu.game.domain.GameState;
 import com.yagubogu.game.domain.ScoreBoard;
 import com.yagubogu.game.dto.KboGameResponse;
 import com.yagubogu.game.dto.KboGameResultResponse;
 import com.yagubogu.game.repository.GameRepository;
 import com.yagubogu.game.service.client.KboGameResultClient;
-import com.yagubogu.game.service.client.KboGameSyncClient;
-import java.time.LocalDate;
-import java.util.List;
+import com.yagubogu.global.exception.NotFoundException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 @Service
 public class GameResultSyncService {
 
-    private final KboGameSyncClient kboGameSyncClient;
     private final KboGameResultClient kboGameResultClient;
     private final GameRepository gameRepository;
 
     @Transactional
-    public void syncGameResult(LocalDate date) {
-        List<KboGameResponse> gameResponses = kboGameSyncClient.fetchGames(date).games();
-
-        for (KboGameResponse response : gameResponses) {
-            gameRepository.findByGameCode(response.gameCode())
-                    .ifPresent(game -> updateGameDetails(game, response));
-        }
-    }
-
-    private void updateGameDetails(Game game, KboGameResponse response) {
+    public void updateGameDetails(String gameCode, KboGameResponse response) {
+        Game game = findGameByGameCode(gameCode);
         game.updateGameState(response.gameState());
 
-        if (game.getGameState().isNotCompleted()) {
-            // TODO: gameState가 LIVE 일 때 로깅
+        if (response.gameState() == GameState.SCHEDULED || response.gameState() == GameState.CANCELED) {
             return;
         }
 
         KboGameResultResponse gameResult = kboGameResultClient.fetchGameResult(game);
+
         ScoreBoard homeScoreBoard = gameResult.homeScoreBoard();
         ScoreBoard awayScoreBoard = gameResult.awayScoreBoard();
         String homePitcher = gameResult.homePitcher();
         String awayPitcher = gameResult.awayPitcher();
-
         game.updateScoreBoard(homeScoreBoard, awayScoreBoard, homePitcher, awayPitcher);
+    }
+
+    private Game findGameByGameCode(final String gameCode) {
+        return gameRepository.findByGameCode(gameCode)
+                .orElseThrow(() -> new NotFoundException("Game not found: " + gameCode));
     }
 }

--- a/backend/src/main/java/com/yagubogu/game/service/GameScheduleSyncService.java
+++ b/backend/src/main/java/com/yagubogu/game/service/GameScheduleSyncService.java
@@ -17,9 +17,11 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 @Service
@@ -42,8 +44,16 @@ public class GameScheduleSyncService {
     private final TeamRepository teamRepository;
     private final StadiumRepository stadiumRepository;
 
+    /**
+     * KBO API에서 일정을 가져와 DB에 저장한다.
+     */
     @Transactional
-    public void syncGameSchedule(final LocalDate date) {
+    public void fetchGameSchedule(final LocalDate date) {
+        if (gameRepository.existsByDate(date)) {
+            log.info("[ScheduleSync] already exists for {}, skip fetching.", date);
+            return;
+        }
+
         KboGamesResponse kboGamesResponse = kboGameSyncClient.fetchGames(date);
         List<Game> games = convertToGames(kboGamesResponse);
 

--- a/backend/src/main/java/com/yagubogu/game/service/client/KboGameResultClient.java
+++ b/backend/src/main/java/com/yagubogu/game/service/client/KboGameResultClient.java
@@ -10,13 +10,12 @@ import com.yagubogu.game.exception.GameSyncException;
 import com.yagubogu.game.exception.KboClientExceptionHandler;
 import java.util.ArrayList;
 import java.util.List;
-import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestClient;
 
-@RequiredArgsConstructor
 @Component
 public class KboGameResultClient {
 
@@ -27,6 +26,16 @@ public class KboGameResultClient {
     private final RestClient kboRestClient;
     private final ObjectMapper objectMapper;
     private final KboClientExceptionHandler kboClientExceptionHandler;
+
+    public KboGameResultClient(
+            @Qualifier("kboRestClient") final RestClient kboRestClient,
+            final ObjectMapper objectMapper,
+            final KboClientExceptionHandler kboClientExceptionHandler
+    ) {
+        this.kboRestClient = kboRestClient;
+        this.objectMapper = objectMapper;
+        this.kboClientExceptionHandler = kboClientExceptionHandler;
+    }
 
     public KboGameResultResponse fetchGameResult(final Game game) {
         MultiValueMap<String, String> params = new LinkedMultiValueMap<>();

--- a/backend/src/main/java/com/yagubogu/game/service/client/KboGameSyncClient.java
+++ b/backend/src/main/java/com/yagubogu/game/service/client/KboGameSyncClient.java
@@ -6,13 +6,12 @@ import com.yagubogu.game.exception.GameSyncException;
 import com.yagubogu.game.exception.KboClientExceptionHandler;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
-import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestClient;
 
-@RequiredArgsConstructor
 @Component
 public class KboGameSyncClient {
 
@@ -22,6 +21,16 @@ public class KboGameSyncClient {
     private final RestClient kboRestClient;
     private final ObjectMapper objectMapper;
     private final KboClientExceptionHandler kboClientExceptionHandler;
+
+    public KboGameSyncClient(
+            @Qualifier("kboRestClient") final RestClient kboRestClient,
+            final ObjectMapper objectMapper,
+            final KboClientExceptionHandler kboClientExceptionHandler
+    ) {
+        this.kboRestClient = kboRestClient;
+        this.objectMapper = objectMapper;
+        this.kboClientExceptionHandler = kboClientExceptionHandler;
+    }
 
     public KboGamesResponse fetchGames(final LocalDate date) {
         MultiValueMap<String, String> param = new LinkedMultiValueMap<>();

--- a/backend/src/main/java/com/yagubogu/global/config/ScheduleConfig.java
+++ b/backend/src/main/java/com/yagubogu/global/config/ScheduleConfig.java
@@ -1,9 +1,21 @@
 package com.yagubogu.global.config;
 
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 
 @EnableScheduling
 @Configuration
 public class ScheduleConfig {
+
+    @Bean
+    public TaskScheduler taskScheduler() {
+        ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
+        scheduler.setPoolSize(4);
+        scheduler.setThreadNamePrefix("scheduler-");
+        scheduler.initialize();
+        return scheduler;
+    }
 }

--- a/backend/src/main/java/com/yagubogu/global/config/TimeConfig.java
+++ b/backend/src/main/java/com/yagubogu/global/config/TimeConfig.java
@@ -1,0 +1,15 @@
+package com.yagubogu.global.config;
+
+import java.time.Clock;
+import java.time.ZoneId;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class TimeConfig {
+
+    @Bean
+    public Clock clock() {
+        return Clock.system(ZoneId.of("Asia/Seoul"));
+    }
+}

--- a/backend/src/test/java/com/yagubogu/game/domain/AdaptivePollerTest.java
+++ b/backend/src/test/java/com/yagubogu/game/domain/AdaptivePollerTest.java
@@ -206,7 +206,7 @@ class AdaptivePollerTest {
         verify(gameResultSyncService, times(1)).updateGameDetails(eq("G2"), any(KboGameResponse.class));
     }
 
-    @DisplayName("SCHEDULED 보호 주기: 킥오프 전/지연 상황에서도 최소 10~15분 주기가 유지된다(행동 검증)")
+    @DisplayName("SCHEDULED 보호 주기: 킥오프 전/지연 상황에서도 최소 10~15분 주기가 유지된다")
     @Test
     void scheduled_hasProtectionWindow_behaviorally() {
         LocalDate today = LocalDate.of(2025, 7, 21);

--- a/backend/src/test/java/com/yagubogu/game/domain/AdaptivePollerTest.java
+++ b/backend/src/test/java/com/yagubogu/game/domain/AdaptivePollerTest.java
@@ -1,0 +1,281 @@
+package com.yagubogu.game.domain;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import com.yagubogu.auth.config.AuthTestConfig;
+import com.yagubogu.game.dto.KboGameResponse;
+import com.yagubogu.game.dto.KboGamesResponse;
+import com.yagubogu.game.exception.GameSyncException;
+import com.yagubogu.game.repository.GameRepository;
+import com.yagubogu.game.service.GameResultSyncService;
+import com.yagubogu.game.service.client.KboGameSyncClient;
+import com.yagubogu.stadium.domain.Stadium;
+import com.yagubogu.stadium.repository.StadiumRepository;
+import com.yagubogu.support.game.GameFactory;
+import com.yagubogu.team.domain.Team;
+import com.yagubogu.team.repository.TeamRepository;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+@Import(AuthTestConfig.class)
+@DataJpaTest
+class AdaptivePollerTest {
+
+    @Autowired
+    private GameRepository gameRepository;
+    @Autowired
+    private TeamRepository teamRepository;
+    @Autowired
+    private StadiumRepository stadiumRepository;
+    @Autowired
+    private GameFactory gameFactory;
+
+    @Mock
+    private KboGameSyncClient kboGameSyncClient;
+    @Mock
+    private GameResultSyncService gameResultSyncService;
+
+    private MutableClock clock;
+    private AdaptivePoller poller;
+
+    /** 테스트용 가변 Clock */
+    static class MutableClock extends Clock {
+
+        private Instant instant;
+        private final ZoneId zone;
+
+        MutableClock(Instant start, ZoneId zone) {
+            this.instant = start;
+            this.zone = zone;
+        }
+
+        public void setInstant(final Instant instant) {
+            this.instant = instant;
+        }
+
+        public void plusMinutes(long m) {
+            instant = instant.plusSeconds(m * 60);
+        }
+
+        public void plusHours(long h) {
+            instant = instant.plusSeconds(h * 3600);
+        }
+
+        @Override
+        public ZoneId getZone() {
+            return zone;
+        }
+
+        @Override
+        public Clock withZone(ZoneId zone) {
+            return new MutableClock(instant, zone);
+        }
+
+        @Override
+        public Instant instant() {
+            return instant;
+        }
+    }
+
+    @BeforeEach
+    void setUp() {
+        clock = new MutableClock(
+                LocalDate.of(2025, 7, 21).atTime(0, 0).atZone(ZoneId.of("Asia/Seoul")).toInstant(),
+                ZoneId.of("Asia/Seoul")
+        );
+        poller = new AdaptivePoller(gameRepository, kboGameSyncClient, gameResultSyncService, clock);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    @DisplayName("초기화: FINALIZED 경기는 이후 폴링에서 호출되지 않는다")
+    @Test
+    void initialize_skipsFinalizedGame() {
+        LocalDate today = LocalDate.of(2025, 7, 21);
+        // COMPLETED(스킵 대상) + LIVE(대상)
+        saveGame(today, "OB", "HT", "잠실구장", "FINAL", GameState.COMPLETED, LocalTime.of(18, 30));
+        Game live = saveGame(today, "SS", "HH", "사직구장", "LIVE1", GameState.LIVE, LocalTime.of(18, 30));
+
+        poller.initializeTodaySchedule(today);
+
+        // due가 도달하도록 시간 전진 (킥오프 이후 + 여유)
+        clock.plusHours(19);
+
+        // fetch에 LIVE1만 내려오게 구성
+        KboGameResponse row = new KboGameResponse("LIVE1", today, 0, LocalTime.of(18, 30),
+                "잠실", "HH", "SS", GameState.LIVE);
+        given(kboGameSyncClient.fetchGames(today))
+                .willReturn(new KboGamesResponse(List.of(row), "100", "success"));
+
+        // 실행
+        poller.pollGameWhenReachDue();
+
+        // then: FINAL은 호출되지 않고, LIVE1만 호출
+        verify(gameResultSyncService, times(1)).updateGameDetails(eq("LIVE1"), any(KboGameResponse.class));
+        verifyNoMoreInteractions(gameResultSyncService);
+    }
+
+    @DisplayName("전역 백오프: SCHEDULED(18:30) - 킥오프 전엔 대기, 이후 실패→백오프→회복한다")
+    @Test
+    void globalBackoff_withScheduledGameAt1830() {
+        // 0) 고정 시각: 2025-07-21 18:00 (Asia/Seoul)
+        LocalDate today = LocalDate.of(2025, 7, 21);
+        clock.setInstant(today.atTime(18, 0).atZone(ZoneId.of("Asia/Seoul")).toInstant());
+
+        // 1) 경기 저장: SCHEDULED 18:30
+        saveGame(today, "OB", "HT", "잠실구장", "G1", GameState.SCHEDULED, LocalTime.of(18, 30));
+        poller.initializeTodaySchedule(today);
+
+        // 2) 아직 킥오프 전(18:00 → 18:30)이라 첫 tick은 아무 일도 안 됨
+        poller.pollGameWhenReachDue();
+        verify(kboGameSyncClient, never()).fetchGames(eq(today));
+
+        // 3) 시계를 18:31로 전진 → due(=18:30)를 넘김 → 첫 fetch 시도
+        clock.plusMinutes(31); // 18:31
+        given(kboGameSyncClient.fetchGames(eq(today)))
+                .willThrow(new GameSyncException("boom1"))  // 첫 tick 실패 → 전역 백오프 시작
+                .willReturn(new KboGamesResponse(
+                        List.of(new KboGameResponse("G1", today, 0, LocalTime.of(18, 30), "잠실", "HT", "OB", GameState.SCHEDULED)),
+                        "100", "success"));
+
+        // 실패 tick → 전역 백오프 진입
+        poller.pollGameWhenReachDue();
+        verify(kboGameSyncClient, times(1)).fetchGames(eq(today));
+        verify(gameResultSyncService, never()).updateGameDetails(anyString(), any());
+
+        // 4) 백오프 창 내 재시도 → fetchGames 호출 자체가 없어야 함
+        poller.pollGameWhenReachDue();
+        verify(kboGameSyncClient, times(1)).fetchGames(eq(today));
+
+        // 5) 백오프 창 경과 후 재시도(예: 2분 전진) → fetch + update 허용
+        clock.plusMinutes(2);
+        poller.pollGameWhenReachDue();
+        verify(kboGameSyncClient, times(2)).fetchGames(eq(today));
+        verify(gameResultSyncService, times(1)).updateGameDetails(eq("G1"), any(KboGameResponse.class));
+    }
+
+    @DisplayName("경기별 백오프: row 없음 → 백오프 창 전에는 호출 안 되고, 이후에는 호출한다")
+    @Test
+    void perGameBackoff_blocksPerGame_untilWindowPasses() {
+        LocalDate today = LocalDate.of(2025, 7, 21);
+        saveGame(today, "OB", "HT", "잠실구장", "G2", GameState.LIVE, LocalTime.of(18, 30));
+        poller.initializeTodaySchedule(today);
+
+        // due 도달
+        clock.plusHours(19);
+
+        // 첫 fetch: 다른 경기만 내려옴(=G2는 row 없음 → per-game backoff)
+        KboGameResponse other = new KboGameResponse("OTHER", today, 0, LocalTime.of(18, 30),
+                "잠실", "HT", "OB", GameState.LIVE);
+        given(kboGameSyncClient.fetchGames(today))
+                .willReturn(new KboGamesResponse(List.of(other), "100", "success"));
+
+        poller.pollGameWhenReachDue();
+        verify(gameResultSyncService, never()).updateGameDetails(eq("G2"), any());
+
+        // 여전히 백오프 창: 곧바로 G2 row를 제공해도 호출되면 안 됨
+        KboGameResponse row = new KboGameResponse("G2", today, 0, LocalTime.of(18, 30),
+                "잠실", "HT", "OB", GameState.LIVE);
+        given(kboGameSyncClient.fetchGames(today))
+                .willReturn(new KboGamesResponse(List.of(row), "100", "success"));
+
+        // 백오프 1분 미만 가정 → 즉시 재시도해도 막혀야 함
+        poller.pollGameWhenReachDue();
+        verify(gameResultSyncService, never()).updateGameDetails(eq("G2"), any());
+
+        // 충분히 전진(>= 1분) → 호출 허용
+        clock.plusMinutes(2);
+        poller.pollGameWhenReachDue();
+        verify(gameResultSyncService, times(1)).updateGameDetails(eq("G2"), any(KboGameResponse.class));
+    }
+
+    @DisplayName("SCHEDULED 보호 주기: 킥오프 전/지연 상황에서도 최소 10~15분 주기가 유지된다(행동 검증)")
+    @Test
+    void scheduled_hasProtectionWindow_behaviorally() {
+        LocalDate today = LocalDate.of(2025, 7, 21);
+        String code = "S1";
+        saveGame(today, "OB", "HT", "잠실구장", code, GameState.SCHEDULED, LocalTime.of(18, 30));
+
+        poller.initializeTodaySchedule(today);
+
+        // 킥오프 전(오전)에는 호출이 안 나와야 함: fetch에 row 제공해도 due 전엔 호출 X
+        KboGameResponse row = new KboGameResponse(code, today, 0, LocalTime.of(18, 30),
+                "잠실", "HT", "OB", GameState.SCHEDULED);
+        given(kboGameSyncClient.fetchGames(today))
+                .willReturn(new KboGamesResponse(List.of(row), "100", "success"));
+
+        // 오전 00:00 → 즉시 poll: due(18:30) 전이라 호출 X
+        poller.pollGameWhenReachDue();
+        verify(gameResultSyncService, never()).updateGameDetails(eq(code), any());
+
+        // 킥오프+10분 이후로 이동 → 호출 허용
+        clock.plusHours(18);
+        clock.plusMinutes(40); // 18:40
+        poller.pollGameWhenReachDue();
+        verify(gameResultSyncService, times(1)).updateGameDetails(eq(code), any());
+    }
+
+    @DisplayName("LIVE 주기: due 이전엔 호출 없고, due 이후엔 1회 호출된다")
+    @Test
+    void live_interval_respected_behaviorally() {
+        LocalDate today = LocalDate.of(2025, 7, 21);
+        String code = "L1";
+        saveGame(today, "OB", "HT", "잠실구장", code, GameState.LIVE, LocalTime.of(18, 30));
+
+        poller.initializeTodaySchedule(today);
+
+        // 킥오프 전에는 호출 X
+        KboGameResponse row = new KboGameResponse(code, today, 0, LocalTime.of(18, 30),
+                "잠실", "HT", "OB", GameState.LIVE);
+        given(kboGameSyncClient.fetchGames(today))
+                .willReturn(new KboGamesResponse(List.of(row), "100", "success"));
+
+        poller.pollGameWhenReachDue();
+        verify(gameResultSyncService, never()).updateGameDetails(eq(code), any());
+
+        // 킥오프 이후로 이동(18:31) → 호출 1회
+        clock.plusHours(18);
+        clock.plusMinutes(31);
+        poller.pollGameWhenReachDue();
+        verify(gameResultSyncService, times(1)).updateGameDetails(eq(code), any());
+    }
+
+    private Team team(String code) {
+        return teamRepository.findByTeamCode(code).orElseThrow();
+    }
+
+    private Stadium stadium(String shortName) {
+        return stadiumRepository.findByShortName(shortName).orElseThrow();
+    }
+
+    private Game saveGame(LocalDate date, String home, String away, String stadiumShort, String code, GameState state,
+                          LocalTime startAt) {
+        return gameFactory.save(b -> b
+                .homeTeam(team(home))
+                .awayTeam(team(away))
+                .stadium(stadium(stadiumShort))
+                .date(date)
+                .startAt(startAt)
+                .gameCode(code)
+                .gameState(state)
+        );
+    }
+}
+


### PR DESCRIPTION
## 📌 관련 이슈
- close #485 

## ✨ 변경 내용
- 경기 결과를 사용자에게 지연 없이 빠르게 제공하기 위해, 실시간 조회를 지원하는 스케줄링을 구현했습니다.
- 동시에 시스템 자원을 효율적으로 활용할 수 있도록, 경기 상태(`SCHEDULED`, `LIVE` 등)에 따라 polling 주기를 동적으로 조절하여 안정성과 사용자 경험을 모두 확보했습니다.

<img width="418" height="205" alt="image" src="https://github.com/user-attachments/assets/c4142d72-2f28-4409-be6f-2779971379f0" />


## 🎸 기타 참고 사항
- 스크린샷, 참고 링크, 추가 설명 등 (없으면 생략 가능)