### PR TITLE
feat: 닉네임 중복 검증, 회원가입시 UUID 닉네임으로 가입, 승리요정 랭킹 탈퇴한 회원 조회 불가

### DIFF
--- a/backend/src/main/java/com/yagubogu/auth/dto/AuthResponse.java
+++ b/backend/src/main/java/com/yagubogu/auth/dto/AuthResponse.java
@@ -1,10 +1,10 @@
 package com.yagubogu.auth.dto;
 
-import com.yagubogu.member.domain.Member;
-
 public interface AuthResponse {
 
-    Member toMember();
-
     String oauthId();
+
+    String email();
+
+    String picture();
 }

--- a/backend/src/main/java/com/yagubogu/auth/dto/GoogleAuthResponse.java
+++ b/backend/src/main/java/com/yagubogu/auth/dto/GoogleAuthResponse.java
@@ -2,9 +2,6 @@ package com.yagubogu.auth.dto;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.yagubogu.member.domain.Member;
-import com.yagubogu.member.domain.OAuthProvider;
-import com.yagubogu.member.domain.Role;
 
 public record GoogleAuthResponse(
         String iss,
@@ -54,9 +51,9 @@ public record GoogleAuthResponse(
                 locale
         );
     }
-
-    @Override
-    public Member toMember() {
-        return new Member(null, name, email, OAuthProvider.GOOGLE, oauthId, Role.USER, picture);
-    }
+//
+//    @Override
+//    public Member toMember() {
+//        return new Member(null, name, email, OAuthProvider.GOOGLE, oauthId, Role.USER, picture);
+//    }
 }

--- a/backend/src/main/java/com/yagubogu/auth/dto/GoogleAuthResponse.java
+++ b/backend/src/main/java/com/yagubogu/auth/dto/GoogleAuthResponse.java
@@ -51,9 +51,4 @@ public record GoogleAuthResponse(
                 locale
         );
     }
-//
-//    @Override
-//    public Member toMember() {
-//        return new Member(null, name, email, OAuthProvider.GOOGLE, oauthId, Role.USER, picture);
-//    }
 }

--- a/backend/src/main/java/com/yagubogu/auth/dto/LoginResponse.java
+++ b/backend/src/main/java/com/yagubogu/auth/dto/LoginResponse.java
@@ -14,7 +14,7 @@ public record LoginResponse(
             String profileImageUrl
     ) {
         public static MemberResponse from(final Member member) {
-            return new MemberResponse(member.getId(), member.getNickname(), member.getImageUrl());
+            return new MemberResponse(member.getId(), member.getNickname().getValue(), member.getImageUrl());
         }
     }
 }

--- a/backend/src/main/java/com/yagubogu/auth/gateway/LocalAuthGateway.java
+++ b/backend/src/main/java/com/yagubogu/auth/gateway/LocalAuthGateway.java
@@ -4,6 +4,7 @@ import com.yagubogu.auth.config.GoogleAuthProperties;
 import com.yagubogu.auth.dto.AuthResponse;
 import com.yagubogu.auth.dto.GoogleAuthResponse;
 import com.yagubogu.auth.dto.LoginRequest;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
@@ -26,7 +27,7 @@ public class LocalAuthGateway implements AuthGateway {
                 9999999999L,
                 "local@example.com",
                 true,
-                "로컬유저",
+                UUID.randomUUID().toString(),
                 "https://example.com/profile.png",
                 "이름",
                 "성",

--- a/backend/src/main/java/com/yagubogu/auth/service/AuthService.java
+++ b/backend/src/main/java/com/yagubogu/auth/service/AuthService.java
@@ -15,6 +15,7 @@ import com.yagubogu.auth.support.AuthTokenProvider;
 import com.yagubogu.auth.support.AuthValidator;
 import com.yagubogu.global.exception.UnAuthorizedException;
 import com.yagubogu.member.domain.Member;
+import com.yagubogu.member.domain.Nickname;
 import com.yagubogu.member.domain.OAuthProvider;
 import com.yagubogu.member.domain.Role;
 import com.yagubogu.member.repository.MemberRepository;
@@ -56,10 +57,10 @@ public class AuthService {
     }
 
     private Member createNewMember(final AuthResponse response) {
-        String randomNickname = UUID.randomUUID().toString();
+        String randomNickname = UUID.randomUUID().toString().substring(0, 15);
         Member newMember = new Member(
                 null,
-                randomNickname,
+                new Nickname(randomNickname),
                 response.email(),
                 OAuthProvider.GOOGLE,
                 response.oauthId(),

--- a/backend/src/main/java/com/yagubogu/auth/service/AuthService.java
+++ b/backend/src/main/java/com/yagubogu/auth/service/AuthService.java
@@ -47,7 +47,7 @@ public class AuthService {
 
         Optional<Member> memberOptional = memberRepository.findByOauthIdAndDeletedAtIsNull(response.oauthId());
         boolean isNew = memberOptional.isEmpty();
-        Member member = memberOptional.orElseGet(() -> createNewMember(response));
+        Member member = memberOptional.orElseGet(() -> saveMember(response));
 
         MemberClaims memberClaims = MemberClaims.from(member);
         String accessToken = authTokenProvider.createAccessToken(memberClaims);
@@ -56,7 +56,7 @@ public class AuthService {
         return new LoginResponse(accessToken, refreshToken, isNew, MemberResponse.from(member));
     }
 
-    private Member createNewMember(final AuthResponse response) {
+    private Member saveMember(final AuthResponse response) {
         String randomNickname = UUID.randomUUID().toString().substring(0, 15);
         Member newMember = new Member(
                 null,

--- a/backend/src/main/java/com/yagubogu/auth/service/AuthService.java
+++ b/backend/src/main/java/com/yagubogu/auth/service/AuthService.java
@@ -57,7 +57,7 @@ public class AuthService {
     }
 
     private Member saveMember(final AuthResponse response) {
-        String randomNickname = UUID.randomUUID().toString().substring(0, 15);
+        String randomNickname = UUID.randomUUID().toString().substring(0, 12);
         Member newMember = new Member(
                 null,
                 new Nickname(randomNickname),

--- a/backend/src/main/java/com/yagubogu/checkin/dto/VictoryFairyRankingEntryResponse.java
+++ b/backend/src/main/java/com/yagubogu/checkin/dto/VictoryFairyRankingEntryResponse.java
@@ -14,7 +14,7 @@ public record VictoryFairyRankingEntryResponse(
     public static VictoryFairyRankingEntryResponse generateEmptyRankingFor(final Member member) {
         return new VictoryFairyRankingEntryResponse(
                 member.getId(),
-                member.getNickname(),
+                member.getNickname().getValue(),
                 member.getImageUrl(),
                 member.getTeam().getShortName(),
                 0L,

--- a/backend/src/main/java/com/yagubogu/checkin/repository/CheckInRepository.java
+++ b/backend/src/main/java/com/yagubogu/checkin/repository/CheckInRepository.java
@@ -152,6 +152,7 @@ public interface CheckInRepository extends JpaRepository<CheckIn, Long> {
             )
             from CheckIn ci
             join ci.game g
+            where ci.member.deletedAt IS NULL
             group by
               ci.member.id
             """)

--- a/backend/src/main/java/com/yagubogu/checkin/repository/CheckInRepository.java
+++ b/backend/src/main/java/com/yagubogu/checkin/repository/CheckInRepository.java
@@ -129,7 +129,7 @@ public interface CheckInRepository extends JpaRepository<CheckIn, Long> {
     @Query("""
             select new com.yagubogu.checkin.dto.VictoryFairyRankingEntryResponse(
               ci.member.id,
-              ci.member.nickname,
+              ci.member.nickname.value,
               ci.member.imageUrl,
               ci.member.team.shortName,
               COUNT(CASE WHEN g.homeTeam.id = ci.team.id OR g.awayTeam.id = ci.team.id THEN 1 END),

--- a/backend/src/main/java/com/yagubogu/global/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/yagubogu/global/GlobalExceptionHandler.java
@@ -2,6 +2,7 @@ package com.yagubogu.global;
 
 import com.yagubogu.global.exception.BadGatewayException;
 import com.yagubogu.global.exception.BadRequestException;
+import com.yagubogu.global.exception.ConflictException;
 import com.yagubogu.global.exception.ForbiddenException;
 import com.yagubogu.global.exception.NotFoundException;
 import com.yagubogu.global.exception.UnAuthorizedException;
@@ -58,6 +59,17 @@ public class GlobalExceptionHandler {
     @ResponseStatus(HttpStatus.NOT_FOUND)
     public ExceptionResponse handleNotFoundException(final NotFoundException e) {
         log.info("[NotFoundException]- {}", e.getMessage());
+
+        return new ExceptionResponse(e.getMessage());
+    }
+
+    /**
+     * 409 Conflict
+     */
+    @ExceptionHandler(value = ConflictException.class)
+    @ResponseStatus(HttpStatus.CONFLICT)
+    public ExceptionResponse handleConflictException(final ConflictException e) {
+        log.info("[ConflictException]- {}", e.getMessage());
 
         return new ExceptionResponse(e.getMessage());
     }

--- a/backend/src/main/java/com/yagubogu/global/exception/ConflictException.java
+++ b/backend/src/main/java/com/yagubogu/global/exception/ConflictException.java
@@ -1,0 +1,7 @@
+package com.yagubogu.global.exception;
+
+public class ConflictException extends RuntimeException {
+    public ConflictException(final String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/yagubogu/global/exception/ConflictException.java
+++ b/backend/src/main/java/com/yagubogu/global/exception/ConflictException.java
@@ -1,6 +1,7 @@
 package com.yagubogu.global.exception;
 
 public class ConflictException extends RuntimeException {
+
     public ConflictException(final String message) {
         super(message);
     }

--- a/backend/src/main/java/com/yagubogu/member/domain/Member.java
+++ b/backend/src/main/java/com/yagubogu/member/domain/Member.java
@@ -3,6 +3,7 @@ package com.yagubogu.member.domain;
 import com.yagubogu.global.domain.BaseEntity;
 import com.yagubogu.team.domain.Team;
 import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -34,8 +35,8 @@ public class Member extends BaseEntity {
     @JoinColumn(name = "team_id", nullable = true)
     private Team team;
 
-    @Column(name = "nickname", unique = true, nullable = false)
-    private String nickname;
+    @Embedded
+    private Nickname nickname;
 
     @Column(name = "email", nullable = false)
     private String email;
@@ -54,7 +55,7 @@ public class Member extends BaseEntity {
     @Column(name = "image_url")
     private String imageUrl;
 
-    public Member(final Team team, final String nickname, final String email, final OAuthProvider provider,
+    public Member(final Team team, final Nickname nickname, final String email, final OAuthProvider provider,
                   final String oauthId, final Role role, final String imageUrl) {
         this.team = team;
         this.nickname = nickname;
@@ -77,7 +78,7 @@ public class Member extends BaseEntity {
         this.team = team;
     }
 
-    public void updateNickname(final String nickname) {
+    public void updateNickname(final Nickname nickname) {
         this.nickname = nickname;
     }
 }

--- a/backend/src/main/java/com/yagubogu/member/domain/Member.java
+++ b/backend/src/main/java/com/yagubogu/member/domain/Member.java
@@ -34,7 +34,7 @@ public class Member extends BaseEntity {
     @JoinColumn(name = "team_id", nullable = true)
     private Team team;
 
-    @Column(name = "nickname", nullable = false)
+    @Column(name = "nickname", unique = true, nullable = false)
     private String nickname;
 
     @Column(name = "email", nullable = false)

--- a/backend/src/main/java/com/yagubogu/member/domain/Nickname.java
+++ b/backend/src/main/java/com/yagubogu/member/domain/Nickname.java
@@ -12,7 +12,7 @@ import lombok.NoArgsConstructor;
 @Embeddable
 public class Nickname {
 
-    private static final int MAX_LENGTH = 15;
+    private static final int MAX_LENGTH = 12;
 
     @Column(name = "nickname", unique = true, nullable = false, length = MAX_LENGTH)
     private String value;
@@ -26,6 +26,7 @@ public class Nickname {
         if (value == null || value.isBlank()) {
             throw new UnprocessableEntityException("Nickname must not be empty.");
         }
+        System.out.println(value);
         if (value.length() > MAX_LENGTH) {
             throw new UnprocessableEntityException("Nickname must be " + MAX_LENGTH + " characters or fewer.");
         }

--- a/backend/src/main/java/com/yagubogu/member/domain/Nickname.java
+++ b/backend/src/main/java/com/yagubogu/member/domain/Nickname.java
@@ -1,0 +1,38 @@
+package com.yagubogu.member.domain;
+
+import com.yagubogu.global.exception.UnprocessableEntityException;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Embeddable
+public class Nickname {
+
+    private static final int MAX_LENGTH = 15;
+
+    @Column(name = "nickname", unique = true, nullable = false, length = MAX_LENGTH)
+    private String value;
+
+    public Nickname(final String value) {
+        validate(value);
+        this.value = value;
+    }
+
+    private void validate(final String value) {
+        if (value == null || value.isBlank()) {
+            throw new UnprocessableEntityException("Nickname must not be empty.");
+        }
+        if (value.length() > MAX_LENGTH) {
+            throw new UnprocessableEntityException("Nickname must be " + MAX_LENGTH + " characters or fewer.");
+        }
+    }
+
+    @Override
+    public String toString() {
+        return value;
+    }
+}

--- a/backend/src/main/java/com/yagubogu/member/dto/MemberInfoResponse.java
+++ b/backend/src/main/java/com/yagubogu/member/dto/MemberInfoResponse.java
@@ -15,7 +15,7 @@ public record MemberInfoResponse(
         Team team = member.getTeam();
         if (team == null) {
             return new MemberInfoResponse(
-                    member.getNickname(),
+                    member.getNickname().getValue(),
                     member.getCreatedAt().toLocalDate(),
                     null,
                     member.getImageUrl()
@@ -23,7 +23,7 @@ public record MemberInfoResponse(
         }
 
         return new MemberInfoResponse(
-                member.getNickname(),
+                member.getNickname().getValue(),
                 member.getCreatedAt().toLocalDate(),
                 member.getTeam().getShortName(),
                 member.getImageUrl()

--- a/backend/src/main/java/com/yagubogu/member/dto/MemberNicknameResponse.java
+++ b/backend/src/main/java/com/yagubogu/member/dto/MemberNicknameResponse.java
@@ -1,6 +1,12 @@
 package com.yagubogu.member.dto;
 
+import com.yagubogu.member.domain.Nickname;
+
 public record MemberNicknameResponse(
         String nickname
 ) {
+
+    public static MemberNicknameResponse from(final Nickname nickname) {
+        return new MemberNicknameResponse(nickname.getValue());
+    }
 }

--- a/backend/src/main/java/com/yagubogu/member/repository/MemberRepository.java
+++ b/backend/src/main/java/com/yagubogu/member/repository/MemberRepository.java
@@ -1,6 +1,7 @@
 package com.yagubogu.member.repository;
 
 import com.yagubogu.member.domain.Member;
+import com.yagubogu.member.domain.Nickname;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -14,5 +15,5 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     @Query("select m.team.id from Member m where m.id = :memberId and m.deletedAt is null")
     Optional<Long> findTeamIdById(Long memberId);
 
-    boolean existsByNickname(String nickname);
+    boolean existsByNickname(Nickname nickname);
 }

--- a/backend/src/main/java/com/yagubogu/member/repository/MemberRepository.java
+++ b/backend/src/main/java/com/yagubogu/member/repository/MemberRepository.java
@@ -13,4 +13,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     @Query("select m.team.id from Member m where m.id = :memberId and m.deletedAt is null")
     Optional<Long> findTeamIdById(Long memberId);
+
+    boolean existsByNickname(String nickname);
 }

--- a/backend/src/main/java/com/yagubogu/member/service/MemberService.java
+++ b/backend/src/main/java/com/yagubogu/member/service/MemberService.java
@@ -3,6 +3,7 @@ package com.yagubogu.member.service;
 import com.yagubogu.global.exception.ConflictException;
 import com.yagubogu.global.exception.NotFoundException;
 import com.yagubogu.member.domain.Member;
+import com.yagubogu.member.domain.Nickname;
 import com.yagubogu.member.dto.MemberFavoriteRequest;
 import com.yagubogu.member.dto.MemberFavoriteResponse;
 import com.yagubogu.member.dto.MemberInfoResponse;
@@ -25,13 +26,13 @@ public class MemberService {
 
     @Transactional
     public MemberNicknameResponse patchNickname(final long memberId, final MemberNicknameRequest request) {
-        String nickname = request.nickname();
+        Nickname nickname = new Nickname(request.nickname());
         validateDuplicateNickname(nickname);
-        
-        Member member = getMember(memberId);
-        member.updateNickname(request.nickname());
 
-        return new MemberNicknameResponse(member.getNickname());
+        Member member = getMember(memberId);
+        member.updateNickname(nickname);
+
+        return MemberNicknameResponse.from(member.getNickname());
     }
 
     @Transactional
@@ -43,8 +44,9 @@ public class MemberService {
 
     public MemberNicknameResponse findNickname(final long memberId) {
         Member member = getMember(memberId);
+        Nickname nickname = member.getNickname();
 
-        return new MemberNicknameResponse(member.getNickname());
+        return MemberNicknameResponse.from(nickname);
     }
 
     public MemberFavoriteResponse findFavorite(final long memberId) {
@@ -87,7 +89,7 @@ public class MemberService {
                 .orElseThrow(() -> new NotFoundException("Team is not found"));
     }
 
-    private void validateDuplicateNickname(final String nickname) {
+    private void validateDuplicateNickname(final Nickname nickname) {
         if (memberRepository.existsByNickname(nickname)) {
             throw new ConflictException("Nickname already exists: " + nickname);
         }

--- a/backend/src/main/java/com/yagubogu/member/service/MemberService.java
+++ b/backend/src/main/java/com/yagubogu/member/service/MemberService.java
@@ -1,5 +1,6 @@
 package com.yagubogu.member.service;
 
+import com.yagubogu.global.exception.ConflictException;
 import com.yagubogu.global.exception.NotFoundException;
 import com.yagubogu.member.domain.Member;
 import com.yagubogu.member.dto.MemberFavoriteRequest;
@@ -24,6 +25,9 @@ public class MemberService {
 
     @Transactional
     public MemberNicknameResponse patchNickname(final long memberId, final MemberNicknameRequest request) {
+        String nickname = request.nickname();
+        validateDuplicateNickname(nickname);
+        
         Member member = getMember(memberId);
         member.updateNickname(request.nickname());
 
@@ -81,5 +85,11 @@ public class MemberService {
     private Team getTeamByCode(final String teamCode) {
         return teamRepository.findByTeamCode(teamCode)
                 .orElseThrow(() -> new NotFoundException("Team is not found"));
+    }
+
+    private void validateDuplicateNickname(final String nickname) {
+        if (memberRepository.existsByNickname(nickname)) {
+            throw new ConflictException("Nickname already exists: " + nickname);
+        }
     }
 }

--- a/backend/src/main/java/com/yagubogu/talk/dto/TalkResponse.java
+++ b/backend/src/main/java/com/yagubogu/talk/dto/TalkResponse.java
@@ -31,7 +31,7 @@ public record TalkResponse(
         return new TalkResponse(
                 talk.getId(),
                 talk.getMember().getId(),
-                talk.getMember().getNickname(),
+                talk.getMember().getNickname().getValue(),
                 talk.getMember().getTeam().getShortName(),
                 talk.getMember().getImageUrl(),
                 talk.getContent(),

--- a/backend/src/test/java/com/yagubogu/auth/AuthE2eTest.java
+++ b/backend/src/test/java/com/yagubogu/auth/AuthE2eTest.java
@@ -1,7 +1,5 @@
 package com.yagubogu.auth;
 
-import static org.assertj.core.api.SoftAssertions.assertSoftly;
-
 import com.yagubogu.auth.config.AuthTestConfig;
 import com.yagubogu.auth.domain.RefreshToken;
 import com.yagubogu.auth.dto.LoginRequest;
@@ -56,9 +54,9 @@ public class AuthE2eTest extends E2eTestBase {
         RestAssured.port = port;
     }
 
-    @DisplayName("로그인한다")
+    @DisplayName("회원가입을 수행한다")
     @Test
-    void login() {
+    void login_register() {
         // given & when
         LoginResponse actual = RestAssured.given().log().all()
                 .contentType(ContentType.JSON)
@@ -74,7 +72,40 @@ public class AuthE2eTest extends E2eTestBase {
             softAssertions.assertThat(actual.accessToken()).isNotNull();
             softAssertions.assertThat(actual.refreshToken()).isNotNull();
             softAssertions.assertThat(actual.isNew()).isTrue();
-            softAssertions.assertThat(actual.member().nickname()).isEqualTo("test-user");
+            softAssertions.assertThat(actual.member().nickname()).matches("^[0-9a-fA-F\\-]{36}$");
+        });
+    }
+
+    @DisplayName("로그인을 수행한다")
+    @Test
+    void login() {
+        // given
+        LoginResponse registerResponse = RestAssured.given().log().all()
+                .contentType(ContentType.JSON)
+                .body(new LoginRequest(ID_TOKEN))
+                .when().post("/api/auth/login")
+                .then().log().all()
+                .statusCode(200)
+                .extract()
+                .as(LoginResponse.class);
+        String expectedStringName = registerResponse.member().nickname();
+
+        // when
+        LoginResponse actual = RestAssured.given().log().all()
+                .contentType(ContentType.JSON)
+                .body(new LoginRequest(ID_TOKEN))
+                .when().post("/api/auth/login")
+                .then().log().all()
+                .statusCode(200)
+                .extract()
+                .as(LoginResponse.class);
+
+        // then
+        assertSoftly(softAssertions -> {
+            softAssertions.assertThat(actual.accessToken()).isNotNull();
+            softAssertions.assertThat(actual.refreshToken()).isNotNull();
+            softAssertions.assertThat(actual.isNew()).isFalse();
+            softAssertions.assertThat(actual.member().nickname()).isEqualTo(expectedStringName);
         });
     }
 

--- a/backend/src/test/java/com/yagubogu/auth/AuthE2eTest.java
+++ b/backend/src/test/java/com/yagubogu/auth/AuthE2eTest.java
@@ -72,7 +72,6 @@ public class AuthE2eTest extends E2eTestBase {
             softAssertions.assertThat(actual.accessToken()).isNotNull();
             softAssertions.assertThat(actual.refreshToken()).isNotNull();
             softAssertions.assertThat(actual.isNew()).isTrue();
-            softAssertions.assertThat(actual.member().nickname()).matches("^[0-9a-fA-F\\-]{36}$");
         });
     }
 

--- a/backend/src/test/java/com/yagubogu/auth/gateway/FakeAuthGateway.java
+++ b/backend/src/test/java/com/yagubogu/auth/gateway/FakeAuthGateway.java
@@ -4,6 +4,7 @@ import com.yagubogu.auth.dto.AuthResponse;
 import com.yagubogu.auth.dto.GoogleAuthResponse;
 import com.yagubogu.auth.dto.LoginRequest;
 import java.time.Instant;
+import java.util.UUID;
 
 public class FakeAuthGateway implements AuthGateway {
 
@@ -17,7 +18,7 @@ public class FakeAuthGateway implements AuthGateway {
                 111L, Instant.now().plusSeconds(3000).getEpochSecond(),
                 "email",
                 true,
-                "test-user",
+                UUID.randomUUID().toString(),
                 "picture",
                 "givenName",
                 "familyName",

--- a/backend/src/test/java/com/yagubogu/auth/service/AuthServiceTest.java
+++ b/backend/src/test/java/com/yagubogu/auth/service/AuthServiceTest.java
@@ -1,8 +1,5 @@
 package com.yagubogu.auth.service;
 
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.SoftAssertions.assertSoftly;
-
 import com.yagubogu.auth.config.AuthTestConfig;
 import com.yagubogu.auth.config.AuthTokenProperties;
 import com.yagubogu.auth.domain.RefreshToken;
@@ -30,6 +27,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 @DataJpaTest
 @ActiveProfiles("integration")
@@ -68,12 +68,11 @@ class AuthServiceTest {
                 List.of(googleAuthValidator), refreshTokenRepository, authTokenProperties);
     }
 
-    @DisplayName("로그인을 수행한다")
+    @DisplayName("회원가입을 수행한다")
     @Test
-    void login() {
+    void login_register() {
         // given
         LoginRequest loginRequest = new LoginRequest("ID_TOKEN");
-        String expectedNickname = "test-user";
 
         // when
         LoginResponse response = authService.login(loginRequest);
@@ -83,7 +82,27 @@ class AuthServiceTest {
             softAssertions.assertThat(response.accessToken()).isNotNull();
             softAssertions.assertThat(response.refreshToken()).isNotNull();
             softAssertions.assertThat(response.isNew()).isTrue();
-            softAssertions.assertThat(response.member().nickname()).isEqualTo(expectedNickname);
+            softAssertions.assertThat(response.member().nickname()).matches("^[0-9a-fA-F\\-]{36}$");
+        });
+    }
+
+    @DisplayName("로그인을 수행한다")
+    @Test
+    void login() {
+        // given
+        LoginRequest loginRequest = new LoginRequest("ID_TOKEN");
+        LoginResponse registerResponse = authService.login(loginRequest);
+        String expectedNickname = registerResponse.member().nickname();
+
+        // when
+        LoginResponse actual = authService.login(loginRequest);
+
+        // then
+        assertSoftly(softAssertions -> {
+            softAssertions.assertThat(actual.accessToken()).isNotNull();
+            softAssertions.assertThat(actual.refreshToken()).isNotNull();
+            softAssertions.assertThat(actual.isNew()).isFalse();
+            softAssertions.assertThat(actual.member().nickname()).isEqualTo(expectedNickname);
         });
     }
 

--- a/backend/src/test/java/com/yagubogu/auth/service/AuthServiceTest.java
+++ b/backend/src/test/java/com/yagubogu/auth/service/AuthServiceTest.java
@@ -82,7 +82,6 @@ class AuthServiceTest {
             softAssertions.assertThat(response.accessToken()).isNotNull();
             softAssertions.assertThat(response.refreshToken()).isNotNull();
             softAssertions.assertThat(response.isNew()).isTrue();
-            softAssertions.assertThat(response.member().nickname()).matches("^[0-9a-fA-F\\-]{36}$");
         });
     }
 

--- a/backend/src/test/java/com/yagubogu/checkin/service/CheckInServiceTest.java
+++ b/backend/src/test/java/com/yagubogu/checkin/service/CheckInServiceTest.java
@@ -1,11 +1,5 @@
 package com.yagubogu.checkin.service;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatCode;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
-import static org.assertj.core.api.AssertionsForClassTypes.tuple;
-import static org.assertj.core.api.SoftAssertions.assertSoftly;
-
 import com.yagubogu.auth.config.AuthTestConfig;
 import com.yagubogu.checkin.domain.CheckIn;
 import com.yagubogu.checkin.domain.CheckInOrderFilter;
@@ -48,6 +42,12 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.assertj.core.api.AssertionsForClassTypes.tuple;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 @Import({AuthTestConfig.class, JpaAuditingConfig.class})
 @DataJpaTest
@@ -409,7 +409,7 @@ class CheckInServiceTest {
         // then
         assertSoftly(softAssertions -> {
             softAssertions.assertThat(actual.myRanking().ranking()).isEqualTo(0);
-            softAssertions.assertThat(actual.myRanking().nickname()).isEqualTo(fora.getNickname());
+            softAssertions.assertThat(actual.myRanking().nickname()).isEqualTo(fora.getNickname().getValue());
             softAssertions.assertThat(actual.myRanking().teamShortName()).isEqualTo(fora.getTeam().getShortName());
             softAssertions.assertThat(actual.myRanking().winPercent()).isEqualTo(0.0);
         });

--- a/backend/src/test/java/com/yagubogu/member/MemberE2eTest.java
+++ b/backend/src/test/java/com/yagubogu/member/MemberE2eTest.java
@@ -117,6 +117,25 @@ public class MemberE2eTest extends E2eTestBase {
         assertThat(actual.nickname()).isEqualTo(newNickname);
     }
 
+    @DisplayName("예외: 닉네임 수정 시 중복된 닉네임이면 409 상태를 반환한다")
+    @Test
+    void patchNickname_duplicateNicknameReturn409Status() {
+        // given
+        String existNickname = "존재하는닉네임";
+        Member member1 = memberFactory.save(builder -> builder.nickname(existNickname));
+        Member member2 = memberFactory.save(builder -> builder.nickname("우가"));
+        String accessToken = authFactory.getAccessTokenByMemberId(member2.getId(), Role.USER);
+
+        // when & then
+        RestAssured.given().log().all()
+                .contentType(ContentType.JSON)
+                .header(HttpHeaders.AUTHORIZATION, accessToken)
+                .body(new MemberNicknameRequest(existNickname))
+                .when().patch("/api/members/me/nickname")
+                .then().log().all()
+                .statusCode(409);
+    }
+
     @DisplayName("회원 탈퇴한다")
     @Test
     void removeMember() {

--- a/backend/src/test/java/com/yagubogu/member/MemberE2eTest.java
+++ b/backend/src/test/java/com/yagubogu/member/MemberE2eTest.java
@@ -204,7 +204,7 @@ public class MemberE2eTest extends E2eTestBase {
 
         // then
         assertSoftly(softAssertions -> {
-            softAssertions.assertThat(actual.nickname()).isEqualTo(member.getNickname());
+            softAssertions.assertThat(actual.nickname()).isEqualTo(member.getNickname().getValue());
             softAssertions.assertThat(actual.profileImageUrl()).isEqualTo(member.getImageUrl());
             softAssertions.assertThat(actual.createdAt()).isEqualTo(member.getCreatedAt().toLocalDate());
             softAssertions.assertThat(actual.favoriteTeam()).isEqualTo(member.getTeam().getShortName());

--- a/backend/src/test/java/com/yagubogu/member/domain/MemberTest.java
+++ b/backend/src/test/java/com/yagubogu/member/domain/MemberTest.java
@@ -15,7 +15,7 @@ class MemberTest {
     public void validateAdmin(Role role, boolean expected) {
         //given
         Team team = new Team("기아 타이거즈", "기아", "HT");
-        Member member = new Member(team, "김도영", "email", OAuthProvider.GOOGLE, "sub",
+        Member member = new Member(team, new Nickname("김도영"), "email", OAuthProvider.GOOGLE, "sub",
                 role, "picture");
 
         //when & then

--- a/backend/src/test/java/com/yagubogu/member/service/MemberServiceTest.java
+++ b/backend/src/test/java/com/yagubogu/member/service/MemberServiceTest.java
@@ -230,7 +230,7 @@ public class MemberServiceTest {
 
         // then
         assertSoftly(softAssertions -> {
-            softAssertions.assertThat(actual.nickname()).isEqualTo(member.getNickname());
+            softAssertions.assertThat(actual.nickname()).isEqualTo(member.getNickname().getValue());
             softAssertions.assertThat(actual.favoriteTeam()).isEqualTo(member.getTeam().getShortName());
             softAssertions.assertThat(actual.createdAt()).isEqualTo(member.getCreatedAt().toLocalDate());
             softAssertions.assertThat(actual.profileImageUrl()).isEqualTo(member.getImageUrl());
@@ -248,7 +248,7 @@ public class MemberServiceTest {
 
         // then
         assertSoftly(softAssertions -> {
-            softAssertions.assertThat(actual.nickname()).isEqualTo(member.getNickname());
+            softAssertions.assertThat(actual.nickname()).isEqualTo(member.getNickname().getValue());
             softAssertions.assertThat(actual.favoriteTeam()).isNull();
             softAssertions.assertThat(actual.createdAt()).isEqualTo(member.getCreatedAt().toLocalDate());
             softAssertions.assertThat(actual.profileImageUrl()).isEqualTo(member.getImageUrl());

--- a/backend/src/test/java/com/yagubogu/member/service/MemberServiceTest.java
+++ b/backend/src/test/java/com/yagubogu/member/service/MemberServiceTest.java
@@ -1,11 +1,8 @@
 package com.yagubogu.member.service;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.SoftAssertions.assertSoftly;
-
 import com.yagubogu.auth.config.AuthTestConfig;
 import com.yagubogu.global.config.JpaAuditingConfig;
+import com.yagubogu.global.exception.ConflictException;
 import com.yagubogu.global.exception.NotFoundException;
 import com.yagubogu.member.domain.Member;
 import com.yagubogu.member.dto.MemberFavoriteRequest;
@@ -24,6 +21,10 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 @Import({AuthTestConfig.class, JpaAuditingConfig.class})
 @DataJpaTest
@@ -104,6 +105,21 @@ public class MemberServiceTest {
 
         // then
         assertThat(actual.nickname()).isEqualTo(newNickname);
+    }
+
+    @DisplayName("예외: 닉네임 수정시 존재하는 닉네임이면 예외가 발생한다")
+    @Test
+    void patchNickname_duplicateNickname() {
+        // given
+        String existNickname = "존재하는닉네임";
+        memberFactory.save(builder -> builder.nickname(existNickname));
+        Member member = memberFactory.save(builder -> builder.nickname("우가"));
+        MemberNicknameRequest request = new MemberNicknameRequest(existNickname);
+
+        // when & then
+        assertThatThrownBy(() -> memberService.patchNickname(member.getId(), request))
+                .isExactlyInstanceOf(ConflictException.class)
+                .hasMessage("Nickname already exists: " + existNickname);
     }
 
     @DisplayName("예외: 멤버를 찾지 못하면 예외가 발생한다")

--- a/backend/src/test/java/com/yagubogu/support/TestFixture.java
+++ b/backend/src/test/java/com/yagubogu/support/TestFixture.java
@@ -1,9 +1,6 @@
 package com.yagubogu.support;
 
 import com.yagubogu.game.domain.ScoreBoard;
-import com.yagubogu.member.domain.Member;
-import com.yagubogu.member.domain.OAuthProvider;
-import com.yagubogu.member.domain.Role;
 import com.yagubogu.team.domain.Team;
 import java.time.Instant;
 import java.time.LocalDate;
@@ -46,11 +43,6 @@ public class TestFixture {
     public static ScoreBoard getAwayScoreBoardAbout(Integer runs) {
         return new ScoreBoard(runs, 10, 10, 10,
                 List.of("0", "1", "2", "0", "0", "2", "0", "0", "0", "-", "-"));
-    }
-
-    public static Member getUser(Team team) {
-        return new Member(team, "김도영", "email", OAuthProvider.GOOGLE, "sub", Role.USER,
-                "picture");
     }
 
     public static Team getTeam() {

--- a/backend/src/test/java/com/yagubogu/support/member/MemberBuilder.java
+++ b/backend/src/test/java/com/yagubogu/support/member/MemberBuilder.java
@@ -10,7 +10,7 @@ import java.util.UUID;
 public class MemberBuilder {
 
     private Team team;
-    private Nickname nickname = new Nickname(UUID.randomUUID().toString().substring(0, 15));
+    private Nickname nickname = new Nickname(UUID.randomUUID().toString().substring(0, 10));
     private String email = UUID.randomUUID() + "email@gmail.com";
     private OAuthProvider provider = OAuthProvider.GOOGLE;
     private String oauthId = UUID.randomUUID().toString();

--- a/backend/src/test/java/com/yagubogu/support/member/MemberBuilder.java
+++ b/backend/src/test/java/com/yagubogu/support/member/MemberBuilder.java
@@ -1,6 +1,7 @@
 package com.yagubogu.support.member;
 
 import com.yagubogu.member.domain.Member;
+import com.yagubogu.member.domain.Nickname;
 import com.yagubogu.member.domain.OAuthProvider;
 import com.yagubogu.member.domain.Role;
 import com.yagubogu.team.domain.Team;
@@ -9,7 +10,7 @@ import java.util.UUID;
 public class MemberBuilder {
 
     private Team team;
-    private String nickname = "user-" + UUID.randomUUID();
+    private Nickname nickname = new Nickname(UUID.randomUUID().toString().substring(0, 15));
     private String email = UUID.randomUUID() + "email@gmail.com";
     private OAuthProvider provider = OAuthProvider.GOOGLE;
     private String oauthId = UUID.randomUUID().toString();
@@ -22,8 +23,8 @@ public class MemberBuilder {
         return this;
     }
 
-    public MemberBuilder nickname(final String nickname) {
-        this.nickname = nickname;
+    public MemberBuilder nickname(final String name) {
+        this.nickname = new Nickname(name);
 
         return this;
     }


### PR DESCRIPTION
## 📌 관련 이슈
- close #509 

## ✨ 변경 내용
- 닉네임 중복 검증 -> 중복 발생 시 409 예외 발생
- 회원가입시 UUID 닉네임으로 가입
- 승리요정 랭킹 조회시 탈퇴한 회원 조회 불가

## 🎸 기타 참고 사항
- 스크린샷, 참고 링크, 추가 설명 등 (없으면 생략 가능)