### PR TITLE
feat: 좋아요 배치 처리 기능 추가

### DIFF
--- a/backend/src/main/java/com/yagubogu/like/controller/LikeController.java
+++ b/backend/src/main/java/com/yagubogu/like/controller/LikeController.java
@@ -1,0 +1,38 @@
+package com.yagubogu.like.controller;
+
+import com.yagubogu.like.dto.LikeBatchRequest;
+import com.yagubogu.like.dto.LikeCountsResponse;
+import com.yagubogu.like.service.LikeService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RequestMapping("/api/games")
+@RestController
+public class LikeController {
+
+    private final LikeService likeService;
+
+    @PostMapping("/{gameId}/likes/batch")
+    public ResponseEntity<LikeCountsResponse> applyLikeBatch(
+            @PathVariable long gameId,
+            @RequestBody LikeBatchRequest body
+    ) {
+        LikeCountsResponse response = likeService.applyBatch(gameId, body);
+
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/{gameId}/likes/counts")
+    public ResponseEntity<LikeCountsResponse> findLikeCounts(@PathVariable long gameId) {
+        LikeCountsResponse response = likeService.findCounts(gameId);
+
+        return ResponseEntity.ok(response);
+    }
+}

--- a/backend/src/main/java/com/yagubogu/like/controller/LikeController.java
+++ b/backend/src/main/java/com/yagubogu/like/controller/LikeController.java
@@ -1,5 +1,6 @@
 package com.yagubogu.like.controller;
 
+import com.yagubogu.auth.annotation.RequireRole;
 import com.yagubogu.auth.dto.MemberClaims;
 import com.yagubogu.like.dto.LikeBatchRequest;
 import com.yagubogu.like.dto.LikeCountsResponse;
@@ -20,16 +21,18 @@ public class LikeController {
 
     private final LikeService likeService;
 
-    @PostMapping("/{gameId}/likes/batch")
-    public ResponseEntity<LikeCountsResponse> applyLikeBatch(
+    @RequireRole
+    @PostMapping("/{gameId}/like-batches")
+    public ResponseEntity<Void> applyLikeBatch(
             @PathVariable final long gameId,
             @RequestBody final LikeBatchRequest body
     ) {
-        LikeCountsResponse response = likeService.applyBatch(gameId, body);
+        likeService.applyBatch(gameId, body);
 
-        return ResponseEntity.ok(response);
+        return ResponseEntity.noContent().build();
     }
 
+    @RequireRole
     @GetMapping("/{gameId}/likes/counts")
     public ResponseEntity<LikeCountsResponse> findLikeCounts(
             final MemberClaims memberClaims,

--- a/backend/src/main/java/com/yagubogu/like/controller/LikeController.java
+++ b/backend/src/main/java/com/yagubogu/like/controller/LikeController.java
@@ -1,5 +1,6 @@
 package com.yagubogu.like.controller;
 
+import com.yagubogu.auth.dto.MemberClaims;
 import com.yagubogu.like.dto.LikeBatchRequest;
 import com.yagubogu.like.dto.LikeCountsResponse;
 import com.yagubogu.like.service.LikeService;
@@ -21,8 +22,8 @@ public class LikeController {
 
     @PostMapping("/{gameId}/likes/batch")
     public ResponseEntity<LikeCountsResponse> applyLikeBatch(
-            @PathVariable long gameId,
-            @RequestBody LikeBatchRequest body
+            @PathVariable final long gameId,
+            @RequestBody final LikeBatchRequest body
     ) {
         LikeCountsResponse response = likeService.applyBatch(gameId, body);
 
@@ -30,8 +31,11 @@ public class LikeController {
     }
 
     @GetMapping("/{gameId}/likes/counts")
-    public ResponseEntity<LikeCountsResponse> findLikeCounts(@PathVariable long gameId) {
-        LikeCountsResponse response = likeService.findCounts(gameId);
+    public ResponseEntity<LikeCountsResponse> findLikeCounts(
+            final MemberClaims memberClaims,
+            @PathVariable final long gameId
+    ) {
+        LikeCountsResponse response = likeService.findCounts(gameId, memberClaims.id());
 
         return ResponseEntity.ok(response);
     }

--- a/backend/src/main/java/com/yagubogu/like/domain/Like.java
+++ b/backend/src/main/java/com/yagubogu/like/domain/Like.java
@@ -1,0 +1,54 @@
+package com.yagubogu.like.domain;
+
+import com.yagubogu.game.domain.Game;
+import com.yagubogu.team.domain.Team;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "likes")
+@Entity
+public class Like {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "game_id", nullable = false)
+    private Game game;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "team_id", nullable = false)
+    private Team team;
+
+    @Column(name = "total_count", nullable = false)
+    private long totalCount = 0L;
+
+    public Like(Game game, Team team) {
+        this.game = game;
+        this.team = team;
+    }
+
+    public static Like of(Game game, Team team) {
+        return new Like(game, team);
+    }
+
+    public void add(long delta) {
+        if (delta == 0) {
+            return;
+        }
+        this.totalCount = this.totalCount + delta;
+    }
+}

--- a/backend/src/main/java/com/yagubogu/like/domain/Like.java
+++ b/backend/src/main/java/com/yagubogu/like/domain/Like.java
@@ -41,11 +41,11 @@ public class Like {
         this.team = team;
     }
 
-    public static Like of(Game game, Team team) {
+    public static Like of(final Game game, final Team team) {
         return new Like(game, team);
     }
 
-    public void add(long delta) {
+    public void add(final long delta) {
         if (delta == 0) {
             return;
         }

--- a/backend/src/main/java/com/yagubogu/like/domain/Like.java
+++ b/backend/src/main/java/com/yagubogu/like/domain/Like.java
@@ -36,7 +36,7 @@ public class Like {
     @Column(name = "total_count", nullable = false)
     private long totalCount = 0L;
 
-    public Like(Game game, Team team) {
+    public Like(final Game game, final Team team) {
         this.game = game;
         this.team = team;
     }

--- a/backend/src/main/java/com/yagubogu/like/dto/LikeBatchRequest.java
+++ b/backend/src/main/java/com/yagubogu/like/dto/LikeBatchRequest.java
@@ -2,13 +2,12 @@ package com.yagubogu.like.dto;
 
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
-import java.util.List;
 
 public record LikeBatchRequest(
         @NotBlank String clientInstanceId,
         @Min(0) Long windowStartEpochSec,
-        List<Entry> entries
+        LikeDelta likeDelta
 ) {
-    public record Entry(Long teamId, Integer delta) {
+    public record LikeDelta(Long teamId, Integer delta) {
     }
 }

--- a/backend/src/main/java/com/yagubogu/like/dto/LikeBatchRequest.java
+++ b/backend/src/main/java/com/yagubogu/like/dto/LikeBatchRequest.java
@@ -8,6 +8,6 @@ public record LikeBatchRequest(
         @Min(0) Long windowStartEpochSec,
         LikeDelta likeDelta
 ) {
-    public record LikeDelta(Long teamId, Integer delta) {
+    public record LikeDelta(Long teamId, Long delta) {
     }
 }

--- a/backend/src/main/java/com/yagubogu/like/dto/LikeBatchRequest.java
+++ b/backend/src/main/java/com/yagubogu/like/dto/LikeBatchRequest.java
@@ -1,0 +1,14 @@
+package com.yagubogu.like.dto;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import java.util.List;
+
+public record LikeBatchRequest(
+        @NotBlank String clientInstanceId,
+        @Min(0) Long windowStartEpochSec,
+        List<Entry> entries
+) {
+    public record Entry(Long teamId, Integer delta) {
+    }
+}

--- a/backend/src/main/java/com/yagubogu/like/dto/LikeCountsResponse.java
+++ b/backend/src/main/java/com/yagubogu/like/dto/LikeCountsResponse.java
@@ -1,0 +1,9 @@
+package com.yagubogu.like.dto;
+
+import java.util.Map;
+
+public record LikeCountsResponse(
+        long gameId,
+        Map<Long, Long> counts
+) {
+}

--- a/backend/src/main/java/com/yagubogu/like/dto/LikeCountsResponse.java
+++ b/backend/src/main/java/com/yagubogu/like/dto/LikeCountsResponse.java
@@ -1,9 +1,9 @@
 package com.yagubogu.like.dto;
 
-import java.util.Map;
+import java.util.List;
 
 public record LikeCountsResponse(
         long gameId,
-        Map<Long, Long> counts
+        List<TeamLikeCountResponse> counts
 ) {
 }

--- a/backend/src/main/java/com/yagubogu/like/dto/TeamLikeCountResponse.java
+++ b/backend/src/main/java/com/yagubogu/like/dto/TeamLikeCountResponse.java
@@ -1,0 +1,7 @@
+package com.yagubogu.like.dto;
+
+public record TeamLikeCountResponse(
+        Long teamId,
+        Long totalCount
+) {
+}

--- a/backend/src/main/java/com/yagubogu/like/repository/LikeRepository.java
+++ b/backend/src/main/java/com/yagubogu/like/repository/LikeRepository.java
@@ -1,6 +1,7 @@
 package com.yagubogu.like.repository;
 
 import com.yagubogu.like.domain.Like;
+import com.yagubogu.like.dto.TeamLikeCountResponse;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -17,4 +18,14 @@ public interface LikeRepository extends JpaRepository<Like, Long> {
     int upsertDelta(long gameId, long teamId, long delta);
 
     List<Like> findAllByGameId(long gameId);
+
+    @Query("""
+                select new com.yagubogu.like.dto.TeamLikeCountResponse(
+                    l.team.id,
+                    l.totalCount
+                )
+                from Like l
+                where l.game.id = :gameId
+            """)
+    List<TeamLikeCountResponse> findTeamCountsByGameId(Long gameId);
 }

--- a/backend/src/main/java/com/yagubogu/like/repository/LikeRepository.java
+++ b/backend/src/main/java/com/yagubogu/like/repository/LikeRepository.java
@@ -1,0 +1,20 @@
+package com.yagubogu.like.repository;
+
+import com.yagubogu.like.domain.Like;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+
+public interface LikeRepository extends JpaRepository<Like, Long> {
+
+    @Modifying(flushAutomatically = true, clearAutomatically = true)
+    @Query(value = """
+            INSERT INTO likes (game_id, team_id, total_count)
+            VALUES (:gameId, :teamId, :delta)
+            ON DUPLICATE KEY UPDATE total_count = total_count + :delta;
+            """, nativeQuery = true)
+    int upsertDelta(long gameId, long teamId, long delta);
+
+    List<Like> findAllByGameId(long gameId);
+}

--- a/backend/src/main/java/com/yagubogu/like/repository/LikeWindowRepository.java
+++ b/backend/src/main/java/com/yagubogu/like/repository/LikeWindowRepository.java
@@ -1,0 +1,26 @@
+package com.yagubogu.like.repository;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+@Repository
+public class LikeWindowRepository {
+
+    @PersistenceContext
+    private EntityManager em;
+
+    @Transactional
+    public boolean tryInsertWindow(long gameId, String clientId, long windowStart) {
+        int updated = em.createNativeQuery("""
+                        insert ignore into like_windows (game_id, client_instance_id, window_start_epoch_sec)
+                        values (:gameId, :clientId, :windowStart)
+                        """)
+                .setParameter("gameId", gameId)
+                .setParameter("clientId", clientId)
+                .setParameter("windowStart", windowStart)
+                .executeUpdate();
+        return updated > 0;
+    }
+}

--- a/backend/src/main/java/com/yagubogu/like/service/LikeService.java
+++ b/backend/src/main/java/com/yagubogu/like/service/LikeService.java
@@ -55,10 +55,14 @@ public class LikeService {
     }
 
     private void existsGame(final long gameId) {
-        gameRepository.findById(gameId).orElseThrow(() -> new NotFoundException("Game not Found"));
+        if (!gameRepository.existsById(gameId)) {
+            throw new NotFoundException("Game not found");
+        }
     }
 
     private void existsMember(final long memberId) {
-        memberRepository.findById(memberId).orElseThrow(() -> new NotFoundException("Member not Found"));
+        if (!memberRepository.existsById(memberId)) {
+            throw new NotFoundException("Member not found");
+        }
     }
 }

--- a/backend/src/main/java/com/yagubogu/like/service/LikeService.java
+++ b/backend/src/main/java/com/yagubogu/like/service/LikeService.java
@@ -1,0 +1,79 @@
+package com.yagubogu.like.service;
+
+import com.yagubogu.game.domain.Game;
+import com.yagubogu.game.repository.GameRepository;
+import com.yagubogu.global.exception.NotFoundException;
+import com.yagubogu.like.domain.Like;
+import com.yagubogu.like.dto.LikeBatchRequest;
+import com.yagubogu.like.dto.LikeCountsResponse;
+import com.yagubogu.like.repository.LikeRepository;
+import com.yagubogu.like.repository.LikeWindowRepository;
+import com.yagubogu.team.domain.Team;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+public class LikeService {
+
+    private final LikeRepository likeRepository;
+    private final LikeWindowRepository likeWindowRepository;
+    private final GameRepository gameRepository;
+
+
+    @Transactional
+    public LikeCountsResponse applyBatch(final long gameId, final LikeBatchRequest request) {
+        Game game = getGame(gameId);
+
+        // 멱등성 키 insert (INSERT IGNORE -> 이미 처리된 배치면 재적용 금지)
+        boolean inserted = likeWindowRepository.tryInsertWindow(
+                gameId,
+                request.clientInstanceId(),
+                request.windowStartEpochSec()
+        );
+        if (!inserted) {
+            return buildCountsResponse(gameId);
+        }
+
+        Set<Long> validTeamIds = fetchParticipantTeamIds(game);
+
+        for (LikeBatchRequest.Entry e : request.entries()) {
+            if (!validTeamIds.contains(e.teamId())) {
+                continue;
+            }
+            likeRepository.upsertDelta(gameId, e.teamId(), e.delta().longValue());
+        }
+
+        return buildCountsResponse(gameId);
+    }
+
+    @Transactional(readOnly = true)
+    public LikeCountsResponse findCounts(final long gameId) {
+        Game game = getGame(gameId);
+
+        return buildCountsResponse(game.getId());
+    }
+
+    private LikeCountsResponse buildCountsResponse(final long gameId) {
+        List<Like> rows = likeRepository.findAllByGameId(gameId);
+        Map<Long, Long> counts = rows.stream()
+                .collect(Collectors.toMap(l -> l.getTeam().getId(), Like::getTotalCount));
+
+        return new LikeCountsResponse(gameId, counts);
+    }
+
+    private Game getGame(final long gameId) {
+        return gameRepository.findById(gameId).orElseThrow(() -> new NotFoundException("Game not Found"));
+    }
+
+    private Set<Long> fetchParticipantTeamIds(final Game game) {
+        Team homeTeam = game.getHomeTeam();
+        Team awayTeam = game.getAwayTeam();
+        return Set.of(homeTeam.getId(), awayTeam.getId());
+    }
+}

--- a/backend/src/main/java/com/yagubogu/like/service/LikeService.java
+++ b/backend/src/main/java/com/yagubogu/like/service/LikeService.java
@@ -5,14 +5,14 @@ import com.yagubogu.game.repository.GameRepository;
 import com.yagubogu.global.exception.NotFoundException;
 import com.yagubogu.like.domain.Like;
 import com.yagubogu.like.dto.LikeBatchRequest;
+import com.yagubogu.like.dto.LikeBatchRequest.LikeDelta;
 import com.yagubogu.like.dto.LikeCountsResponse;
+import com.yagubogu.like.dto.TeamLikeCountResponse;
 import com.yagubogu.like.repository.LikeRepository;
 import com.yagubogu.like.repository.LikeWindowRepository;
-import com.yagubogu.team.domain.Team;
+import com.yagubogu.member.domain.Member;
+import com.yagubogu.member.repository.MemberRepository;
 import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -24,11 +24,14 @@ public class LikeService {
     private final LikeRepository likeRepository;
     private final LikeWindowRepository likeWindowRepository;
     private final GameRepository gameRepository;
-
+    private final MemberRepository memberRepository;
 
     @Transactional
-    public LikeCountsResponse applyBatch(final long gameId, final LikeBatchRequest request) {
-        Game game = getGame(gameId);
+    public LikeCountsResponse applyBatch(
+            final long gameId,
+            final LikeBatchRequest request
+    ) {
+        getGame(gameId);
 
         // 멱등성 키 insert (INSERT IGNORE -> 이미 처리된 배치면 재적용 금지)
         boolean inserted = likeWindowRepository.tryInsertWindow(
@@ -40,40 +43,40 @@ public class LikeService {
             return buildCountsResponse(gameId);
         }
 
-        Set<Long> validTeamIds = fetchParticipantTeamIds(game);
-
-        for (LikeBatchRequest.Entry e : request.entries()) {
-            if (!validTeamIds.contains(e.teamId())) {
-                continue;
-            }
-            likeRepository.upsertDelta(gameId, e.teamId(), e.delta().longValue());
-        }
+        LikeDelta likeDelta = request.likeDelta();
+        likeRepository.upsertDelta(gameId, likeDelta.teamId(), likeDelta.delta().longValue());
 
         return buildCountsResponse(gameId);
     }
 
     @Transactional(readOnly = true)
-    public LikeCountsResponse findCounts(final long gameId) {
+    public LikeCountsResponse findCounts(final long gameId, final long memberId) {
         Game game = getGame(gameId);
+        Member member = getMember(memberId);
 
-        return buildCountsResponse(game.getId());
+        List<TeamLikeCountResponse> teamLikeCounts = likeRepository.findTeamCountsByGameId(gameId);
+
+        return new LikeCountsResponse(gameId, teamLikeCounts);
     }
 
     private LikeCountsResponse buildCountsResponse(final long gameId) {
         List<Like> rows = likeRepository.findAllByGameId(gameId);
-        Map<Long, Long> counts = rows.stream()
-                .collect(Collectors.toMap(l -> l.getTeam().getId(), Like::getTotalCount));
 
-        return new LikeCountsResponse(gameId, counts);
+        List<TeamLikeCountResponse> teamLikeCounts = rows.stream()
+                .map(like -> new TeamLikeCountResponse(
+                        like.getTeam().getId(),
+                        like.getTotalCount()
+                ))
+                .toList();
+
+        return new LikeCountsResponse(gameId, teamLikeCounts);
     }
 
     private Game getGame(final long gameId) {
         return gameRepository.findById(gameId).orElseThrow(() -> new NotFoundException("Game not Found"));
     }
 
-    private Set<Long> fetchParticipantTeamIds(final Game game) {
-        Team homeTeam = game.getHomeTeam();
-        Team awayTeam = game.getAwayTeam();
-        return Set.of(homeTeam.getId(), awayTeam.getId());
+    private Member getMember(final long memberId) {
+        return memberRepository.findById(memberId).orElseThrow(() -> new NotFoundException("Member not Found"));
     }
 }

--- a/backend/src/main/java/com/yagubogu/like/service/LikeService.java
+++ b/backend/src/main/java/com/yagubogu/like/service/LikeService.java
@@ -1,6 +1,5 @@
 package com.yagubogu.like.service;
 
-import com.yagubogu.game.domain.Game;
 import com.yagubogu.game.repository.GameRepository;
 import com.yagubogu.global.exception.NotFoundException;
 import com.yagubogu.like.dto.LikeBatchRequest;
@@ -9,7 +8,6 @@ import com.yagubogu.like.dto.LikeCountsResponse;
 import com.yagubogu.like.dto.TeamLikeCountResponse;
 import com.yagubogu.like.repository.LikeRepository;
 import com.yagubogu.like.repository.LikeWindowRepository;
-import com.yagubogu.member.domain.Member;
 import com.yagubogu.member.repository.MemberRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -31,7 +29,7 @@ public class LikeService {
             final long gameId,
             final LikeBatchRequest request
     ) {
-        getGame(gameId);
+        existsGame(gameId);
 
         // 멱등성 키 insert (INSERT IGNORE -> 이미 처리된 배치면 재적용 금지)
         boolean inserted = likeWindowRepository.tryInsertWindow(
@@ -48,19 +46,19 @@ public class LikeService {
     }
 
     public LikeCountsResponse findCounts(final long gameId, final long memberId) {
-        Game game = getGame(gameId);
-        Member member = getMember(memberId);
+        existsGame(gameId);
+        existsMember(memberId);
 
         List<TeamLikeCountResponse> teamLikeCounts = likeRepository.findTeamCountsByGameId(gameId);
 
         return new LikeCountsResponse(gameId, teamLikeCounts);
     }
 
-    private Game getGame(final long gameId) {
-        return gameRepository.findById(gameId).orElseThrow(() -> new NotFoundException("Game not Found"));
+    private void existsGame(final long gameId) {
+        gameRepository.findById(gameId).orElseThrow(() -> new NotFoundException("Game not Found"));
     }
 
-    private Member getMember(final long memberId) {
-        return memberRepository.findById(memberId).orElseThrow(() -> new NotFoundException("Member not Found"));
+    private void existsMember(final long memberId) {
+        memberRepository.findById(memberId).orElseThrow(() -> new NotFoundException("Member not Found"));
     }
 }

--- a/backend/src/main/resources/db/migration/mysql/V2__add_like_counts_to_games.sql
+++ b/backend/src/main/resources/db/migration/mysql/V2__add_like_counts_to_games.sql
@@ -1,0 +1,30 @@
+-- V12__create_likes_table.sql
+-- 엔진/문자셋은 프로젝트 표준에 맞추세요 (InnoDB, utf8mb4 권장)
+
+CREATE TABLE IF NOT EXISTS likes (
+     id            BIGINT NOT NULL AUTO_INCREMENT,
+     game_id       BIGINT NOT NULL,
+     team_id       BIGINT NOT NULL,
+     total_count   BIGINT NOT NULL DEFAULT 0,
+     created_at    TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+     updated_at    TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+
+     CONSTRAINT pk_likes PRIMARY KEY (id),
+
+    -- 한 경기에서 팀별 카운터는 한 행만 존재해야 함(UPSERT 전제)
+    CONSTRAINT uk_likes_game_team UNIQUE (game_id, team_id),
+
+    -- 외래키 (테이블명은 실제 스키마에 맞게 수정: games/teams)
+    CONSTRAINT fk_likes_game FOREIGN KEY (game_id) REFERENCES games (game_id) ON DELETE CASCADE,
+    CONSTRAINT fk_likes_team FOREIGN KEY (team_id) REFERENCES teams (team_id) ON DELETE RESTRICT
+    ) ENGINE=InnoDB;
+
+CREATE TABLE like_windows (
+      id BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+      game_id BIGINT NOT NULL,
+      client_instance_id VARCHAR(64) NOT NULL,
+      window_start_epoch_sec BIGINT NOT NULL,
+      created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+      CONSTRAINT uk_like_windows UNIQUE (game_id, client_instance_id, window_start_epoch_sec),
+      CONSTRAINT fk_like_windows_game FOREIGN KEY (game_id) REFERENCES games (game_id) ON DELETE CASCADE
+) ENGINE=InnoDB;

--- a/backend/src/test/java/com/yagubogu/like/LikeE2eTest.java
+++ b/backend/src/test/java/com/yagubogu/like/LikeE2eTest.java
@@ -1,0 +1,104 @@
+package com.yagubogu.like;
+
+import static org.hamcrest.CoreMatchers.is;
+
+import com.yagubogu.auth.config.AuthTestConfig;
+import com.yagubogu.game.domain.Game;
+import com.yagubogu.global.config.JpaAuditingConfig;
+import com.yagubogu.like.dto.LikeBatchRequest;
+import com.yagubogu.stadium.domain.Stadium;
+import com.yagubogu.stadium.repository.StadiumRepository;
+import com.yagubogu.support.E2eTestBase;
+import com.yagubogu.support.game.GameFactory;
+import com.yagubogu.team.domain.Team;
+import com.yagubogu.team.repository.TeamRepository;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.context.annotation.Import;
+
+@Import({AuthTestConfig.class, JpaAuditingConfig.class})
+public class LikeE2eTest extends E2eTestBase {
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private TeamRepository teamRepository;
+
+    @Autowired
+    private StadiumRepository stadiumRepository;
+
+    @Autowired
+    private GameFactory gameFactory;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+    }
+
+    @DisplayName("좋아요 카운트: 초기값은 비어있다")
+    @Test
+    void findLikeCounts_initiallyEmpty() {
+        // given
+        Stadium stadium = stadiumRepository.findByShortName("사직구장").orElseThrow();
+        Team homeTeam = teamRepository.findByTeamCode("LT").orElseThrow();
+        Team awayTeam = teamRepository.findByTeamCode("HH").orElseThrow();
+        Game game = gameFactory.save(builder -> builder
+                .homeTeam(homeTeam)
+                .awayTeam(awayTeam)
+                .stadium(stadium));
+
+        // when & then
+        RestAssured.given().log().all()
+                .contentType(ContentType.JSON)
+                .pathParam("gameId", game.getId())
+                .when()
+                .get("/api/games/{gameId}/likes/counts")
+                .then().log().all()
+                .statusCode(200)
+                .body("gameId", is(game.getId().intValue()))
+                .body("counts.size()", is(0));
+    }
+
+    @DisplayName("좋아요 배치를 적용하고 카운트를 반환한다")
+    @Test
+    void applyLikeBatch_andGetCounts() {
+        // given
+        Stadium stadium = stadiumRepository.findByShortName("사직구장").orElseThrow();
+        Team homeTeam = teamRepository.findByTeamCode("LT").orElseThrow();
+        Team awayTeam = teamRepository.findByTeamCode("HH").orElseThrow();
+        Game game = gameFactory.save(builder -> builder
+                .homeTeam(homeTeam)
+                .awayTeam(awayTeam)
+                .stadium(stadium));
+
+        LikeBatchRequest request = new LikeBatchRequest(
+                "test-client-1",
+                1L,
+                List.of(
+                        new LikeBatchRequest.Entry(homeTeam.getId(), 3),
+                        new LikeBatchRequest.Entry(awayTeam.getId(), 2)
+                )
+        );
+
+        // when & then
+        RestAssured.given().log().all()
+                .contentType(ContentType.JSON)
+                .pathParam("gameId", game.getId())
+                .body(request)
+                .when()
+                .post("/api/games/{gameId}/likes/batch")
+                .then().log().all()
+                .statusCode(200)
+                .body("gameId", is(game.getId().intValue()))
+                .body("counts.%s".formatted(homeTeam.getId()), is(3))
+                .body("counts.%s".formatted(awayTeam.getId()), is(2));
+    }
+}
+

--- a/backend/src/test/java/com/yagubogu/like/LikeE2eTest.java
+++ b/backend/src/test/java/com/yagubogu/like/LikeE2eTest.java
@@ -99,7 +99,7 @@ public class LikeE2eTest extends E2eTestBase {
         LikeBatchRequest request = new LikeBatchRequest(
                 "test-client-1",
                 1L,
-                new LikeDelta(homeTeam.getId(), 3)
+                new LikeDelta(homeTeam.getId(), 3L)
         );
 
         // when & then
@@ -111,9 +111,7 @@ public class LikeE2eTest extends E2eTestBase {
                 .when()
                 .post("/api/games/{gameId}/likes/batch")
                 .then().log().all()
-                .statusCode(200)
-                .body("gameId", is(game.getId().intValue()))
-                .body("counts.find {it.teamId == %s }.totalCount".formatted(homeTeam.getId()), is(3));
+                .statusCode(204);
     }
 }
 

--- a/backend/src/test/java/com/yagubogu/like/LikeE2eTest.java
+++ b/backend/src/test/java/com/yagubogu/like/LikeE2eTest.java
@@ -109,7 +109,7 @@ public class LikeE2eTest extends E2eTestBase {
                 .pathParam("gameId", game.getId())
                 .body(request)
                 .when()
-                .post("/api/games/{gameId}/likes/batch")
+                .post("/api/games/{gameId}/like-batches")
                 .then().log().all()
                 .statusCode(204);
     }

--- a/backend/src/test/java/com/yagubogu/support/E2eTestBase.java
+++ b/backend/src/test/java/com/yagubogu/support/E2eTestBase.java
@@ -63,6 +63,8 @@ public abstract class E2eTestBase {
             em.createNativeQuery("TRUNCATE TABLE talk_reports").executeUpdate();
             em.createNativeQuery("TRUNCATE TABLE check_ins").executeUpdate();
             em.createNativeQuery("TRUNCATE TABLE talks").executeUpdate();
+            em.createNativeQuery("TRUNCATE TABLE likes").executeUpdate();
+            em.createNativeQuery("TRUNCATE TABLE like_windows").executeUpdate();
 
             em.createNativeQuery("SET FOREIGN_KEY_CHECKS = 1").executeUpdate();
         });


### PR DESCRIPTION
## 📌 관련 이슈
- close #508 


## Summary
- 안드로이드가 각 사용자의 **n분간 모은 좋아요 수**를 서버에 한 번에 보낸다.  
- 예: n분간 10명의 유저가 클릭했다면 서버에는 10개의 요청(batch)이 도착한다.  
- 본 PR은 좋아요 집계를 위한 **멱등성 보장 + 원자적 누적** 처리 로직을 추가했다.  
- 초기 버전은 **DB만으로** 구현하여 성능을 먼저 측정하고, 이후 Redis 기반 확장을 고려한다.

---

## 흐름 (End-to-End)
1. **안드로이드 → 서버**
   - 앱이 **1분치 증분(delta)** 을 `POST /games/{gameId}/likes/batch`로 전송
2. **Controller/Service**
   - `(gameId, clientInstanceId, windowStartEpochSec)`를 멱등성 키로 생성
   - `INSERT IGNORE INTO like_windows (...) VALUES (...)` 실행 → **이미 처리된 배치면 무시**
   - 멱등성 보장: 동일 키로는 **한 번만 처리**
3. **Repository**
   - 팀별 카운트는 `likes` 테이블에 **원자적 UPSERT** 반영
   - `INSERT ... ON DUPLICATE KEY UPDATE total_count = total_count + :delta`  
     → **없으면 INSERT, 있으면 누적 UPDATE**
4. **조회**
   - `GET /games/{id}/likes/counts` → 전체 집계 조회
5. **쿼리 전략**
   - MySQL 네이티브 쿼리(`INSERT IGNORE`, `ON DUPLICATE KEY UPDATE`) 사용
   - JPQL로는 불가능(JPQL은 insert 미지원 + upsert 없음)
6. **이후 계획**
   - 성능 측정 이후 Redis 전환 (멱등: `SETNX`, 누적: `HINCRBY`)

---

## 배경
- **사용 시나리오**: 현장톡에서 경기당 톡방 1개, 사용자는 팀 이모지를 눌러 팀별 좋아요를 기록한다.  
- **분산 환경 이슈 고려**  
  - 네트워크 재시도  
  - 요청 순서 꼬임  
  - 다중 서버 동시 처리  
- **보장 목표**  
  - **멱등성**: 같은 1분 배치를 한 번만 반영  
  - **원자성**: 다중 인스턴스/스레드 환경에서도 합산 정확  
- 이번 PR은 **DB만으로 이를 보장하는 초기 버전**이다. 실제 성능을 확인한 뒤 Redis 확장을 고려한다.

---

## 참고사항

### 멱등성
- 단순 `엔티티.save()` 접근 시 PK 충돌 예외 처리 필요.  
- 네이티브 `INSERT IGNORE`는 중복 시 **조용히 무시**하므로 효율적.  
- Redis 도입 시: `SETNX`로 이미 처리된 배치는 즉시 무시 → DB 접근 자체 생략 가능.  
- TTL 설정 시 메모리 관리 용이.

### 원자적 누적
- 단순 `find → entity.total + delta → save()`  
  - 다중 인스턴스/스레드에서 **마지막 저장이 덮어쓰기** 문제 발생  
  - 락 기반 접근은 경쟁이 많아질수록 성능 저하:
    - 낙관적 락: 예외 다발 + 재시도 폭증  
    - 비관적 락: waiting 증가 + DB 락 경합
- 네이티브 `ON DUPLICATE KEY UPDATE total_count = total_count + VALUES(total_count)` →  
  DB 단일 문장으로 **원자적 증가 보장** (경쟁 상황에서도 정확).
- Redis 도입 시: `HINCRBY`로 팀별 카운트를 해시 단위 원자적 증가 가능.  
  → DB 대신 Redis가 write 경합을 흡수해 **고QPS 대응**.

### API 의도
- `POST /likes/batch` → **한 유저 기기의 자기 증분(1분치 합산)** 전송  
- `GET /likes/counts` → **모든 유저·모든 기기 합산 결과** 조회  
- 즉, POST는 “한 유저당 좋아요 개수 전달”, GET은 “전체 합계 조회”