### PR TITLE
fix: CurrentFragment가 null일 때 scrollToTop 호출 시 crash 수정

### DIFF
--- a/android/app/src/main/java/com/yagubogu/presentation/MainActivity.kt
+++ b/android/app/src/main/java/com/yagubogu/presentation/MainActivity.kt
@@ -110,9 +110,7 @@ class MainActivity : AppCompatActivity() {
             val currentFragment: Fragment? =
                 supportFragmentManager.fragments.firstOrNull { it.isVisible }
 
-            if (currentFragment is ScrollToTop) {
-                currentFragment.scrollToTop()
-            }
+            (currentFragment as? ScrollToTop)?.scrollToTop()
         }
     }
 


### PR DESCRIPTION
## 📌 관련 이슈
- close #544 

## ✨ 변경 내용
- safe cast를 통해 scrollToTop 호출하도록 수정

## 🎸 기타 참고 사항
- 스크린샷, 참고 링크, 추가 설명 등 (없으면 생략 가능)