### PR TITLE
fix: 승리 요정 조회 시 내 랭킹이 0으로 나오는 문제 수정

### DIFF
--- a/backend/src/main/java/com/yagubogu/checkin/repository/CustomCheckInRepositoryImpl.java
+++ b/backend/src/main/java/com/yagubogu/checkin/repository/CustomCheckInRepositoryImpl.java
@@ -232,7 +232,7 @@ public class CustomCheckInRepositoryImpl implements CustomCheckInRepository {
                 .leftJoin(CHECK_IN).on(CHECK_IN.member.eq(MEMBER))
                 .leftJoin(GAME).on(CHECK_IN.game.eq(GAME), isFinished(), isBetweenYear(year))
                 .leftJoin(TEAM).on(CHECK_IN.team.eq(TEAM))
-                .where(filterByTeam(teamFilter))
+                .where(filterByTeam(teamFilter), isMemberNotDeleted())
                 .groupBy(MEMBER)
                 .having(score.gt(myScore))
                 .fetch().size();
@@ -291,6 +291,7 @@ public class CustomCheckInRepositoryImpl implements CustomCheckInRepository {
         return conditionCountOnRecentGames(member, year, drawCondition(QCheckIn.checkIn, QGame.game), limit);
     }
 
+    // 내 직관 내역 조회
     // 내 응원 팀 여부 관계 o, 게임 완료 여부 관계 x(취소된 경기도 보여줌)
     public List<CheckInGameResponse> findCheckInHistory(
             Member member,

--- a/backend/src/main/java/com/yagubogu/checkin/service/CheckInService.java
+++ b/backend/src/main/java/com/yagubogu/checkin/service/CheckInService.java
@@ -193,7 +193,7 @@ public class CheckInService {
                                                              final Member member) {
         VictoryFairyRank myRanking = checkInRepository.findMyRanking(m, c, member, year, teamFilter);
         double score = Math.round(myRanking.score() * 100 * ROUND_FACTOR) / ROUND_FACTOR;
-        int myRankingOrder = checkInRepository.calculateMyRankingOrder(score, m, c, year, teamFilter);
+        int myRankingOrder = checkInRepository.calculateMyRankingOrder(myRanking.score(), m, c, year, teamFilter) + 1;
         double winPercent = Math.round(myRanking.winPercent() * ROUND_FACTOR) / ROUND_FACTOR;
 
         return new VictoryFairyRankingResponse(

--- a/backend/src/test/java/com/yagubogu/checkin/service/CheckInServiceTest.java
+++ b/backend/src/test/java/com/yagubogu/checkin/service/CheckInServiceTest.java
@@ -1,5 +1,11 @@
 package com.yagubogu.checkin.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.assertj.core.api.AssertionsForClassTypes.tuple;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
 import com.yagubogu.auth.config.AuthTestConfig;
 import com.yagubogu.checkin.domain.CheckIn;
 import com.yagubogu.checkin.domain.CheckInOrderFilter;
@@ -15,7 +21,6 @@ import com.yagubogu.checkin.dto.StadiumCheckInCountResponse;
 import com.yagubogu.checkin.dto.StadiumCheckInCountsResponse;
 import com.yagubogu.checkin.dto.TeamFanRateResponse;
 import com.yagubogu.checkin.dto.TeamFilter;
-import com.yagubogu.checkin.dto.VictoryFairyRank;
 import com.yagubogu.checkin.dto.VictoryFairyRankingResponses;
 import com.yagubogu.checkin.dto.VictoryFairyRankingResponses.VictoryFairyRankingResponse;
 import com.yagubogu.checkin.repository.CheckInRepository;
@@ -46,12 +51,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.Import;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatCode;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
-import static org.assertj.core.api.AssertionsForClassTypes.tuple;
-import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 @Import({AuthTestConfig.class, JpaAuditingConfig.class})
 @DataJpaTest
@@ -422,7 +421,7 @@ class CheckInServiceTest {
         checkInFavorite(uga, g3, g5, g6, g7);
 
         // when
-        VictoryFairyRankingResponses actual = checkInService.findVictoryFairyRankings(por.getId(), TeamFilter.ALL,
+        VictoryFairyRankingResponses actual = checkInService.findVictoryFairyRankings(duri.getId(), TeamFilter.ALL,
                 2025);
 
         // then
@@ -430,9 +429,10 @@ class CheckInServiceTest {
                     softAssertions.assertThat(actual.topRankings())
                             .extracting("nickname")
                             .containsExactly("밍트", "포르", "포라", "두리", "우가");
-                    softAssertions.assertThat(actual.myRanking().nickname()).isEqualTo("포르");
-                    softAssertions.assertThat(actual.myRanking().teamShortName()).isEqualTo("KIA");
-                    softAssertions.assertThat(actual.myRanking().winPercent()).isEqualTo(100.0);
+                    softAssertions.assertThat(actual.myRanking().nickname()).isEqualTo(duri.getNickname().getValue());
+                    softAssertions.assertThat(actual.myRanking().teamShortName()).isEqualTo(duri.getTeam().getShortName());
+                    softAssertions.assertThat(actual.myRanking().winPercent()).isEqualTo(0.0);
+                    softAssertions.assertThat(actual.myRanking().ranking()).isEqualTo(4);
                 }
         );
     }
@@ -549,7 +549,7 @@ class CheckInServiceTest {
 
         // then
         assertSoftly(softAssertions -> {
-            softAssertions.assertThat(actual.myRanking().ranking()).isEqualTo(0);
+            softAssertions.assertThat(actual.myRanking().ranking()).isEqualTo(1);
             softAssertions.assertThat(actual.myRanking().nickname()).isEqualTo(fora.getNickname().getValue());
             softAssertions.assertThat(actual.myRanking().teamShortName()).isEqualTo(fora.getTeam().getShortName());
             softAssertions.assertThat(actual.myRanking().winPercent()).isEqualTo(0.0);


### PR DESCRIPTION
## 📌 관련 이슈
- close #555 

## ✨ 변경 내용
- 내 랭킹 계산이 0~1사이의 베이즈 정리 값이 아니라, 100점 만점으로 계산한 승리요정 점수로 내 랭킹을 계산했었습니다

## 🎸 기타 참고 사항
- 스크린샷, 참고 링크, 추가 설명 등 (없으면 생략 가능)