### PR TITLE
fix: 승리 요정 승률 계산 버그, 직관 내역 조회 버그 수정

### DIFF
--- a/backend/src/main/java/com/yagubogu/checkin/repository/CustomCheckInRepositoryImpl.java
+++ b/backend/src/main/java/com/yagubogu/checkin/repository/CustomCheckInRepositoryImpl.java
@@ -1,8 +1,5 @@
 package com.yagubogu.checkin.repository;
 
-import static com.yagubogu.game.domain.QGame.game;
-import static com.yagubogu.member.domain.QMember.member;
-
 import com.querydsl.core.Tuple;
 import com.querydsl.core.types.ConstructorExpression;
 import com.querydsl.core.types.Expression;
@@ -720,7 +717,7 @@ public class CustomCheckInRepositoryImpl implements CustomCheckInRepository {
     }
 
     private BooleanExpression isMyTeamInGame() {
-        return member.team.eq(game.homeTeam)
-                .or(member.team.eq(game.awayTeam));
+        return MEMBER.team.eq(GAME.homeTeam)
+                .or(MEMBER.team.eq(GAME.awayTeam));
     }
 }

--- a/backend/src/main/java/com/yagubogu/checkin/service/CheckInService.java
+++ b/backend/src/main/java/com/yagubogu/checkin/service/CheckInService.java
@@ -176,7 +176,7 @@ public class CheckInService {
         int count = 1;
         List<VictoryFairyRankingResponse> topRankingResponses = new ArrayList<>();
         for (VictoryFairyRank rank : topRanking) {
-            double currentScore = Math.round(rank.score() * 100 * ROUND_FACTOR) / ROUND_FACTOR;
+            double currentScore = rank.score();
             if (previousScore != currentScore) {
                 ranking += count;
                 count = 1;
@@ -184,8 +184,13 @@ public class CheckInService {
                 count++;
             }
             double winPercent = Math.round(rank.winPercent() * ROUND_FACTOR) / ROUND_FACTOR;
-            topRankingResponses.add(new VictoryFairyRankingResponse(ranking, rank.nickname(),
-                    rank.profileImageUrl(), rank.teamShortName(), winPercent, currentScore));
+            topRankingResponses.add(new VictoryFairyRankingResponse(
+                    ranking, rank.nickname(),
+                    rank.profileImageUrl(),
+                    rank.teamShortName(),
+                    winPercent,
+                    Math.round(rank.score() * 100 * ROUND_FACTOR) / ROUND_FACTOR)
+            );
             previousScore = currentScore;
         }
         return topRankingResponses;

--- a/backend/src/test/java/com/yagubogu/checkin/service/CheckInServiceTest.java
+++ b/backend/src/test/java/com/yagubogu/checkin/service/CheckInServiceTest.java
@@ -563,16 +563,35 @@ class CheckInServiceTest {
         Member por = memberFactory.save(b -> b.team(samsung).nickname("포르"));
 
         LocalDate startDate = LocalDate.of(2025, 7, 21);
-        Game game = gameFactory.save(b -> b.stadium(stadiumJamsil)
+        Game game1 = gameFactory.save(b -> b.stadium(stadiumJamsil)
                 .homeTeam(kia)
                 .awayTeam(kt)
                 .homeScoreBoard(TestFixture.getHomeScoreBoardAbout(10))
                 .awayScoreBoard(TestFixture.getAwayScoreBoardAbout(1))
-                .date(startDate));
+                .homeScore(10)
+                .awayScore(1)
+                .date(startDate)
+                .gameState(GameState.COMPLETED)
+        );
+        Game game2 = gameFactory.save(b -> b.stadium(stadiumJamsil)
+                .homeTeam(samsung)
+                .awayTeam(kt)
+                .homeScoreBoard(TestFixture.getHomeScoreBoardAbout(10))
+                .awayScoreBoard(TestFixture.getAwayScoreBoardAbout(1))
+                .homeScore(10)
+                .awayScore(1)
+                .date(startDate)
+                .gameState(GameState.COMPLETED)
+        );
+
         checkInFactory.save(builder -> builder
                 .team(samsung)
                 .member(por)
-                .game(game)
+                .game(game1)
+        );
+        checkInFactory.save(builder -> builder.team(samsung)
+                .member(por)
+                .game(game2)
         );
 
         // when
@@ -586,7 +605,7 @@ class CheckInServiceTest {
                             .containsExactly("포르");
                     softAssertions.assertThat(actual.myRanking().nickname()).isEqualTo("포르");
                     softAssertions.assertThat(actual.myRanking().teamShortName()).isEqualTo("삼성");
-                    softAssertions.assertThat(actual.myRanking().winPercent()).isEqualTo(0.0);
+                    softAssertions.assertThat(actual.myRanking().winPercent()).isEqualTo(100.0);
                 }
         );
     }


### PR DESCRIPTION
## 📌 관련 이슈
- close #577
## ✨ 변경 내용
- 내 승률 계산 시 게임에 내팀이 포함됐는지 검사하는 로직 추가
- 승리요정 랭킹 승률 계산 시 게임에 내 팀이 포함됐는지 검사하는 로직 추가
- 취소된 경기를 반환 시 npe발생으로 인해 완료된 경기만 반환하도록 수정
- (추가) 승리 요정 랭킹 계산시 Top 랭킹은 백분율로 환산한 값으로, 내 랭킹은 베이즈 점수로 계산하던걸 둘 다 베이즈 점수로 계산하도록 수정

## 🎸 기타 참고 사항
- 스크린샷, 참고 링크, 추가 설명 등 (없으면 생략 가능)