### PR TITLE
feat: 직관 내역 기준 수정

### DIFF
--- a/backend/src/main/java/com/yagubogu/checkin/repository/CustomCheckInRepositoryImpl.java
+++ b/backend/src/main/java/com/yagubogu/checkin/repository/CustomCheckInRepositoryImpl.java
@@ -305,7 +305,7 @@ public class CustomCheckInRepositoryImpl implements CustomCheckInRepository {
         QScoreBoard homeScoreBoard = new QScoreBoard("homeScoreBoard");
         QScoreBoard awayScoreBoard = new QScoreBoard("awayScoreBoard");
 
-        BooleanExpression myTeamWinFilter = getMyTeamWinFilter(resultFilter, member, CHECK_IN);
+        BooleanExpression myTeamWinFilter = getMyTeamWinFilter(resultFilter, CHECK_IN);
         OrderSpecifier<LocalDate> order = getOrderByFilter(orderFilter, GAME);
         return jpaQueryFactory.select(Projections.constructor(
                         CheckInGameResponse.class,
@@ -326,8 +326,7 @@ public class CustomCheckInRepositoryImpl implements CustomCheckInRepository {
                 .where(
                         CHECK_IN.member.eq(member),
                         isBetweenYear(GAME, year),
-                        isFinished(),
-                        isMyCurrentFavorite(member, CHECK_IN),
+                        isFinished(), // 버저닝 후 삭제 예정(취소된 경기도 보여주도록)
                         myTeamWinFilter
                 ).orderBy(order)
                 .fetch();
@@ -675,7 +674,7 @@ public class CustomCheckInRepositoryImpl implements CustomCheckInRepository {
         return game.date.desc();
     }
 
-    private BooleanExpression getMyTeamWinFilter(CheckInResultFilter resultFilter, Member member, QCheckIn checkIn) {
+    private BooleanExpression getMyTeamWinFilter(CheckInResultFilter resultFilter, QCheckIn checkIn) {
         if (resultFilter == CheckInResultFilter.ALL) {
             return null;
         }


### PR DESCRIPTION
## 📌 관련 이슈
- close #580 

## ✨ 변경 내용
- 모든 직관 내역을 보여준다
- 승리한 경기 필터링 시, 당시 내가 응원하던 팀 기준으로 승리한 경기를 판단한다

## 🎸 기타 참고 사항
- 스크린샷, 참고 링크, 추가 설명 등 (없으면 생략 가능)