### PR TITLE
feat: 배지 화면 API 연동

### DIFF
--- a/android/app/src/main/java/com/yagubogu/data/datasource/member/MemberDataSource.kt
+++ b/android/app/src/main/java/com/yagubogu/data/datasource/member/MemberDataSource.kt
@@ -1,5 +1,6 @@
 package com.yagubogu.data.datasource.member
 
+import com.yagubogu.data.dto.response.member.BadgeResponse
 import com.yagubogu.data.dto.response.member.MemberFavoriteResponse
 import com.yagubogu.data.dto.response.member.MemberInfoResponse
 import com.yagubogu.data.dto.response.member.MemberNicknameResponse
@@ -17,4 +18,6 @@ interface MemberDataSource {
     suspend fun updateFavoriteTeam(team: Team): Result<MemberFavoriteResponse>
 
     suspend fun deleteMember(): Result<Unit>
+
+    suspend fun getBadges(): Result<BadgeResponse>
 }

--- a/android/app/src/main/java/com/yagubogu/data/datasource/member/MemberDataSource.kt
+++ b/android/app/src/main/java/com/yagubogu/data/datasource/member/MemberDataSource.kt
@@ -20,4 +20,6 @@ interface MemberDataSource {
     suspend fun deleteMember(): Result<Unit>
 
     suspend fun getBadges(): Result<BadgeResponse>
+
+    suspend fun patchRepresentativeBadge(badgeId: Long): Result<Unit>
 }

--- a/android/app/src/main/java/com/yagubogu/data/datasource/member/MemberRemoteDataSource.kt
+++ b/android/app/src/main/java/com/yagubogu/data/datasource/member/MemberRemoteDataSource.kt
@@ -49,4 +49,9 @@ class MemberRemoteDataSource(
         safeApiCall {
             memberApiService.getBadges()
         }
+
+    override suspend fun patchRepresentativeBadge(badgeId: Long): Result<Unit> =
+        safeApiCall {
+            memberApiService.patchRepresentativeBadge(badgeId)
+        }
 }

--- a/android/app/src/main/java/com/yagubogu/data/datasource/member/MemberRemoteDataSource.kt
+++ b/android/app/src/main/java/com/yagubogu/data/datasource/member/MemberRemoteDataSource.kt
@@ -2,6 +2,7 @@ package com.yagubogu.data.datasource.member
 
 import com.yagubogu.data.dto.request.member.MemberFavoriteRequest
 import com.yagubogu.data.dto.request.member.MemberNicknameRequest
+import com.yagubogu.data.dto.response.member.BadgeResponse
 import com.yagubogu.data.dto.response.member.MemberFavoriteResponse
 import com.yagubogu.data.dto.response.member.MemberInfoResponse
 import com.yagubogu.data.dto.response.member.MemberNicknameResponse
@@ -42,5 +43,10 @@ class MemberRemoteDataSource(
     override suspend fun deleteMember(): Result<Unit> =
         safeApiCall {
             memberApiService.deleteMember()
+        }
+
+    override suspend fun getBadges(): Result<BadgeResponse> =
+        safeApiCall {
+            memberApiService.getBadges()
         }
 }

--- a/android/app/src/main/java/com/yagubogu/data/dto/response/member/BadgeDto.kt
+++ b/android/app/src/main/java/com/yagubogu/data/dto/response/member/BadgeDto.kt
@@ -27,6 +27,7 @@ data class BadgeDto(
 ) {
     fun toPresentation(): BadgeUiModel =
         BadgeUiModel(
+            id = id,
             imageUrl = "TODO",
             name = name,
             description = description,

--- a/android/app/src/main/java/com/yagubogu/data/dto/response/member/BadgeDto.kt
+++ b/android/app/src/main/java/com/yagubogu/data/dto/response/member/BadgeDto.kt
@@ -19,7 +19,9 @@ data class BadgeDto(
     @SerialName("acquired")
     val acquired: Boolean,
     @SerialName("achievedAt")
-    val achievedAt: LocalDateTime,
+    val achievedAt: LocalDateTime?,
+    @SerialName("badgeImageUrl")
+    val badgeImageUrl: String,
     @SerialName("progressRate")
     val progressRate: Double,
     @SerialName("achievedRate")
@@ -28,12 +30,12 @@ data class BadgeDto(
     fun toPresentation(): BadgeUiModel =
         BadgeUiModel(
             id = id,
-            imageUrl = "TODO",
+            imageUrl = badgeImageUrl,
             name = name,
             description = description,
             isAcquired = acquired,
             achievedRate = achievedRate.toInt(),
-            achievedAt = achievedAt.date.toJavaLocalDate(),
+            achievedAt = achievedAt?.date?.toJavaLocalDate(),
             progressRate = progressRate,
         )
 }

--- a/android/app/src/main/java/com/yagubogu/data/dto/response/member/BadgeDto.kt
+++ b/android/app/src/main/java/com/yagubogu/data/dto/response/member/BadgeDto.kt
@@ -1,0 +1,38 @@
+package com.yagubogu.data.dto.response.member
+
+import com.yagubogu.ui.badge.model.BadgeUiModel
+import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.toJavaLocalDate
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class BadgeDto(
+    @SerialName("id")
+    val id: Long,
+    @SerialName("name")
+    val name: String,
+    @SerialName("description")
+    val description: String,
+    @SerialName("policy")
+    val policy: String,
+    @SerialName("acquired")
+    val acquired: Boolean,
+    @SerialName("achievedAt")
+    val achievedAt: LocalDateTime,
+    @SerialName("progressRate")
+    val progressRate: Double,
+    @SerialName("achievedRate")
+    val achievedRate: Double,
+) {
+    fun toPresentation(): BadgeUiModel =
+        BadgeUiModel(
+            imageUrl = "TODO",
+            name = name,
+            description = description,
+            isAcquired = acquired,
+            achievedRate = achievedRate.toInt(),
+            achievedAt = achievedAt.date.toJavaLocalDate(),
+            progressRate = progressRate,
+        )
+}

--- a/android/app/src/main/java/com/yagubogu/data/dto/response/member/BadgeResponse.kt
+++ b/android/app/src/main/java/com/yagubogu/data/dto/response/member/BadgeResponse.kt
@@ -1,0 +1,12 @@
+package com.yagubogu.data.dto.response.member
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class BadgeResponse(
+    @SerialName("representativeBadge")
+    val representativeBadge: RepresentativeBadgeDto,
+    @SerialName("badges")
+    val badges: List<BadgeDto>,
+)

--- a/android/app/src/main/java/com/yagubogu/data/dto/response/member/BadgeResponse.kt
+++ b/android/app/src/main/java/com/yagubogu/data/dto/response/member/BadgeResponse.kt
@@ -6,7 +6,7 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class BadgeResponse(
     @SerialName("representativeBadge")
-    val representativeBadge: RepresentativeBadgeDto,
+    val representativeBadge: RepresentativeBadgeDto?,
     @SerialName("badges")
     val badges: List<BadgeDto>,
 )

--- a/android/app/src/main/java/com/yagubogu/data/dto/response/member/RepresentativeBadgeDto.kt
+++ b/android/app/src/main/java/com/yagubogu/data/dto/response/member/RepresentativeBadgeDto.kt
@@ -1,0 +1,27 @@
+package com.yagubogu.data.dto.response.member
+
+import com.yagubogu.ui.badge.model.BadgeUiModel
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import java.time.LocalDate
+
+@Serializable
+data class RepresentativeBadgeDto(
+    @SerialName("id")
+    val id: Long,
+    @SerialName("name")
+    val name: String,
+    @SerialName("type")
+    val type: String,
+) {
+    fun toPresentation(): BadgeUiModel =
+        BadgeUiModel(
+            imageUrl = "TODO",
+            name = name,
+            description = "",
+            isAcquired = true,
+            achievedRate = 0,
+            achievedAt = LocalDate.now(),
+            progressRate = 0.0,
+        )
+}

--- a/android/app/src/main/java/com/yagubogu/data/dto/response/member/RepresentativeBadgeDto.kt
+++ b/android/app/src/main/java/com/yagubogu/data/dto/response/member/RepresentativeBadgeDto.kt
@@ -11,13 +11,15 @@ data class RepresentativeBadgeDto(
     val id: Long,
     @SerialName("name")
     val name: String,
-    @SerialName("type")
-    val type: String,
+    @SerialName("policy")
+    val policy: String,
+    @SerialName("badgeImageUrl")
+    val badgeImageUrl: String,
 ) {
     fun toPresentation(): BadgeUiModel =
         BadgeUiModel(
             id = id,
-            imageUrl = "TODO",
+            imageUrl = badgeImageUrl,
             name = name,
             description = "",
             isAcquired = true,

--- a/android/app/src/main/java/com/yagubogu/data/dto/response/member/RepresentativeBadgeDto.kt
+++ b/android/app/src/main/java/com/yagubogu/data/dto/response/member/RepresentativeBadgeDto.kt
@@ -16,6 +16,7 @@ data class RepresentativeBadgeDto(
 ) {
     fun toPresentation(): BadgeUiModel =
         BadgeUiModel(
+            id = id,
             imageUrl = "TODO",
             name = name,
             description = "",

--- a/android/app/src/main/java/com/yagubogu/data/repository/MemberDefaultRepository.kt
+++ b/android/app/src/main/java/com/yagubogu/data/repository/MemberDefaultRepository.kt
@@ -1,6 +1,8 @@
 package com.yagubogu.data.repository
 
 import com.yagubogu.data.datasource.member.MemberDataSource
+import com.yagubogu.data.dto.response.member.BadgeDto
+import com.yagubogu.data.dto.response.member.BadgeResponse
 import com.yagubogu.data.dto.response.member.MemberFavoriteResponse
 import com.yagubogu.data.dto.response.member.MemberInfoResponse
 import com.yagubogu.data.dto.response.member.MemberNicknameResponse
@@ -8,6 +10,8 @@ import com.yagubogu.data.network.TokenManager
 import com.yagubogu.domain.model.Team
 import com.yagubogu.domain.repository.MemberRepository
 import com.yagubogu.presentation.setting.MemberInfoItem
+import com.yagubogu.ui.badge.BadgeUiState
+import com.yagubogu.ui.badge.model.BadgeUiModel
 
 class MemberDefaultRepository(
     private val memberDataSource: MemberDataSource,
@@ -72,6 +76,15 @@ class MemberDefaultRepository(
     override suspend fun deleteMember(): Result<Unit> =
         memberDataSource.deleteMember().map {
             tokenManager.clearTokens()
+        }
+
+    override suspend fun getBadges(): Result<BadgeUiState> =
+        memberDataSource.getBadges().map { badgeResponse: BadgeResponse ->
+            val representativeBadge: BadgeUiModel =
+                badgeResponse.representativeBadge.toPresentation()
+            val badges: List<BadgeUiModel> =
+                badgeResponse.badges.map { badge: BadgeDto -> badge.toPresentation() }
+            BadgeUiState.Success(representativeBadge, badges)
         }
 
     override fun invalidateCache() {

--- a/android/app/src/main/java/com/yagubogu/data/repository/MemberDefaultRepository.kt
+++ b/android/app/src/main/java/com/yagubogu/data/repository/MemberDefaultRepository.kt
@@ -87,6 +87,8 @@ class MemberDefaultRepository(
             BadgeUiState.Success(representativeBadge, badges)
         }
 
+    override suspend fun patchRepresentativeBadge(badgeId: Long): Result<Unit> = memberDataSource.patchRepresentativeBadge(badgeId)
+
     override fun invalidateCache() {
         cachedNickname = null
         cachedFavoriteTeam = null

--- a/android/app/src/main/java/com/yagubogu/data/repository/MemberDefaultRepository.kt
+++ b/android/app/src/main/java/com/yagubogu/data/repository/MemberDefaultRepository.kt
@@ -80,8 +80,8 @@ class MemberDefaultRepository(
 
     override suspend fun getBadges(): Result<BadgeUiState> =
         memberDataSource.getBadges().map { badgeResponse: BadgeResponse ->
-            val representativeBadge: BadgeUiModel =
-                badgeResponse.representativeBadge.toPresentation()
+            val representativeBadge: BadgeUiModel? =
+                badgeResponse.representativeBadge?.toPresentation()
             val badges: List<BadgeUiModel> =
                 badgeResponse.badges.map { badge: BadgeDto -> badge.toPresentation() }
             BadgeUiState.Success(representativeBadge, badges)

--- a/android/app/src/main/java/com/yagubogu/data/service/MemberApiService.kt
+++ b/android/app/src/main/java/com/yagubogu/data/service/MemberApiService.kt
@@ -11,7 +11,6 @@ import retrofit2.http.Body
 import retrofit2.http.DELETE
 import retrofit2.http.GET
 import retrofit2.http.PATCH
-import retrofit2.http.POST
 import retrofit2.http.Path
 
 interface MemberApiService {
@@ -40,7 +39,7 @@ interface MemberApiService {
     @GET("/api/members/me/badges")
     suspend fun getBadges(): Response<BadgeResponse>
 
-    @POST("/api/members/me/badges/{badgeId}/representative")
+    @PATCH("/api/members/me/badges/{badgeId}/representative")
     suspend fun patchRepresentativeBadge(
         @Path("badgeId") badgeId: Long,
     ): Response<Unit>

--- a/android/app/src/main/java/com/yagubogu/data/service/MemberApiService.kt
+++ b/android/app/src/main/java/com/yagubogu/data/service/MemberApiService.kt
@@ -11,6 +11,8 @@ import retrofit2.http.Body
 import retrofit2.http.DELETE
 import retrofit2.http.GET
 import retrofit2.http.PATCH
+import retrofit2.http.POST
+import retrofit2.http.Path
 
 interface MemberApiService {
     @GET("/api/members/me")
@@ -37,4 +39,9 @@ interface MemberApiService {
 
     @GET("/api/members/me/badges")
     suspend fun getBadges(): Response<BadgeResponse>
+
+    @POST("/api/members/me/badges/{badgeId}/representative")
+    suspend fun patchRepresentativeBadge(
+        @Path("badgeId") badgeId: Long,
+    ): Response<Unit>
 }

--- a/android/app/src/main/java/com/yagubogu/data/service/MemberApiService.kt
+++ b/android/app/src/main/java/com/yagubogu/data/service/MemberApiService.kt
@@ -2,6 +2,7 @@ package com.yagubogu.data.service
 
 import com.yagubogu.data.dto.request.member.MemberFavoriteRequest
 import com.yagubogu.data.dto.request.member.MemberNicknameRequest
+import com.yagubogu.data.dto.response.member.BadgeResponse
 import com.yagubogu.data.dto.response.member.MemberFavoriteResponse
 import com.yagubogu.data.dto.response.member.MemberInfoResponse
 import com.yagubogu.data.dto.response.member.MemberNicknameResponse
@@ -33,4 +34,7 @@ interface MemberApiService {
 
     @DELETE("/api/members/me")
     suspend fun deleteMember(): Response<Unit>
+
+    @GET("/api/members/me/badges")
+    suspend fun getBadges(): Response<BadgeResponse>
 }

--- a/android/app/src/main/java/com/yagubogu/domain/repository/MemberRepository.kt
+++ b/android/app/src/main/java/com/yagubogu/domain/repository/MemberRepository.kt
@@ -2,6 +2,7 @@ package com.yagubogu.domain.repository
 
 import com.yagubogu.domain.model.Team
 import com.yagubogu.presentation.setting.MemberInfoItem
+import com.yagubogu.ui.badge.BadgeUiState
 
 interface MemberRepository {
     suspend fun getMemberInfo(): Result<MemberInfoItem>
@@ -15,6 +16,8 @@ interface MemberRepository {
     suspend fun updateFavoriteTeam(team: Team): Result<Unit>
 
     suspend fun deleteMember(): Result<Unit>
+
+    suspend fun getBadges(): Result<BadgeUiState>
 
     fun invalidateCache()
 }

--- a/android/app/src/main/java/com/yagubogu/domain/repository/MemberRepository.kt
+++ b/android/app/src/main/java/com/yagubogu/domain/repository/MemberRepository.kt
@@ -19,5 +19,7 @@ interface MemberRepository {
 
     suspend fun getBadges(): Result<BadgeUiState>
 
+    suspend fun patchRepresentativeBadge(badgeId: Long): Result<Unit>
+
     fun invalidateCache()
 }

--- a/android/app/src/main/java/com/yagubogu/ui/badge/BadgeActivity.kt
+++ b/android/app/src/main/java/com/yagubogu/ui/badge/BadgeActivity.kt
@@ -6,28 +6,23 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.activity.viewModels
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.ui.Modifier
+import com.yagubogu.YaguBoguApplication
 import com.yagubogu.ui.badge.component.BadgeScreen
-import com.yagubogu.ui.badge.model.BADGE_ACQUIRED_FIXTURE
-import com.yagubogu.ui.badge.model.BADGE_NOT_ACQUIRED_FIXTURE
 import com.yagubogu.ui.theme.YaguBoguTheme
 
 class BadgeActivity : ComponentActivity() {
+    val viewModel: BadgeViewModel by viewModels { BadgeViewModelFactory((application as YaguBoguApplication).memberRepository) }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
         setContent {
             YaguBoguTheme {
                 BadgeScreen(
-                    mainBadge = null,
-                    badgeList =
-                        listOf(
-                            BADGE_ACQUIRED_FIXTURE,
-                            BADGE_NOT_ACQUIRED_FIXTURE,
-                            BADGE_ACQUIRED_FIXTURE,
-                            BADGE_ACQUIRED_FIXTURE,
-                        ),
+                    badgeUiState = viewModel.badgeUiState.value,
                     onBackClick = { finish() },
                     onRegisterClick = {},
                     modifier = Modifier.fillMaxSize(),

--- a/android/app/src/main/java/com/yagubogu/ui/badge/BadgeActivity.kt
+++ b/android/app/src/main/java/com/yagubogu/ui/badge/BadgeActivity.kt
@@ -24,7 +24,7 @@ class BadgeActivity : ComponentActivity() {
                 BadgeScreen(
                     badgeUiState = viewModel.badgeUiState.value,
                     onBackClick = { finish() },
-                    onRegisterClick = {},
+                    onRegisterClick = { badgeId: Long -> viewModel.patchRepresentativeBadge(badgeId) },
                     modifier = Modifier.fillMaxSize(),
                 )
             }

--- a/android/app/src/main/java/com/yagubogu/ui/badge/BadgeUiState.kt
+++ b/android/app/src/main/java/com/yagubogu/ui/badge/BadgeUiState.kt
@@ -1,0 +1,12 @@
+package com.yagubogu.ui.badge
+
+import com.yagubogu.ui.badge.model.BadgeUiModel
+
+sealed class BadgeUiState {
+    object Loading : BadgeUiState()
+
+    data class Success(
+        val representativeBadge: BadgeUiModel,
+        val badges: List<BadgeUiModel>,
+    ) : BadgeUiState()
+}

--- a/android/app/src/main/java/com/yagubogu/ui/badge/BadgeUiState.kt
+++ b/android/app/src/main/java/com/yagubogu/ui/badge/BadgeUiState.kt
@@ -6,7 +6,7 @@ sealed class BadgeUiState {
     object Loading : BadgeUiState()
 
     data class Success(
-        val representativeBadge: BadgeUiModel,
+        val representativeBadge: BadgeUiModel?,
         val badges: List<BadgeUiModel>,
     ) : BadgeUiState()
 }

--- a/android/app/src/main/java/com/yagubogu/ui/badge/BadgeViewModel.kt
+++ b/android/app/src/main/java/com/yagubogu/ui/badge/BadgeViewModel.kt
@@ -1,0 +1,47 @@
+package com.yagubogu.ui.badge
+
+import androidx.compose.runtime.mutableStateOf
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.yagubogu.domain.repository.MemberRepository
+import com.yagubogu.ui.badge.model.BADGE_ACQUIRED_FIXTURE
+import com.yagubogu.ui.badge.model.BADGE_NOT_ACQUIRED_FIXTURE
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+
+class BadgeViewModel(
+    private val memberRepository: MemberRepository,
+) : ViewModel() {
+    var badgeUiState = mutableStateOf<BadgeUiState>(BadgeUiState.Loading)
+        private set
+
+    init {
+        fetchBadges()
+    }
+
+    // TODO API 배포 시 코드 수정
+    private fun fetchBadges() {
+//        viewModelScope.launch {
+//            val badgesResult: Result<BadgeUiState> = memberRepository.getBadges()
+//            badgesResult
+//                .onSuccess { badges: BadgeUiState ->
+//                    Timber.d("$badges")
+//                    badgeUiState.value = badges
+//                }.onFailure { exception: Throwable ->
+//                    Timber.w(exception, "API 호출 실패")
+//                }
+//        }
+        viewModelScope.launch {
+            delay(1000L)
+            badgeUiState.value =
+                BadgeUiState.Success(
+                    BADGE_NOT_ACQUIRED_FIXTURE,
+                    listOf(
+                        BADGE_ACQUIRED_FIXTURE,
+                        BADGE_NOT_ACQUIRED_FIXTURE,
+                        BADGE_ACQUIRED_FIXTURE,
+                    ),
+                )
+        }
+    }
+}

--- a/android/app/src/main/java/com/yagubogu/ui/badge/BadgeViewModel.kt
+++ b/android/app/src/main/java/com/yagubogu/ui/badge/BadgeViewModel.kt
@@ -21,6 +21,27 @@ class BadgeViewModel(
         fetchBadges()
     }
 
+    fun patchRepresentativeBadge(badgeId: Long) {
+        viewModelScope.launch {
+            val patchRepresentativeBadgeResult: Result<Unit> =
+                memberRepository.patchRepresentativeBadge(badgeId)
+            patchRepresentativeBadgeResult
+                .onSuccess {
+                    val currentBadgeUiState: BadgeUiState = badgeUiState.value
+
+                    if (currentBadgeUiState is BadgeUiState.Success) {
+                        val selectedBadge = currentBadgeUiState.badges.find { it.id == badgeId }
+                        selectedBadge?.let { badge: BadgeUiModel ->
+                            badgeUiState.value =
+                                currentBadgeUiState.copy(representativeBadge = badge)
+                        }
+                    }
+                }.onFailure { exception: Throwable ->
+                    Timber.w(exception, "API 호출 실패")
+                }
+        }
+    }
+
     // TODO API 배포 시 코드 수정
     private fun fetchBadges() {
 //        viewModelScope.launch {
@@ -44,27 +65,6 @@ class BadgeViewModel(
                         BADGE_ACQUIRED_FIXTURE,
                     ),
                 )
-        }
-    }
-
-    private fun patchRepresentativeBadge(badgeId: Long) {
-        viewModelScope.launch {
-            val patchRepresentativeBadgeResult: Result<Unit> =
-                memberRepository.patchRepresentativeBadge(badgeId)
-            patchRepresentativeBadgeResult
-                .onSuccess {
-                    val currentBadgeUiState: BadgeUiState = badgeUiState.value
-
-                    if (currentBadgeUiState is BadgeUiState.Success) {
-                        val selectedBadge = currentBadgeUiState.badges.find { it.id == badgeId }
-                        selectedBadge?.let { badge: BadgeUiModel ->
-                            badgeUiState.value =
-                                currentBadgeUiState.copy(representativeBadge = badge)
-                        }
-                    }
-                }.onFailure { exception: Throwable ->
-                    Timber.w(exception, "API 호출 실패")
-                }
         }
     }
 }

--- a/android/app/src/main/java/com/yagubogu/ui/badge/BadgeViewModel.kt
+++ b/android/app/src/main/java/com/yagubogu/ui/badge/BadgeViewModel.kt
@@ -4,10 +4,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.yagubogu.domain.repository.MemberRepository
-import com.yagubogu.ui.badge.model.BADGE_ACQUIRED_FIXTURE
-import com.yagubogu.ui.badge.model.BADGE_NOT_ACQUIRED_FIXTURE
 import com.yagubogu.ui.badge.model.BadgeUiModel
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import timber.log.Timber
 
@@ -42,29 +39,16 @@ class BadgeViewModel(
         }
     }
 
-    // TODO API 배포 시 코드 수정
     private fun fetchBadges() {
-//        viewModelScope.launch {
-//            val badgesResult: Result<BadgeUiState> = memberRepository.getBadges()
-//            badgesResult
-//                .onSuccess { badges: BadgeUiState ->
-//                    Timber.d("$badges")
-//                    badgeUiState.value = badges
-//                }.onFailure { exception: Throwable ->
-//                    Timber.w(exception, "API 호출 실패")
-//                }
-//        }
         viewModelScope.launch {
-            delay(1000L)
-            badgeUiState.value =
-                BadgeUiState.Success(
-                    BADGE_NOT_ACQUIRED_FIXTURE,
-                    listOf(
-                        BADGE_ACQUIRED_FIXTURE,
-                        BADGE_NOT_ACQUIRED_FIXTURE,
-                        BADGE_ACQUIRED_FIXTURE,
-                    ),
-                )
+            val badgesResult: Result<BadgeUiState> = memberRepository.getBadges()
+            badgesResult
+                .onSuccess { badges: BadgeUiState ->
+                    Timber.d("$badges")
+                    badgeUiState.value = badges
+                }.onFailure { exception: Throwable ->
+                    Timber.w(exception, "API 호출 실패")
+                }
         }
     }
 }

--- a/android/app/src/main/java/com/yagubogu/ui/badge/BadgeViewModelFactory.kt
+++ b/android/app/src/main/java/com/yagubogu/ui/badge/BadgeViewModelFactory.kt
@@ -1,0 +1,17 @@
+package com.yagubogu.ui.badge
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import com.yagubogu.domain.repository.MemberRepository
+
+class BadgeViewModelFactory(
+    private val memberRepository: MemberRepository,
+) : ViewModelProvider.Factory {
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        if (modelClass.isAssignableFrom(BadgeViewModel::class.java)) {
+            @Suppress("UNCHECKED_CAST")
+            return BadgeViewModel(memberRepository) as T
+        }
+        throw IllegalArgumentException()
+    }
+}

--- a/android/app/src/main/java/com/yagubogu/ui/badge/component/Badge.kt
+++ b/android/app/src/main/java/com/yagubogu/ui/badge/component/Badge.kt
@@ -2,26 +2,37 @@ package com.yagubogu.ui.badge.component
 
 import androidx.annotation.DrawableRes
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.ColorMatrix
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil3.compose.AsyncImage
+import coil3.request.ImageRequest
+import coil3.request.crossfade
 import com.yagubogu.R
 import com.yagubogu.ui.badge.model.BadgeUiModel
 import com.yagubogu.ui.theme.PretendardSemiBold
 import com.yagubogu.ui.util.noRippleClickable
+import com.yagubogu.ui.util.shimmerLoading
 
 @Composable
 fun Badge(
@@ -33,24 +44,43 @@ fun Badge(
         horizontalAlignment = Alignment.CenterHorizontally,
         modifier = modifier.noRippleClickable(onClick),
     ) {
-        AsyncImage(
-            model = badge.imageUrl,
-            contentDescription = stringResource(R.string.badge_image_description),
-            colorFilter =
-                if (!badge.isAcquired) {
-                    ColorFilter.colorMatrix(
-                        ColorMatrix().apply {
-                            setToSaturation(
-                                0.2f,
-                            )
-                        },
-                    )
-                } else {
-                    null
-                },
-            placeholder = painterResource(R.drawable.img_badge_lock),
-            modifier = Modifier.size(140.dp),
-        )
+        var isLoading by remember { mutableStateOf(true) }
+
+        Box(
+            modifier =
+                Modifier
+                    .size(140.dp)
+                    .clip(RoundedCornerShape(12.dp)),
+        ) {
+            AsyncImage(
+                model =
+                    ImageRequest
+                        .Builder(LocalContext.current)
+                        .data(badge.imageUrl)
+                        .crossfade(true)
+                        .build(),
+                contentDescription = stringResource(R.string.badge_image_description),
+                colorFilter =
+                    if (!badge.isAcquired) {
+                        ColorFilter.colorMatrix(ColorMatrix().apply { setToSaturation(0.2f) })
+                    } else {
+                        null
+                    },
+                onSuccess = { isLoading = false },
+                onError = { isLoading = false },
+                modifier = Modifier.matchParentSize(),
+            )
+
+            if (isLoading) {
+                Box(
+                    modifier =
+                        Modifier
+                            .matchParentSize()
+                            .shimmerLoading(),
+                )
+            }
+        }
+
         Spacer(modifier = Modifier.height(10.dp))
         Text(
             text = badge.name,

--- a/android/app/src/main/java/com/yagubogu/ui/badge/component/Badge.kt
+++ b/android/app/src/main/java/com/yagubogu/ui/badge/component/Badge.kt
@@ -62,7 +62,7 @@ fun Badge(
                 contentDescription = stringResource(R.string.badge_image_description),
                 colorFilter =
                     if (!badge.isAcquired) {
-                        ColorFilter.colorMatrix(ColorMatrix().apply { setToSaturation(0.2f) })
+                        ColorFilter.colorMatrix(ColorMatrix().apply { setToSaturation(0.1f) })
                     } else {
                         null
                     },

--- a/android/app/src/main/java/com/yagubogu/ui/badge/component/BadgeBottomSheet.kt
+++ b/android/app/src/main/java/com/yagubogu/ui/badge/component/BadgeBottomSheet.kt
@@ -43,7 +43,7 @@ import com.yagubogu.ui.theme.White
 @Composable
 fun BadgeBottomSheet(
     badge: BadgeUiModel,
-    onRegisterClick: () -> Unit,
+    onRegisterClick: (Long) -> Unit,
     onDismiss: () -> Unit,
     modifier: Modifier = Modifier,
     sheetState: SheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
@@ -84,7 +84,7 @@ fun BadgeBottomSheet(
             Spacer(modifier = Modifier.height(30.dp))
             if (badge.isAcquired) {
                 Button(
-                    onClick = onRegisterClick,
+                    onClick = { onRegisterClick(badge.id) },
                     colors =
                         ButtonColors(
                             containerColor = Primary500,

--- a/android/app/src/main/java/com/yagubogu/ui/badge/component/BadgeBottomSheet.kt
+++ b/android/app/src/main/java/com/yagubogu/ui/badge/component/BadgeBottomSheet.kt
@@ -105,7 +105,7 @@ fun BadgeBottomSheet(
                     text =
                         stringResource(
                             R.string.badge_achieved_date,
-                            badge.achievedAt.format(DateFormatter.yyyyMMdd),
+                            badge.achievedAt?.format(DateFormatter.yyyyMMdd) ?: "",
                         ),
                     style = PretendardRegular12,
                     color = Gray500,

--- a/android/app/src/main/java/com/yagubogu/ui/badge/component/BadgeBottomSheet.kt
+++ b/android/app/src/main/java/com/yagubogu/ui/badge/component/BadgeBottomSheet.kt
@@ -30,6 +30,7 @@ import com.yagubogu.presentation.util.DateFormatter
 import com.yagubogu.ui.badge.model.BADGE_NOT_ACQUIRED_FIXTURE
 import com.yagubogu.ui.badge.model.BadgeUiModel
 import com.yagubogu.ui.theme.Gray300
+import com.yagubogu.ui.theme.Gray400
 import com.yagubogu.ui.theme.Gray500
 import com.yagubogu.ui.theme.PretendardBold12
 import com.yagubogu.ui.theme.PretendardBold16
@@ -43,6 +44,7 @@ import com.yagubogu.ui.theme.White
 @Composable
 fun BadgeBottomSheet(
     badge: BadgeUiModel,
+    isEnabled: Boolean,
     onRegisterClick: (Long) -> Unit,
     onDismiss: () -> Unit,
     modifier: Modifier = Modifier,
@@ -85,11 +87,12 @@ fun BadgeBottomSheet(
             if (badge.isAcquired) {
                 Button(
                     onClick = { onRegisterClick(badge.id) },
+                    enabled = isEnabled,
                     colors =
                         ButtonColors(
                             containerColor = Primary500,
                             contentColor = White,
-                            disabledContainerColor = Primary500,
+                            disabledContainerColor = Gray400,
                             disabledContentColor = White,
                         ),
                     shape = RoundedCornerShape(12.dp),
@@ -97,7 +100,14 @@ fun BadgeBottomSheet(
                     modifier = Modifier.fillMaxWidth(),
                 ) {
                     Text(
-                        text = stringResource(R.string.badge_register_main_badge),
+                        text =
+                            stringResource(
+                                if (isEnabled) {
+                                    R.string.badge_register_main_badge
+                                } else {
+                                    R.string.badge_already_used_badge
+                                },
+                            ),
                         style = PretendardBold16,
                     )
                 }
@@ -146,6 +156,7 @@ fun BadgeBottomSheet(
 private fun BadgeBottomSheetPreview() {
     BadgeBottomSheet(
         badge = BADGE_NOT_ACQUIRED_FIXTURE,
+        isEnabled = true,
         onRegisterClick = {},
         onDismiss = {},
         sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),

--- a/android/app/src/main/java/com/yagubogu/ui/badge/component/BadgeScreen.kt
+++ b/android/app/src/main/java/com/yagubogu/ui/badge/component/BadgeScreen.kt
@@ -42,7 +42,7 @@ private const val COLUMN_SIZE = 2
 fun BadgeScreen(
     badgeUiState: BadgeUiState,
     onBackClick: () -> Unit,
-    onRegisterClick: () -> Unit,
+    onRegisterClick: (Long) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Scaffold(
@@ -63,7 +63,7 @@ fun BadgeScreen(
             is BadgeUiState.Success -> {
                 BadgeSuccessContent(
                     badgeUiState = badgeUiState,
-                    onRegisterClick = onRegisterClick,
+                    onRegisterClick = { badgeId: Long -> onRegisterClick(badgeId) },
                     modifier =
                         Modifier
                             .padding(innerPadding)
@@ -78,7 +78,7 @@ fun BadgeScreen(
 @Composable
 private fun BadgeSuccessContent(
     badgeUiState: BadgeUiState.Success,
-    onRegisterClick: () -> Unit,
+    onRegisterClick: (Long) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val selectedBadge = rememberSaveable { mutableStateOf<BadgeUiModel?>(null) }
@@ -86,8 +86,8 @@ private fun BadgeSuccessContent(
     selectedBadge.value?.let { badge ->
         BadgeBottomSheet(
             badge = badge,
-            onRegisterClick = {
-                onRegisterClick()
+            onRegisterClick = { badgeId: Long ->
+                onRegisterClick(badgeId)
                 selectedBadge.value = null
             },
             onDismiss = { selectedBadge.value = null },

--- a/android/app/src/main/java/com/yagubogu/ui/badge/component/BadgeScreen.kt
+++ b/android/app/src/main/java/com/yagubogu/ui/badge/component/BadgeScreen.kt
@@ -1,5 +1,6 @@
 package com.yagubogu.ui.badge.component
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -33,6 +34,7 @@ import com.yagubogu.ui.badge.model.BadgeUiModel
 import com.yagubogu.ui.theme.Gray050
 import com.yagubogu.ui.theme.Gray300
 import com.yagubogu.ui.theme.PretendardBold20
+import com.yagubogu.ui.theme.White
 import com.yagubogu.ui.util.shimmerLoading
 
 private const val COLUMN_SIZE = 2
@@ -48,7 +50,7 @@ fun BadgeScreen(
     Scaffold(
         topBar = { BadgeToolbar(onBackClick = onBackClick) },
         containerColor = Gray050,
-        modifier = modifier,
+        modifier = modifier.background(Gray300),
     ) { innerPadding: PaddingValues ->
         when (badgeUiState) {
             is BadgeUiState.Loading -> {
@@ -56,7 +58,9 @@ fun BadgeScreen(
                     modifier =
                         Modifier
                             .padding(innerPadding)
-                            .padding(start = 20.dp, end = 20.dp, bottom = 20.dp),
+                            .padding(start = 20.dp, end = 20.dp, bottom = 20.dp)
+                            .clip(RoundedCornerShape(12.dp))
+                            .background(White),
                 )
             }
 
@@ -67,7 +71,9 @@ fun BadgeScreen(
                     modifier =
                         Modifier
                             .padding(innerPadding)
-                            .padding(start = 20.dp, end = 20.dp, bottom = 20.dp),
+                            .padding(start = 20.dp, end = 20.dp, bottom = 20.dp)
+                            .clip(RoundedCornerShape(12.dp))
+                            .background(White),
                 )
             }
         }
@@ -105,20 +111,21 @@ private fun BadgeSuccessContent(
                 modifier =
                     Modifier
                         .fillMaxWidth()
-                        .padding(top = 20.dp),
+                        .padding(top = 20.dp, start = 20.dp, end = 20.dp),
             )
         }
         item(span = { GridItemSpan(COLUMN_SIZE) }) {
             HorizontalDivider(
                 thickness = 0.4.dp,
                 color = Gray300,
-                modifier = Modifier.padding(vertical = 10.dp),
+                modifier = Modifier.padding(vertical = 10.dp, horizontal = 20.dp),
             )
         }
         item(span = { GridItemSpan(COLUMN_SIZE) }) {
             Text(
                 text = stringResource(R.string.badge_list_title),
                 style = PretendardBold20,
+                modifier = Modifier.padding(start = 20.dp),
             )
         }
         items(badgeUiState.badges.size) { index ->
@@ -141,13 +148,12 @@ private fun BadgeLoadingContent(modifier: Modifier = Modifier) {
         item(span = { GridItemSpan(COLUMN_SIZE) }) {
             Column(
                 modifier =
-                    Modifier
-                        .fillMaxWidth()
-                        .padding(top = 20.dp),
+                    Modifier.fillMaxWidth(),
             ) {
                 Text(
                     text = stringResource(R.string.badge_main_badge_title),
                     style = PretendardBold20,
+                    modifier = Modifier.padding(20.dp),
                 )
                 Box(
                     modifier =
@@ -161,13 +167,14 @@ private fun BadgeLoadingContent(modifier: Modifier = Modifier) {
             HorizontalDivider(
                 thickness = 0.4.dp,
                 color = Gray300,
-                modifier = Modifier.padding(vertical = 10.dp),
+                modifier = Modifier.padding(vertical = 10.dp, horizontal = 20.dp),
             )
         }
         item(span = { GridItemSpan(COLUMN_SIZE) }) {
             Text(
                 text = stringResource(R.string.badge_list_title),
                 style = PretendardBold20,
+                modifier = Modifier.padding(start = 20.dp),
             )
         }
         items(6) {

--- a/android/app/src/main/java/com/yagubogu/ui/badge/component/BadgeScreen.kt
+++ b/android/app/src/main/java/com/yagubogu/ui/badge/component/BadgeScreen.kt
@@ -103,29 +103,26 @@ private fun BadgeSuccessContent(
     LazyVerticalGrid(
         columns = GridCells.Fixed(COLUMN_SIZE),
         verticalArrangement = Arrangement.spacedBy(20.dp),
-        modifier = modifier,
+        modifier = modifier.padding(20.dp),
     ) {
         item(span = { GridItemSpan(COLUMN_SIZE) }) {
             MainBadgeCard(
                 badge = badgeUiState.representativeBadge,
                 modifier =
                     Modifier
-                        .fillMaxWidth()
-                        .padding(top = 20.dp, start = 20.dp, end = 20.dp),
+                        .fillMaxWidth(),
             )
         }
         item(span = { GridItemSpan(COLUMN_SIZE) }) {
             HorizontalDivider(
                 thickness = 0.4.dp,
                 color = Gray300,
-                modifier = Modifier.padding(vertical = 10.dp, horizontal = 20.dp),
             )
         }
         item(span = { GridItemSpan(COLUMN_SIZE) }) {
             Text(
                 text = stringResource(R.string.badge_list_title),
                 style = PretendardBold20,
-                modifier = Modifier.padding(start = 20.dp),
             )
         }
         items(badgeUiState.badges.size) { index ->
@@ -143,7 +140,8 @@ private fun BadgeLoadingContent(modifier: Modifier = Modifier) {
     LazyVerticalGrid(
         columns = GridCells.Fixed(COLUMN_SIZE),
         verticalArrangement = Arrangement.spacedBy(20.dp),
-        modifier = modifier,
+        horizontalArrangement = Arrangement.spacedBy(20.dp),
+        modifier = modifier.padding(20.dp),
     ) {
         item(span = { GridItemSpan(COLUMN_SIZE) }) {
             Column(
@@ -153,12 +151,11 @@ private fun BadgeLoadingContent(modifier: Modifier = Modifier) {
                 Text(
                     text = stringResource(R.string.badge_main_badge_title),
                     style = PretendardBold20,
-                    modifier = Modifier.padding(20.dp),
                 )
                 Box(
                     modifier =
                         shimmeringBadgeModifier
-                            .sizeIn(maxWidth = 120.dp)
+                            .sizeIn(maxWidth = 140.dp)
                             .align(Alignment.CenterHorizontally),
                 )
             }
@@ -167,14 +164,12 @@ private fun BadgeLoadingContent(modifier: Modifier = Modifier) {
             HorizontalDivider(
                 thickness = 0.4.dp,
                 color = Gray300,
-                modifier = Modifier.padding(vertical = 10.dp, horizontal = 20.dp),
             )
         }
         item(span = { GridItemSpan(COLUMN_SIZE) }) {
             Text(
                 text = stringResource(R.string.badge_list_title),
                 style = PretendardBold20,
-                modifier = Modifier.padding(start = 20.dp),
             )
         }
         items(6) {
@@ -185,8 +180,8 @@ private fun BadgeLoadingContent(modifier: Modifier = Modifier) {
 
 private val shimmeringBadgeModifier =
     Modifier
-        .padding(start = 20.dp, end = 20.dp, bottom = 20.dp)
-        .size(160.dp)
+        .padding(bottom = 10.dp)
+        .size(140.dp)
         .clip(RoundedCornerShape(12.dp))
         .shimmerLoading()
 

--- a/android/app/src/main/java/com/yagubogu/ui/badge/component/BadgeScreen.kt
+++ b/android/app/src/main/java/com/yagubogu/ui/badge/component/BadgeScreen.kt
@@ -5,7 +5,9 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.sizeIn
@@ -90,8 +92,11 @@ private fun BadgeSuccessContent(
     val selectedBadge = rememberSaveable { mutableStateOf<BadgeUiModel?>(null) }
 
     selectedBadge.value?.let { badge ->
+        val isEnabled = badge.id != (badgeUiState.representativeBadge?.id ?: -1)
+
         BadgeBottomSheet(
             badge = badge,
+            isEnabled = isEnabled,
             onRegisterClick = { badgeId: Long ->
                 onRegisterClick(badgeId)
                 selectedBadge.value = null
@@ -103,14 +108,15 @@ private fun BadgeSuccessContent(
     LazyVerticalGrid(
         columns = GridCells.Fixed(COLUMN_SIZE),
         verticalArrangement = Arrangement.spacedBy(20.dp),
-        modifier = modifier.padding(20.dp),
+        modifier = modifier.padding(horizontal = 20.dp),
     ) {
         item(span = { GridItemSpan(COLUMN_SIZE) }) {
             MainBadgeCard(
                 badge = badgeUiState.representativeBadge,
                 modifier =
                     Modifier
-                        .fillMaxWidth(),
+                        .fillMaxWidth()
+                        .padding(top = 20.dp),
             )
         }
         item(span = { GridItemSpan(COLUMN_SIZE) }) {
@@ -132,6 +138,9 @@ private fun BadgeSuccessContent(
                 modifier = Modifier.padding(bottom = 10.dp),
             )
         }
+        item(span = { GridItemSpan(COLUMN_SIZE) }) {
+            Spacer(modifier = Modifier.height(20.dp))
+        }
     }
 }
 
@@ -141,12 +150,11 @@ private fun BadgeLoadingContent(modifier: Modifier = Modifier) {
         columns = GridCells.Fixed(COLUMN_SIZE),
         verticalArrangement = Arrangement.spacedBy(20.dp),
         horizontalArrangement = Arrangement.spacedBy(20.dp),
-        modifier = modifier.padding(20.dp),
+        modifier = modifier.padding(horizontal = 20.dp),
     ) {
         item(span = { GridItemSpan(COLUMN_SIZE) }) {
             Column(
-                modifier =
-                    Modifier.fillMaxWidth(),
+                modifier = Modifier.fillMaxWidth().padding(top = 20.dp),
             ) {
                 Text(
                     text = stringResource(R.string.badge_main_badge_title),
@@ -174,6 +182,9 @@ private fun BadgeLoadingContent(modifier: Modifier = Modifier) {
         }
         items(6) {
             Box(modifier = shimmeringBadgeModifier)
+        }
+        item {
+            Spacer(modifier = Modifier.height(20.dp))
         }
     }
 }

--- a/android/app/src/main/java/com/yagubogu/ui/badge/model/BadgeFixture.kt
+++ b/android/app/src/main/java/com/yagubogu/ui/badge/model/BadgeFixture.kt
@@ -4,6 +4,7 @@ import java.time.LocalDate
 
 val BADGE_ACQUIRED_FIXTURE =
     BadgeUiModel(
+        id = 0,
         imageUrl = "https://i.postimg.cc/jsKmwFjc/5.png",
         name = "공포의 주둥아리",
         description = "첫 직관 인증 기념 배지예요! \uD83C\uDF89\n\n이제 당신의 직관 여정이 본격적으로 시작돼요.\n\n앞으로도 다양한 순간들을 기록하며,\n멋진 야구 이야기를 만들어가 보세요!",
@@ -15,6 +16,7 @@ val BADGE_ACQUIRED_FIXTURE =
 
 val BADGE_NOT_ACQUIRED_FIXTURE =
     BadgeUiModel(
+        id = 0,
         imageUrl = "https://i.postimg.cc/jsKmwFjc/5.png",
         name = "공포의 주둥아리",
         description = "첫 직관 인증 기념 배지예요! \uD83C\uDF89\n\n이제 당신의 직관 여정이 본격적으로 시작돼요.\n\n앞으로도 다양한 순간들을 기록하며,\n멋진 야구 이야기를 만들어가 보세요!",

--- a/android/app/src/main/java/com/yagubogu/ui/badge/model/BadgeUiModel.kt
+++ b/android/app/src/main/java/com/yagubogu/ui/badge/model/BadgeUiModel.kt
@@ -6,6 +6,7 @@ import java.time.LocalDate
 
 @Parcelize
 data class BadgeUiModel(
+    val id: Long,
     val imageUrl: String,
     val name: String,
     val description: String,

--- a/android/app/src/main/java/com/yagubogu/ui/badge/model/BadgeUiModel.kt
+++ b/android/app/src/main/java/com/yagubogu/ui/badge/model/BadgeUiModel.kt
@@ -12,6 +12,6 @@ data class BadgeUiModel(
     val description: String,
     val isAcquired: Boolean,
     val achievedRate: Int,
-    val achievedAt: LocalDate,
+    val achievedAt: LocalDate?,
     val progressRate: Double,
 ) : Parcelable

--- a/android/app/src/main/java/com/yagubogu/ui/util/ModifierExt.kt
+++ b/android/app/src/main/java/com/yagubogu/ui/util/ModifierExt.kt
@@ -1,10 +1,20 @@
 package com.yagubogu.ui.util
 
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
 
 fun Modifier.noRippleClickable(onClick: () -> Unit): Modifier =
     composed {
@@ -13,5 +23,45 @@ fun Modifier.noRippleClickable(onClick: () -> Unit): Modifier =
             interactionSource = remember { MutableInteractionSource() },
         ) {
             onClick()
+        }
+    }
+
+fun Modifier.shimmerLoading(): Modifier =
+    composed {
+        // 무한 반복 애니메이션 정의
+        val transition = rememberInfiniteTransition(label = "shimmerTransition")
+        val translateAnim =
+            transition.animateFloat(
+                initialValue = 0f,
+                targetValue = 1000f, // 이동 범위 (size에 맞게 충분히 크게 설정)
+                animationSpec =
+                    infiniteRepeatable(
+                        animation =
+                            tween(
+                                durationMillis = 1200,
+                                easing = LinearEasing,
+                            ),
+                        repeatMode = RepeatMode.Restart,
+                    ),
+                label = "shimmerAnim",
+            )
+
+        // Shimmer 색상 (회색 → 밝은 회색 → 회색)
+        val shimmerColors =
+            listOf(
+                Color.LightGray.copy(alpha = 0.6f),
+                Color.LightGray.copy(alpha = 0.2f),
+                Color.LightGray.copy(alpha = 0.6f),
+            )
+
+        drawWithContent {
+            // Shimmer 효과 브러시
+            val brush =
+                Brush.linearGradient(
+                    colors = shimmerColors,
+                    start = Offset(translateAnim.value - size.width, 0f),
+                    end = Offset(translateAnim.value, size.height),
+                )
+            drawRect(brush = brush)
         }
     }

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -133,6 +133,7 @@
     <string name="badge_empty_badge_message">대표 배지를 선택해 주세요</string>
     <string name="badge_list_title">배지 목록</string>
     <string name="badge_register_main_badge">대표 배지로 사용하기</string>
+    <string name="badge_already_used_badge">이미 사용 중인 배지예요</string>"
     <string name="badge_achieved_rate_message">%의 사용자가 획득했어요</string>
     <string name="badge_achieved_date">획득한 날: %s</string>
     <string name="badge_progress_rate">달성률: %.1f%%</string>


### PR DESCRIPTION
## 📌 관련 이슈
- close #599 

## ✨ 변경 내용
- 배지 조회 API 연동 : `/api/members/me/badges`
- 대표 배지 설정 API 연동 : `/api/members/me/badges/{badgeId}/representative` 
- 배지 화면 로딩 스켈레톤 추가

## 🎸 기타 참고 사항
- 스크린샷, 참고 링크, 추가 설명 등 (없으면 생략 가능)

https://github.com/user-attachments/assets/c82d0f4a-52c4-4671-8a96-f0c7bee94354

