### PR TITLE
feat: 취소된 경기도 직관 내역에 포함 (#653)

### DIFF
--- a/backend/src/main/java/com/yagubogu/checkin/repository/CustomCheckInRepositoryImpl.java
+++ b/backend/src/main/java/com/yagubogu/checkin/repository/CustomCheckInRepositoryImpl.java
@@ -64,7 +64,7 @@ public class CustomCheckInRepositoryImpl implements CustomCheckInRepository {
                                 drawExpr.sum(),
                                 loseExpr.sum()
                         )).from(CHECK_IN)
-                .join(CHECK_IN.game, CustomCheckInRepositoryImpl.GAME).on(isFinished())
+                .join(CHECK_IN.game, CustomCheckInRepositoryImpl.GAME).on(isComplete())
                 .where(
                         CHECK_IN.member.eq(member),
                         GAME.date.between(start, end)
@@ -117,7 +117,7 @@ public class CustomCheckInRepositoryImpl implements CustomCheckInRepository {
         Tuple tuple = jpaQueryFactory.select(w, n)
                 .from(MEMBER)
                 .leftJoin(CHECK_IN).on(CHECK_IN.member.eq(MEMBER), isFavoriteTeam())
-                .leftJoin(GAME).on(CHECK_IN.game.eq(GAME), isFinished(), isBetweenYear(year))
+                .leftJoin(GAME).on(CHECK_IN.game.eq(GAME), isComplete(), isBetweenYear(year))
                 .where(isMemberNotDeleted()).fetchOne();
 
         long winCounts =
@@ -178,7 +178,7 @@ public class CustomCheckInRepositoryImpl implements CustomCheckInRepository {
                                 MEMBER.team.shortName, safeWinPercent))
                 .from(MEMBER)
                 .join(CHECK_IN).on(CHECK_IN.member.eq(MEMBER), isFavoriteTeam())
-                .leftJoin(GAME).on(CHECK_IN.game.eq(GAME), isFinished(), isBetweenYear(year), isMyTeamInGame())
+                .leftJoin(GAME).on(CHECK_IN.game.eq(GAME), isComplete(), isBetweenYear(year), isMyTeamInGame())
                 .leftJoin(TEAM).on(MEMBER.team.eq(TEAM))
                 .where(isMemberNotDeleted(), filterByTeam(teamFilter))
                 .groupBy(MEMBER.id, MEMBER.nickname, MEMBER.imageUrl, MEMBER.team.shortName)
@@ -215,7 +215,7 @@ public class CustomCheckInRepositoryImpl implements CustomCheckInRepository {
                                 MEMBER.team.shortName, safeWinPercent))
                 .from(MEMBER)
                 .join(CHECK_IN).on(CHECK_IN.member.eq(MEMBER), isFavoriteTeam())
-                .leftJoin(GAME).on(CHECK_IN.game.eq(GAME), isFinished(), isBetweenYear(year), isMyTeamInGame())
+                .leftJoin(GAME).on(CHECK_IN.game.eq(GAME), isComplete(), isBetweenYear(year), isMyTeamInGame())
                 .leftJoin(TEAM).on(MEMBER.team.eq(TEAM))
                 .where(
                         MEMBER.eq(targetMember),
@@ -253,7 +253,7 @@ public class CustomCheckInRepositoryImpl implements CustomCheckInRepository {
         return jpaQueryFactory.selectOne()
                 .from(MEMBER)
                 .leftJoin(CHECK_IN).on(CHECK_IN.member.eq(MEMBER))
-                .leftJoin(GAME).on(CHECK_IN.game.eq(GAME), isFinished(), isBetweenYear(year))
+                .leftJoin(GAME).on(CHECK_IN.game.eq(GAME), isComplete(), isBetweenYear(year))
                 .leftJoin(TEAM).on(CHECK_IN.team.eq(TEAM))
                 .where(filterByTeam(teamFilter), isMemberNotDeleted())
                 .groupBy(MEMBER)
@@ -349,7 +349,7 @@ public class CustomCheckInRepositoryImpl implements CustomCheckInRepository {
                 .where(
                         CHECK_IN.member.eq(member),
                         isBetweenYear(GAME, year),
-                        isFinished(), // 버저닝 후 삭제 예정(취소된 경기도 보여주도록)
+                        isCompleteOrCanceled(),
                         myTeamWinFilter
                 ).orderBy(order)
                 .fetch();
@@ -425,7 +425,7 @@ public class CustomCheckInRepositoryImpl implements CustomCheckInRepository {
                 .join(CHECK_IN.game, GAME)
                 .where(
                         CHECK_IN.member.eq(member),
-                        GAME.homeTeam.eq(CHECK_IN.team).or(GAME.awayTeam.eq(CHECK_IN.team)),
+                        isCompleteOrCanceled(),
                         isMyCurrentFavorite(member, CHECK_IN),
                         GAME.gameState.eq(GameState.COMPLETED)
                 ).fetchOne();
@@ -559,8 +559,12 @@ public class CustomCheckInRepositoryImpl implements CustomCheckInRepository {
                 .otherwise(0.0);
     }
 
-    private BooleanExpression isFinished() {
+    private BooleanExpression isComplete() {
         return GAME.gameState.eq(GameState.COMPLETED);
+    }
+
+    private BooleanExpression isCompleteOrCanceled() {
+        return GAME.gameState.eq(GameState.COMPLETED).or(GAME.gameState.eq(GameState.CANCELED));
     }
 
     private BooleanExpression isBetweenYear(final int year) {
@@ -581,7 +585,7 @@ public class CustomCheckInRepositoryImpl implements CustomCheckInRepository {
     private Long calculateTotalCheckInCount(final int year) {
         return jpaQueryFactory.select(CHECK_IN.count())
                 .from(CHECK_IN)
-                .join(GAME).on(CHECK_IN.game.eq(GAME), isFinished(), isBetweenYear(year))
+                .join(GAME).on(CHECK_IN.game.eq(GAME), isComplete(), isBetweenYear(year))
                 .join(MEMBER).on(CHECK_IN.member.eq(MEMBER), isFavoriteTeam(), isMemberNotDeleted())
                 .fetchOne();
     }
@@ -611,7 +615,7 @@ public class CustomCheckInRepositoryImpl implements CustomCheckInRepository {
     private Long calculatePerCheckInCount(final int year) {
         return jpaQueryFactory.select(MEMBER.countDistinct())
                 .from(CHECK_IN)
-                .join(GAME).on(CHECK_IN.game.eq(GAME), isFinished(), isBetweenYear(year))
+                .join(GAME).on(CHECK_IN.game.eq(GAME), isComplete(), isBetweenYear(year))
                 .join(MEMBER).on(CHECK_IN.member.eq(MEMBER), isFavoriteTeam(), isMemberNotDeleted())
                 .fetchOne();
     }


### PR DESCRIPTION
* feat: 취소된 경기도 직관 내역에 포함한다

* fix: 점수 계산엔 Canceled된 경기 제외

## 📌 관련 이슈
- close #653 

## ✨ 변경 내용
- 어떤 기능/수정이 포함되었는지 간단 요약

## 🎸 기타 참고 사항
- 스크린샷, 참고 링크, 추가 설명 등 (없으면 생략 가능)