### PR TITLE
feat: 월별 직관 내역 조회 API 연동

### DIFF
--- a/android/app/src/main/java/com/yagubogu/data/datasource/checkin/CheckInDataSource.kt
+++ b/android/app/src/main/java/com/yagubogu/data/datasource/checkin/CheckInDataSource.kt
@@ -16,6 +16,7 @@ interface CheckInDataSource {
 
     suspend fun getCheckInHistories(
         year: Int,
+        month: Int,
         filter: String,
         sort: String,
     ): Result<CheckInHistoryResponse>

--- a/android/app/src/main/java/com/yagubogu/data/datasource/checkin/CheckInRemoteDataSource.kt
+++ b/android/app/src/main/java/com/yagubogu/data/datasource/checkin/CheckInRemoteDataSource.kt
@@ -34,11 +34,12 @@ class CheckInRemoteDataSource @Inject constructor(
 
     override suspend fun getCheckInHistories(
         year: Int,
+        month: Int,
         filter: String,
         sort: String,
     ): Result<CheckInHistoryResponse> =
         safeApiCall {
-            checkInApiService.getCheckInHistories(year, filter, sort)
+            checkInApiService.getCheckInHistories(year, month, filter, sort)
         }
 
     override suspend fun getCheckInStatus(date: LocalDate): Result<CheckInStatusResponse> =

--- a/android/app/src/main/java/com/yagubogu/data/repository/checkin/CheckInDefaultRepository.kt
+++ b/android/app/src/main/java/com/yagubogu/data/repository/checkin/CheckInDefaultRepository.kt
@@ -33,11 +33,12 @@ class CheckInDefaultRepository @Inject constructor(
 
     override suspend fun getCheckInHistories(
         year: Int,
+        month: Int,
         filter: String,
         sort: String,
     ): Result<List<CheckInGameDto>> =
         checkInDataSource
-            .getCheckInHistories(year, filter, sort)
+            .getCheckInHistories(year, month, filter, sort)
             .map { checkInHistoryResponse: CheckInHistoryResponse ->
                 checkInHistoryResponse.checkInHistory
             }

--- a/android/app/src/main/java/com/yagubogu/data/repository/checkin/CheckInRepository.kt
+++ b/android/app/src/main/java/com/yagubogu/data/repository/checkin/CheckInRepository.kt
@@ -14,6 +14,7 @@ interface CheckInRepository {
 
     suspend fun getCheckInHistories(
         year: Int,
+        month: Int,
         filter: String,
         sort: String,
     ): Result<List<CheckInGameDto>>

--- a/android/app/src/main/java/com/yagubogu/data/service/CheckInApiService.kt
+++ b/android/app/src/main/java/com/yagubogu/data/service/CheckInApiService.kt
@@ -32,6 +32,7 @@ interface CheckInApiService {
     @GET("/api/v1/check-ins/members")
     suspend fun getCheckInHistories(
         @Query("year") year: Int,
+        @Query("month") month: Int,
         @Query("result") result: String,
         @Query("order") order: String,
     ): Response<CheckInHistoryResponse>

--- a/android/app/src/main/java/com/yagubogu/ui/attendance/AttendanceHistoryScreen.kt
+++ b/android/app/src/main/java/com/yagubogu/ui/attendance/AttendanceHistoryScreen.kt
@@ -84,8 +84,8 @@ fun AttendanceHistoryScreen(
     }
     val coroutineScope: CoroutineScope = rememberCoroutineScope()
 
-    LaunchedEffect(viewType) {
-        viewModel.fetchAttendanceHistoryItems(yearMonth = currentMonth)
+    LaunchedEffect(currentMonth, viewType) {
+        viewModel.fetchAttendanceHistoryItems()
     }
 
     val checkInSuccessMessage: String =
@@ -108,7 +108,6 @@ fun AttendanceHistoryScreen(
         items = attendanceItems,
         updateItems = { filter: AttendanceHistoryFilter, sort: AttendanceHistorySort ->
             viewModel.fetchAttendanceHistoryItems(
-                yearMonth = currentMonth,
                 filter = filter,
                 sort = sort,
             )

--- a/android/app/src/main/java/com/yagubogu/ui/attendance/AttendanceHistoryScreen.kt
+++ b/android/app/src/main/java/com/yagubogu/ui/attendance/AttendanceHistoryScreen.kt
@@ -75,6 +75,7 @@ fun AttendanceHistoryScreen(
 ) {
     val attendanceItems: List<AttendanceHistoryItem> by viewModel.items.collectAsStateWithLifecycle()
     val currentMonth: YearMonth by viewModel.currentMonth.collectAsStateWithLifecycle()
+    val currentDate: LocalDate by viewModel.currentDate.collectAsStateWithLifecycle()
     val filter: AttendanceHistoryFilter by viewModel.filter.collectAsStateWithLifecycle()
     val sort: AttendanceHistorySort by viewModel.sort.collectAsStateWithLifecycle()
     val pastGames: List<PastGameUiModel> by viewModel.pastGames.collectAsStateWithLifecycle()
@@ -91,6 +92,10 @@ fun AttendanceHistoryScreen(
         viewModel.fetchAttendanceHistoryItems()
     }
 
+    LaunchedEffect(currentMonth) {
+        viewModel.updateCurrentDate(currentMonth.atDay(1))
+    }
+
     val checkInSuccessMessage: String =
         stringResource(R.string.attendance_history_check_in_success_message)
     LaunchedEffect(Unit) {
@@ -104,10 +109,12 @@ fun AttendanceHistoryScreen(
     AttendanceHistoryScreen(
         startMonth = startMonth,
         endMonth = endMonth,
-        currentMonth = currentMonth,
-        onMonthChange = viewModel::updateCurrentMonth,
         viewType = viewType,
         onViewTypeChange = { viewType = viewType.toggle() },
+        currentMonth = currentMonth,
+        onMonthChange = viewModel::updateCurrentMonth,
+        currentDate = currentDate,
+        onDateChange = viewModel::updateCurrentDate,
         items = attendanceItems,
         filter = filter,
         updateFilter = viewModel::updateFilter,
@@ -125,10 +132,12 @@ fun AttendanceHistoryScreen(
 private fun AttendanceHistoryScreen(
     startMonth: YearMonth,
     endMonth: YearMonth,
-    currentMonth: YearMonth,
-    onMonthChange: (YearMonth) -> Unit,
     viewType: AttendanceHistoryViewType,
     onViewTypeChange: () -> Unit,
+    currentMonth: YearMonth,
+    onMonthChange: (YearMonth) -> Unit,
+    currentDate: LocalDate,
+    onDateChange: (LocalDate) -> Unit,
     items: List<AttendanceHistoryItem>,
     filter: AttendanceHistoryFilter,
     updateFilter: (AttendanceHistoryFilter) -> Unit,
@@ -165,6 +174,8 @@ private fun AttendanceHistoryScreen(
                     endMonth = endMonth,
                     currentMonth = currentMonth,
                     onMonthChange = onMonthChange,
+                    currentDate = currentDate,
+                    onDateChange = onDateChange,
                     pastGames = pastGames,
                     onRequestGames = onRequestGames,
                     onPastCheckIn = onPastCheckIn,
@@ -336,10 +347,12 @@ private fun AttendanceCalenderScreenPreview() {
     AttendanceHistoryScreen(
         startMonth = AttendanceHistoryViewModel.START_MONTH,
         endMonth = AttendanceHistoryViewModel.END_MONTH,
-        currentMonth = YearMonth.now(),
-        onMonthChange = {},
         viewType = AttendanceHistoryViewType.CALENDAR,
         onViewTypeChange = {},
+        currentMonth = YearMonth.now(),
+        onMonthChange = {},
+        currentDate = LocalDate.now(),
+        onDateChange = {},
         items = ATTENDANCE_HISTORY_ITEMS,
         filter = AttendanceHistoryFilter.ALL,
         updateFilter = {},
@@ -357,10 +370,12 @@ private fun AttendanceListScreenPreview() {
     AttendanceHistoryScreen(
         startMonth = AttendanceHistoryViewModel.START_MONTH,
         endMonth = AttendanceHistoryViewModel.END_MONTH,
-        currentMonth = YearMonth.now(),
-        onMonthChange = {},
         viewType = AttendanceHistoryViewType.LIST,
         onViewTypeChange = {},
+        currentMonth = YearMonth.now(),
+        onMonthChange = {},
+        currentDate = LocalDate.now(),
+        onDateChange = {},
         items = ATTENDANCE_HISTORY_ITEMS,
         filter = AttendanceHistoryFilter.ALL,
         updateFilter = {},

--- a/android/app/src/main/java/com/yagubogu/ui/attendance/AttendanceHistoryScreen.kt
+++ b/android/app/src/main/java/com/yagubogu/ui/attendance/AttendanceHistoryScreen.kt
@@ -74,8 +74,8 @@ fun AttendanceHistoryScreen(
     viewModel: AttendanceHistoryViewModel = hiltViewModel(),
 ) {
     val attendanceItems: List<AttendanceHistoryItem> by viewModel.items.collectAsStateWithLifecycle()
-    val currentVisibleMonth: YearMonth by viewModel.currentVisibleMonth.collectAsStateWithLifecycle()
-    val currentSelectedDate: LocalDate by viewModel.currentSelectedDate.collectAsStateWithLifecycle()
+    val selectedMonth: YearMonth by viewModel.selectedMonth.collectAsStateWithLifecycle()
+    val selectedDate: LocalDate by viewModel.selectedDate.collectAsStateWithLifecycle()
     val filter: AttendanceHistoryFilter by viewModel.filter.collectAsStateWithLifecycle()
     val sort: AttendanceHistorySort by viewModel.sort.collectAsStateWithLifecycle()
     val pastGames: List<PastGameUiModel> by viewModel.pastGames.collectAsStateWithLifecycle()
@@ -88,12 +88,12 @@ fun AttendanceHistoryScreen(
     }
     val coroutineScope: CoroutineScope = rememberCoroutineScope()
 
-    LaunchedEffect(currentVisibleMonth, viewType, filter, sort) {
+    LaunchedEffect(selectedMonth, viewType, filter, sort) {
         viewModel.fetchAttendanceHistoryItems()
     }
 
-    LaunchedEffect(currentVisibleMonth) {
-        viewModel.updateCurrentSelectedDate(currentVisibleMonth.atDay(1))
+    LaunchedEffect(selectedMonth) {
+        viewModel.updateSelectedDate(selectedMonth.atDay(1))
     }
 
     val checkInSuccessMessage: String =
@@ -111,17 +111,17 @@ fun AttendanceHistoryScreen(
         endMonth = endMonth,
         viewType = viewType,
         onViewTypeChange = { viewType = viewType.toggle() },
-        currentVisibleMonth = currentVisibleMonth,
-        onMonthChange = viewModel::updateCurrentVisibleMonth,
-        currentSelectedDate = currentSelectedDate,
-        onDateChange = viewModel::updateCurrentSelectedDate,
+        selectedMonth = selectedMonth,
+        onMonthChange = viewModel::updateSelectedMonth,
+        selectedDate = selectedDate,
+        onDateChange = viewModel::updateSelectedDate,
         items = attendanceItems,
         filter = filter,
         updateFilter = viewModel::updateFilter,
         sort = sort,
         updateSort = viewModel::updateSort,
         pastGames = pastGames,
-        onRequestPastGames = viewModel::fetchPastGames,
+        onPastGamesRequest = viewModel::fetchPastGames,
         onPastCheckIn = viewModel::addPastCheckIn,
         modifier = modifier,
         scrollToTopEvent = scrollToTopEvent,
@@ -134,9 +134,9 @@ private fun AttendanceHistoryScreen(
     endMonth: YearMonth,
     viewType: AttendanceHistoryViewType,
     onViewTypeChange: () -> Unit,
-    currentVisibleMonth: YearMonth,
+    selectedMonth: YearMonth,
     onMonthChange: (YearMonth) -> Unit,
-    currentSelectedDate: LocalDate,
+    selectedDate: LocalDate,
     onDateChange: (LocalDate) -> Unit,
     items: List<AttendanceHistoryItem>,
     filter: AttendanceHistoryFilter,
@@ -144,7 +144,7 @@ private fun AttendanceHistoryScreen(
     sort: AttendanceHistorySort,
     updateSort: (AttendanceHistorySort) -> Unit,
     pastGames: List<PastGameUiModel>,
-    onRequestPastGames: (LocalDate) -> Unit,
+    onPastGamesRequest: (LocalDate) -> Unit,
     onPastCheckIn: (Long) -> Unit,
     modifier: Modifier = Modifier,
     scrollToTopEvent: SharedFlow<Unit> = MutableSharedFlow(),
@@ -159,7 +159,7 @@ private fun AttendanceHistoryScreen(
         AttendanceHistoryHeader(
             startMonth = startMonth,
             endMonth = endMonth,
-            currentVisibleMonth = currentVisibleMonth,
+            selectedMonth = selectedMonth,
             onMonthChange = onMonthChange,
             viewType = viewType,
             onViewTypeChange = onViewTypeChange,
@@ -172,12 +172,12 @@ private fun AttendanceHistoryScreen(
                     items = items,
                     startMonth = startMonth,
                     endMonth = endMonth,
-                    currentVisibleMonth = currentVisibleMonth,
+                    selectedMonth = selectedMonth,
                     onMonthChange = onMonthChange,
-                    currentSelectedDate = currentSelectedDate,
+                    selectedDate = selectedDate,
                     onDateChange = onDateChange,
                     pastGames = pastGames,
-                    onRequestPastGames = onRequestPastGames,
+                    onPastGamesRequest = onPastGamesRequest,
                     onPastCheckIn = onPastCheckIn,
                     scrollToTopEvent = scrollToTopEvent,
                 )
@@ -199,21 +199,21 @@ private fun AttendanceHistoryScreen(
 private fun AttendanceHistoryHeader(
     startMonth: YearMonth,
     endMonth: YearMonth,
-    currentVisibleMonth: YearMonth,
+    selectedMonth: YearMonth,
     onMonthChange: (YearMonth) -> Unit,
     viewType: AttendanceHistoryViewType,
     onViewTypeChange: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val isStartMonth: Boolean = currentVisibleMonth == startMonth
-    val isEndMonth: Boolean = currentVisibleMonth == endMonth
+    val isStartMonth: Boolean = selectedMonth == startMonth
+    val isEndMonth: Boolean = selectedMonth == endMonth
 
     var showDialog: Boolean by rememberSaveable { mutableStateOf(false) }
     if (showDialog) {
         YearMonthPickerDialog(
             startMonth = startMonth,
             endMonth = endMonth,
-            currentMonth = currentVisibleMonth,
+            selectedMonth = selectedMonth,
             onConfirm = { newMonth: YearMonth ->
                 onMonthChange(newMonth)
                 showDialog = false
@@ -244,15 +244,15 @@ private fun AttendanceHistoryHeader(
                         .clip(CircleShape)
                         .clickable(
                             enabled = !isStartMonth,
-                            onClick = { onMonthChange(currentVisibleMonth.minusMonths(1)) },
+                            onClick = { onMonthChange(selectedMonth.minusMonths(1)) },
                         ),
             )
             Text(
                 text =
                     stringResource(
                         R.string.attendance_history_year_month,
-                        currentVisibleMonth.year,
-                        currentVisibleMonth.monthValue,
+                        selectedMonth.year,
+                        selectedMonth.monthValue,
                     ),
                 style = PretendardSemiBold20,
                 modifier =
@@ -271,7 +271,7 @@ private fun AttendanceHistoryHeader(
                         .clip(CircleShape)
                         .clickable(
                             enabled = !isEndMonth,
-                            onClick = { onMonthChange(currentVisibleMonth.plusMonths(1)) },
+                            onClick = { onMonthChange(selectedMonth.plusMonths(1)) },
                         ),
             )
         }
@@ -349,9 +349,9 @@ private fun AttendanceCalenderScreenPreview() {
         endMonth = AttendanceHistoryViewModel.END_MONTH,
         viewType = AttendanceHistoryViewType.CALENDAR,
         onViewTypeChange = {},
-        currentVisibleMonth = YearMonth.now(),
+        selectedMonth = YearMonth.now(),
         onMonthChange = {},
-        currentSelectedDate = LocalDate.now(),
+        selectedDate = LocalDate.now(),
         onDateChange = {},
         items = ATTENDANCE_HISTORY_ITEMS,
         filter = AttendanceHistoryFilter.ALL,
@@ -359,7 +359,7 @@ private fun AttendanceCalenderScreenPreview() {
         sort = AttendanceHistorySort.LATEST,
         updateSort = {},
         pastGames = listOf(),
-        onRequestPastGames = {},
+        onPastGamesRequest = {},
         onPastCheckIn = {},
     )
 }
@@ -372,9 +372,9 @@ private fun AttendanceListScreenPreview() {
         endMonth = AttendanceHistoryViewModel.END_MONTH,
         viewType = AttendanceHistoryViewType.LIST,
         onViewTypeChange = {},
-        currentVisibleMonth = YearMonth.now(),
+        selectedMonth = YearMonth.now(),
         onMonthChange = {},
-        currentSelectedDate = LocalDate.now(),
+        selectedDate = LocalDate.now(),
         onDateChange = {},
         items = ATTENDANCE_HISTORY_ITEMS,
         filter = AttendanceHistoryFilter.ALL,
@@ -382,7 +382,7 @@ private fun AttendanceListScreenPreview() {
         sort = AttendanceHistorySort.LATEST,
         updateSort = {},
         pastGames = listOf(),
-        onRequestPastGames = {},
+        onPastGamesRequest = {},
         onPastCheckIn = {},
     )
 }

--- a/android/app/src/main/java/com/yagubogu/ui/attendance/AttendanceHistoryScreen.kt
+++ b/android/app/src/main/java/com/yagubogu/ui/attendance/AttendanceHistoryScreen.kt
@@ -74,8 +74,11 @@ fun AttendanceHistoryScreen(
     viewModel: AttendanceHistoryViewModel = hiltViewModel(),
 ) {
     val attendanceItems: List<AttendanceHistoryItem> by viewModel.items.collectAsStateWithLifecycle()
-    val pastGames: List<PastGameUiModel> by viewModel.pastGames.collectAsStateWithLifecycle()
     val currentMonth: YearMonth by viewModel.currentMonth.collectAsStateWithLifecycle()
+    val filter: AttendanceHistoryFilter by viewModel.filter.collectAsStateWithLifecycle()
+    val sort: AttendanceHistorySort by viewModel.sort.collectAsStateWithLifecycle()
+    val pastGames: List<PastGameUiModel> by viewModel.pastGames.collectAsStateWithLifecycle()
+
     val startMonth: YearMonth = AttendanceHistoryViewModel.START_MONTH
     val endMonth: YearMonth = AttendanceHistoryViewModel.END_MONTH
 
@@ -84,7 +87,7 @@ fun AttendanceHistoryScreen(
     }
     val coroutineScope: CoroutineScope = rememberCoroutineScope()
 
-    LaunchedEffect(currentMonth, viewType) {
+    LaunchedEffect(currentMonth, viewType, filter, sort) {
         viewModel.fetchAttendanceHistoryItems()
     }
 
@@ -106,12 +109,10 @@ fun AttendanceHistoryScreen(
         viewType = viewType,
         onViewTypeChange = { viewType = viewType.toggle() },
         items = attendanceItems,
-        updateItems = { filter: AttendanceHistoryFilter, sort: AttendanceHistorySort ->
-            viewModel.fetchAttendanceHistoryItems(
-                filter = filter,
-                sort = sort,
-            )
-        },
+        filter = filter,
+        updateFilter = viewModel::updateFilter,
+        sort = sort,
+        updateSort = viewModel::updateSort,
         pastGames = pastGames,
         onRequestGames = viewModel::fetchPastGames,
         onPastCheckIn = viewModel::addPastCheckIn,
@@ -129,7 +130,10 @@ private fun AttendanceHistoryScreen(
     viewType: AttendanceHistoryViewType,
     onViewTypeChange: () -> Unit,
     items: List<AttendanceHistoryItem>,
-    updateItems: (AttendanceHistoryFilter, AttendanceHistorySort) -> Unit,
+    filter: AttendanceHistoryFilter,
+    updateFilter: (AttendanceHistoryFilter) -> Unit,
+    sort: AttendanceHistorySort,
+    updateSort: (AttendanceHistorySort) -> Unit,
     pastGames: List<PastGameUiModel>,
     onRequestGames: (LocalDate) -> Unit,
     onPastCheckIn: (Long) -> Unit,
@@ -170,7 +174,10 @@ private fun AttendanceHistoryScreen(
             AttendanceHistoryViewType.LIST ->
                 AttendanceListContent(
                     items = items,
-                    updateItems = updateItems,
+                    filter = filter,
+                    updateFilter = updateFilter,
+                    sort = sort,
+                    updateSort = updateSort,
                     scrollToTopEvent = scrollToTopEvent,
                 )
         }
@@ -334,10 +341,13 @@ private fun AttendanceCalenderScreenPreview() {
         viewType = AttendanceHistoryViewType.CALENDAR,
         onViewTypeChange = {},
         items = ATTENDANCE_HISTORY_ITEMS,
+        filter = AttendanceHistoryFilter.ALL,
+        updateFilter = {},
+        sort = AttendanceHistorySort.LATEST,
+        updateSort = {},
         pastGames = listOf(),
         onRequestGames = {},
         onPastCheckIn = {},
-        updateItems = { _, _ -> },
     )
 }
 
@@ -352,9 +362,12 @@ private fun AttendanceListScreenPreview() {
         viewType = AttendanceHistoryViewType.LIST,
         onViewTypeChange = {},
         items = ATTENDANCE_HISTORY_ITEMS,
+        filter = AttendanceHistoryFilter.ALL,
+        updateFilter = {},
+        sort = AttendanceHistorySort.LATEST,
+        updateSort = {},
         pastGames = listOf(),
         onRequestGames = {},
         onPastCheckIn = {},
-        updateItems = { _, _ -> },
     )
 }

--- a/android/app/src/main/java/com/yagubogu/ui/attendance/AttendanceHistoryViewModel.kt
+++ b/android/app/src/main/java/com/yagubogu/ui/attendance/AttendanceHistoryViewModel.kt
@@ -34,11 +34,11 @@ class AttendanceHistoryViewModel @Inject constructor(
     private val _items = MutableStateFlow<List<AttendanceHistoryItem>>(emptyList())
     val items: StateFlow<List<AttendanceHistoryItem>> = _items.asStateFlow()
 
-    private val _currentVisibleMonth = MutableStateFlow<YearMonth>(YearMonth.now())
-    val currentVisibleMonth: StateFlow<YearMonth> = _currentVisibleMonth.asStateFlow()
+    private val _selectedMonth = MutableStateFlow<YearMonth>(YearMonth.now())
+    val selectedMonth: StateFlow<YearMonth> = _selectedMonth.asStateFlow()
 
-    private val _currentSelectedDate = MutableStateFlow<LocalDate>(LocalDate.now())
-    val currentSelectedDate: StateFlow<LocalDate> = _currentSelectedDate.asStateFlow()
+    private val _selectedDate = MutableStateFlow<LocalDate>(LocalDate.now())
+    val selectedDate: StateFlow<LocalDate> = _selectedDate.asStateFlow()
 
     private val _filter = MutableStateFlow(AttendanceHistoryFilter.ALL)
     val filter: StateFlow<AttendanceHistoryFilter> = _filter.asStateFlow()
@@ -59,7 +59,7 @@ class AttendanceHistoryViewModel @Inject constructor(
 
     fun fetchAttendanceHistoryItems() {
         viewModelScope.launch {
-            val yearMonth: YearMonth = currentVisibleMonth.value
+            val yearMonth: YearMonth = selectedMonth.value
             checkInRepository
                 .getCheckInHistories(
                     yearMonth.year,
@@ -106,12 +106,12 @@ class AttendanceHistoryViewModel @Inject constructor(
         }
     }
 
-    fun updateCurrentVisibleMonth(yearMonth: YearMonth) {
-        _currentVisibleMonth.value = yearMonth
+    fun updateSelectedMonth(yearMonth: YearMonth) {
+        _selectedMonth.value = yearMonth
     }
 
-    fun updateCurrentSelectedDate(date: LocalDate) {
-        _currentSelectedDate.value = date
+    fun updateSelectedDate(date: LocalDate) {
+        _selectedDate.value = date
     }
 
     fun updateFilter(filter: AttendanceHistoryFilter) {

--- a/android/app/src/main/java/com/yagubogu/ui/attendance/AttendanceHistoryViewModel.kt
+++ b/android/app/src/main/java/com/yagubogu/ui/attendance/AttendanceHistoryViewModel.kt
@@ -49,13 +49,13 @@ class AttendanceHistoryViewModel @Inject constructor(
     val pastCheckInUiEvent: SharedFlow<Unit> = _pastCheckInUiEvent.asSharedFlow()
 
     fun fetchAttendanceHistoryItems(
-        yearMonth: YearMonth = YearMonth.now(),
         filter: AttendanceHistoryFilter = AttendanceHistoryFilter.ALL,
         sort: AttendanceHistorySort = AttendanceHistorySort.LATEST,
     ) {
         viewModelScope.launch {
+            val yearMonth: YearMonth = currentMonth.value
             checkInRepository
-                .getCheckInHistories(yearMonth.year, filter.name, sort.name)
+                .getCheckInHistories(yearMonth.year, yearMonth.monthValue, filter.name, sort.name)
                 .mapList { it.toUiModel() }
                 .onSuccess { attendanceItems: List<AttendanceHistoryItem> ->
                     _items.value = attendanceItems

--- a/android/app/src/main/java/com/yagubogu/ui/attendance/AttendanceHistoryViewModel.kt
+++ b/android/app/src/main/java/com/yagubogu/ui/attendance/AttendanceHistoryViewModel.kt
@@ -116,7 +116,7 @@ class AttendanceHistoryViewModel @Inject constructor(
     }
 
     companion object {
-        val START_MONTH: YearMonth = YearMonth.of(2021, 1)
+        val START_MONTH: YearMonth = YearMonth.of(2021, 3)
         val END_MONTH: YearMonth = YearMonth.now()
     }
 }

--- a/android/app/src/main/java/com/yagubogu/ui/attendance/AttendanceHistoryViewModel.kt
+++ b/android/app/src/main/java/com/yagubogu/ui/attendance/AttendanceHistoryViewModel.kt
@@ -34,11 +34,11 @@ class AttendanceHistoryViewModel @Inject constructor(
     private val _items = MutableStateFlow<List<AttendanceHistoryItem>>(emptyList())
     val items: StateFlow<List<AttendanceHistoryItem>> = _items.asStateFlow()
 
-    private val _currentMonth = MutableStateFlow<YearMonth>(YearMonth.now())
-    val currentMonth: StateFlow<YearMonth> = _currentMonth.asStateFlow()
+    private val _currentVisibleMonth = MutableStateFlow<YearMonth>(YearMonth.now())
+    val currentVisibleMonth: StateFlow<YearMonth> = _currentVisibleMonth.asStateFlow()
 
-    private val _currentDate = MutableStateFlow<LocalDate>(LocalDate.now())
-    val currentDate: StateFlow<LocalDate> = _currentDate.asStateFlow()
+    private val _currentSelectedDate = MutableStateFlow<LocalDate>(LocalDate.now())
+    val currentSelectedDate: StateFlow<LocalDate> = _currentSelectedDate.asStateFlow()
 
     private val _filter = MutableStateFlow(AttendanceHistoryFilter.ALL)
     val filter: StateFlow<AttendanceHistoryFilter> = _filter.asStateFlow()
@@ -59,7 +59,7 @@ class AttendanceHistoryViewModel @Inject constructor(
 
     fun fetchAttendanceHistoryItems() {
         viewModelScope.launch {
-            val yearMonth: YearMonth = currentMonth.value
+            val yearMonth: YearMonth = currentVisibleMonth.value
             checkInRepository
                 .getCheckInHistories(
                     yearMonth.year,
@@ -106,12 +106,12 @@ class AttendanceHistoryViewModel @Inject constructor(
         }
     }
 
-    fun updateCurrentMonth(yearMonth: YearMonth) {
-        _currentMonth.value = yearMonth
+    fun updateCurrentVisibleMonth(yearMonth: YearMonth) {
+        _currentVisibleMonth.value = yearMonth
     }
 
-    fun updateCurrentDate(date: LocalDate) {
-        _currentDate.value = date
+    fun updateCurrentSelectedDate(date: LocalDate) {
+        _currentSelectedDate.value = date
     }
 
     fun updateFilter(filter: AttendanceHistoryFilter) {

--- a/android/app/src/main/java/com/yagubogu/ui/attendance/AttendanceHistoryViewModel.kt
+++ b/android/app/src/main/java/com/yagubogu/ui/attendance/AttendanceHistoryViewModel.kt
@@ -37,6 +37,9 @@ class AttendanceHistoryViewModel @Inject constructor(
     private val _currentMonth = MutableStateFlow<YearMonth>(YearMonth.now())
     val currentMonth: StateFlow<YearMonth> = _currentMonth.asStateFlow()
 
+    private val _currentDate = MutableStateFlow<LocalDate>(LocalDate.now())
+    val currentDate: StateFlow<LocalDate> = _currentDate.asStateFlow()
+
     private val _filter = MutableStateFlow(AttendanceHistoryFilter.ALL)
     val filter: StateFlow<AttendanceHistoryFilter> = _filter.asStateFlow()
 
@@ -105,6 +108,10 @@ class AttendanceHistoryViewModel @Inject constructor(
 
     fun updateCurrentMonth(yearMonth: YearMonth) {
         _currentMonth.value = yearMonth
+    }
+
+    fun updateCurrentDate(date: LocalDate) {
+        _currentDate.value = date
     }
 
     fun updateFilter(filter: AttendanceHistoryFilter) {

--- a/android/app/src/main/java/com/yagubogu/ui/attendance/component/AttendanceCalendar.kt
+++ b/android/app/src/main/java/com/yagubogu/ui/attendance/component/AttendanceCalendar.kt
@@ -46,9 +46,9 @@ import java.util.Locale
 fun AttendanceCalendar(
     startMonth: YearMonth,
     endMonth: YearMonth,
-    currentVisibleMonth: YearMonth,
+    selectedMonth: YearMonth,
     onMonthChange: (YearMonth) -> Unit,
-    currentSelectedDate: LocalDate,
+    selectedDate: LocalDate,
     onDateChange: (LocalDate) -> Unit,
     attendanceDates: Set<LocalDate>,
     modifier: Modifier = Modifier,
@@ -59,18 +59,18 @@ fun AttendanceCalendar(
         rememberCalendarState(
             startMonth = startMonth,
             endMonth = endMonth,
-            firstVisibleMonth = currentVisibleMonth,
+            firstVisibleMonth = selectedMonth,
             firstDayOfWeek = daysOfWeek.first(),
         )
 
-    LaunchedEffect(currentVisibleMonth) {
-        if (state.firstVisibleMonth.yearMonth != currentVisibleMonth) {
-            state.animateScrollToMonth(currentVisibleMonth)
+    LaunchedEffect(selectedMonth) {
+        if (state.firstVisibleMonth.yearMonth != selectedMonth) {
+            state.animateScrollToMonth(selectedMonth)
         }
     }
 
     LaunchedEffect(state.firstVisibleMonth) {
-        if (state.firstVisibleMonth.yearMonth != currentVisibleMonth) {
+        if (state.firstVisibleMonth.yearMonth != selectedMonth) {
             onMonthChange(state.firstVisibleMonth.yearMonth)
         }
     }
@@ -88,7 +88,7 @@ fun AttendanceCalendar(
             dayContent = { day: CalendarDay ->
                 Day(
                     day = day,
-                    isSelected = currentSelectedDate == day.date,
+                    isSelected = selectedDate == day.date,
                     hasAttendance = day.date in attendanceDates,
                     onClick = { day: CalendarDay -> onDateChange(day.date) },
                 )
@@ -171,9 +171,9 @@ private fun AttendanceCalendarPreview() {
     AttendanceCalendar(
         startMonth = YearMonth.now().minusMonths(1),
         endMonth = YearMonth.now(),
-        currentVisibleMonth = YearMonth.now(),
+        selectedMonth = YearMonth.now(),
         onMonthChange = {},
-        currentSelectedDate = LocalDate.now(),
+        selectedDate = LocalDate.now(),
         onDateChange = {},
         attendanceDates = ATTENDANCE_HISTORY_ITEMS.map { it.summary.attendanceDate }.toSet(),
     )

--- a/android/app/src/main/java/com/yagubogu/ui/attendance/component/AttendanceCalendar.kt
+++ b/android/app/src/main/java/com/yagubogu/ui/attendance/component/AttendanceCalendar.kt
@@ -46,9 +46,9 @@ import java.util.Locale
 fun AttendanceCalendar(
     startMonth: YearMonth,
     endMonth: YearMonth,
-    currentMonth: YearMonth,
+    currentVisibleMonth: YearMonth,
     onMonthChange: (YearMonth) -> Unit,
-    currentDate: LocalDate,
+    currentSelectedDate: LocalDate,
     onDateChange: (LocalDate) -> Unit,
     attendanceDates: Set<LocalDate>,
     modifier: Modifier = Modifier,
@@ -59,18 +59,18 @@ fun AttendanceCalendar(
         rememberCalendarState(
             startMonth = startMonth,
             endMonth = endMonth,
-            firstVisibleMonth = currentMonth,
+            firstVisibleMonth = currentVisibleMonth,
             firstDayOfWeek = daysOfWeek.first(),
         )
 
-    LaunchedEffect(currentMonth) {
-        if (state.firstVisibleMonth.yearMonth != currentMonth) {
-            state.animateScrollToMonth(currentMonth)
+    LaunchedEffect(currentVisibleMonth) {
+        if (state.firstVisibleMonth.yearMonth != currentVisibleMonth) {
+            state.animateScrollToMonth(currentVisibleMonth)
         }
     }
 
     LaunchedEffect(state.firstVisibleMonth) {
-        if (state.firstVisibleMonth.yearMonth != currentMonth) {
+        if (state.firstVisibleMonth.yearMonth != currentVisibleMonth) {
             onMonthChange(state.firstVisibleMonth.yearMonth)
         }
     }
@@ -88,7 +88,7 @@ fun AttendanceCalendar(
             dayContent = { day: CalendarDay ->
                 Day(
                     day = day,
-                    isSelected = currentDate == day.date,
+                    isSelected = currentSelectedDate == day.date,
                     hasAttendance = day.date in attendanceDates,
                     onClick = { day: CalendarDay -> onDateChange(day.date) },
                 )
@@ -171,9 +171,9 @@ private fun AttendanceCalendarPreview() {
     AttendanceCalendar(
         startMonth = YearMonth.now().minusMonths(1),
         endMonth = YearMonth.now(),
-        currentMonth = YearMonth.now(),
+        currentVisibleMonth = YearMonth.now(),
         onMonthChange = {},
-        currentDate = LocalDate.now(),
+        currentSelectedDate = LocalDate.now(),
         onDateChange = {},
         attendanceDates = ATTENDANCE_HISTORY_ITEMS.map { it.summary.attendanceDate }.toSet(),
     )

--- a/android/app/src/main/java/com/yagubogu/ui/attendance/component/AttendanceCalendarContent.kt
+++ b/android/app/src/main/java/com/yagubogu/ui/attendance/component/AttendanceCalendarContent.kt
@@ -52,19 +52,19 @@ fun AttendanceCalendarContent(
     items: List<AttendanceHistoryItem>,
     startMonth: YearMonth,
     endMonth: YearMonth,
-    currentVisibleMonth: YearMonth,
+    selectedMonth: YearMonth,
     onMonthChange: (YearMonth) -> Unit,
-    currentSelectedDate: LocalDate,
+    selectedDate: LocalDate,
     onDateChange: (LocalDate) -> Unit,
     pastGames: List<PastGameUiModel>,
-    onRequestPastGames: (LocalDate) -> Unit,
+    onPastGamesRequest: (LocalDate) -> Unit,
     onPastCheckIn: (Long) -> Unit,
     modifier: Modifier = Modifier,
     scrollToTopEvent: SharedFlow<Unit> = MutableSharedFlow(),
 ) {
     val itemsByDate: Map<LocalDate, List<AttendanceHistoryItem>> =
         items.groupBy { item: AttendanceHistoryItem -> item.summary.attendanceDate }
-    val currentItems: List<AttendanceHistoryItem>? = itemsByDate[currentSelectedDate]
+    val currentItems: List<AttendanceHistoryItem>? = itemsByDate[selectedDate]
     val scrollState: ScrollState = rememberScrollState()
     var showBottomSheet: Boolean by rememberSaveable { mutableStateOf(false) }
 
@@ -99,9 +99,9 @@ fun AttendanceCalendarContent(
             AttendanceCalendar(
                 startMonth = startMonth,
                 endMonth = endMonth,
-                currentVisibleMonth = currentVisibleMonth,
+                selectedMonth = selectedMonth,
                 onMonthChange = onMonthChange,
-                currentSelectedDate = currentSelectedDate,
+                selectedDate = selectedDate,
                 onDateChange = onDateChange,
                 attendanceDates = itemsByDate.keys,
             )
@@ -113,7 +113,7 @@ fun AttendanceCalendarContent(
             } else {
                 AttendanceAdditionButton(
                     onClick = {
-                        onRequestPastGames(currentSelectedDate)
+                        onPastGamesRequest(selectedDate)
                         showBottomSheet = true
                     },
                     modifier = Modifier.padding(vertical = 30.dp),
@@ -124,7 +124,7 @@ fun AttendanceCalendarContent(
         if (currentItems != null) {
             SmallFloatingActionButton(
                 onClick = {
-                    onRequestPastGames(currentSelectedDate)
+                    onPastGamesRequest(selectedDate)
                     showBottomSheet = true
                 },
                 containerColor = Primary500,
@@ -181,12 +181,12 @@ private fun AttendanceCalendarContentPreview() {
         items = ATTENDANCE_HISTORY_ITEMS,
         startMonth = YearMonth.now().minusMonths(1),
         endMonth = YearMonth.now(),
-        currentVisibleMonth = YearMonth.now(),
+        selectedMonth = YearMonth.now(),
         onMonthChange = {},
-        currentSelectedDate = LocalDate.now(),
+        selectedDate = LocalDate.now(),
         onDateChange = {},
         pastGames = listOf(),
-        onRequestPastGames = {},
+        onPastGamesRequest = {},
         onPastCheckIn = {},
     )
 }
@@ -198,12 +198,12 @@ private fun AttendanceCalendarContentNoItemPreview() {
         items = emptyList(),
         startMonth = YearMonth.now().minusMonths(1),
         endMonth = YearMonth.now(),
-        currentVisibleMonth = YearMonth.now(),
+        selectedMonth = YearMonth.now(),
         onMonthChange = {},
-        currentSelectedDate = LocalDate.now(),
+        selectedDate = LocalDate.now(),
         onDateChange = {},
         pastGames = listOf(),
-        onRequestPastGames = {},
+        onPastGamesRequest = {},
         onPastCheckIn = {},
     )
 }

--- a/android/app/src/main/java/com/yagubogu/ui/attendance/component/AttendanceCalendarContent.kt
+++ b/android/app/src/main/java/com/yagubogu/ui/attendance/component/AttendanceCalendarContent.kt
@@ -52,19 +52,19 @@ fun AttendanceCalendarContent(
     items: List<AttendanceHistoryItem>,
     startMonth: YearMonth,
     endMonth: YearMonth,
-    currentMonth: YearMonth,
+    currentVisibleMonth: YearMonth,
     onMonthChange: (YearMonth) -> Unit,
-    currentDate: LocalDate,
+    currentSelectedDate: LocalDate,
     onDateChange: (LocalDate) -> Unit,
     pastGames: List<PastGameUiModel>,
-    onRequestGames: (LocalDate) -> Unit,
+    onRequestPastGames: (LocalDate) -> Unit,
     onPastCheckIn: (Long) -> Unit,
     modifier: Modifier = Modifier,
     scrollToTopEvent: SharedFlow<Unit> = MutableSharedFlow(),
 ) {
     val itemsByDate: Map<LocalDate, List<AttendanceHistoryItem>> =
         items.groupBy { item: AttendanceHistoryItem -> item.summary.attendanceDate }
-    val currentItems: List<AttendanceHistoryItem>? = itemsByDate[currentDate]
+    val currentItems: List<AttendanceHistoryItem>? = itemsByDate[currentSelectedDate]
     val scrollState: ScrollState = rememberScrollState()
     var showBottomSheet: Boolean by rememberSaveable { mutableStateOf(false) }
 
@@ -99,9 +99,9 @@ fun AttendanceCalendarContent(
             AttendanceCalendar(
                 startMonth = startMonth,
                 endMonth = endMonth,
-                currentMonth = currentMonth,
+                currentVisibleMonth = currentVisibleMonth,
                 onMonthChange = onMonthChange,
-                currentDate = currentDate,
+                currentSelectedDate = currentSelectedDate,
                 onDateChange = onDateChange,
                 attendanceDates = itemsByDate.keys,
             )
@@ -113,7 +113,7 @@ fun AttendanceCalendarContent(
             } else {
                 AttendanceAdditionButton(
                     onClick = {
-                        onRequestGames(currentDate)
+                        onRequestPastGames(currentSelectedDate)
                         showBottomSheet = true
                     },
                     modifier = Modifier.padding(vertical = 30.dp),
@@ -124,7 +124,7 @@ fun AttendanceCalendarContent(
         if (currentItems != null) {
             SmallFloatingActionButton(
                 onClick = {
-                    onRequestGames(currentDate)
+                    onRequestPastGames(currentSelectedDate)
                     showBottomSheet = true
                 },
                 containerColor = Primary500,
@@ -181,12 +181,12 @@ private fun AttendanceCalendarContentPreview() {
         items = ATTENDANCE_HISTORY_ITEMS,
         startMonth = YearMonth.now().minusMonths(1),
         endMonth = YearMonth.now(),
-        currentMonth = YearMonth.now(),
+        currentVisibleMonth = YearMonth.now(),
         onMonthChange = {},
-        currentDate = LocalDate.now(),
+        currentSelectedDate = LocalDate.now(),
         onDateChange = {},
         pastGames = listOf(),
-        onRequestGames = {},
+        onRequestPastGames = {},
         onPastCheckIn = {},
     )
 }
@@ -198,12 +198,12 @@ private fun AttendanceCalendarContentNoItemPreview() {
         items = emptyList(),
         startMonth = YearMonth.now().minusMonths(1),
         endMonth = YearMonth.now(),
-        currentMonth = YearMonth.now(),
+        currentVisibleMonth = YearMonth.now(),
         onMonthChange = {},
-        currentDate = LocalDate.now(),
+        currentSelectedDate = LocalDate.now(),
         onDateChange = {},
         pastGames = listOf(),
-        onRequestGames = {},
+        onRequestPastGames = {},
         onPastCheckIn = {},
     )
 }

--- a/android/app/src/main/java/com/yagubogu/ui/attendance/component/AttendanceCalendarContent.kt
+++ b/android/app/src/main/java/com/yagubogu/ui/attendance/component/AttendanceCalendarContent.kt
@@ -54,13 +54,14 @@ fun AttendanceCalendarContent(
     endMonth: YearMonth,
     currentMonth: YearMonth,
     onMonthChange: (YearMonth) -> Unit,
+    currentDate: LocalDate,
+    onDateChange: (LocalDate) -> Unit,
     pastGames: List<PastGameUiModel>,
     onRequestGames: (LocalDate) -> Unit,
     onPastCheckIn: (Long) -> Unit,
     modifier: Modifier = Modifier,
     scrollToTopEvent: SharedFlow<Unit> = MutableSharedFlow(),
 ) {
-    var currentDate: LocalDate by rememberSaveable { mutableStateOf(LocalDate.now()) }
     val itemsByDate: Map<LocalDate, List<AttendanceHistoryItem>> =
         items.groupBy { item: AttendanceHistoryItem -> item.summary.attendanceDate }
     val currentItems: List<AttendanceHistoryItem>? = itemsByDate[currentDate]
@@ -102,7 +103,7 @@ fun AttendanceCalendarContent(
                 currentMonth = currentMonth,
                 onMonthChange = onMonthChange,
                 currentDate = currentDate,
-                onDateChange = { date: LocalDate -> currentDate = date },
+                onDateChange = onDateChange,
                 attendanceDates = itemsByDate.keys,
             )
 
@@ -183,6 +184,8 @@ private fun AttendanceCalendarContentPreview() {
         endMonth = YearMonth.now(),
         currentMonth = YearMonth.now(),
         onMonthChange = {},
+        currentDate = LocalDate.now(),
+        onDateChange = {},
         pastGames = listOf(),
         onRequestGames = {},
         onPastCheckIn = {},
@@ -198,6 +201,8 @@ private fun AttendanceCalendarContentNoItemPreview() {
         endMonth = YearMonth.now(),
         currentMonth = YearMonth.now(),
         onMonthChange = {},
+        currentDate = LocalDate.now(),
+        onDateChange = {},
         pastGames = listOf(),
         onRequestGames = {},
         onPastCheckIn = {},

--- a/android/app/src/main/java/com/yagubogu/ui/attendance/component/AttendanceListContent.kt
+++ b/android/app/src/main/java/com/yagubogu/ui/attendance/component/AttendanceListContent.kt
@@ -59,7 +59,10 @@ private const val FIRST_INDEX = 0
 @Composable
 fun AttendanceListContent(
     items: List<AttendanceHistoryItem>,
-    updateItems: (AttendanceHistoryFilter, AttendanceHistorySort) -> Unit,
+    filter: AttendanceHistoryFilter,
+    updateFilter: (AttendanceHistoryFilter) -> Unit,
+    sort: AttendanceHistorySort,
+    updateSort: (AttendanceHistorySort) -> Unit,
     modifier: Modifier = Modifier,
     scrollToTopEvent: SharedFlow<Unit> = MutableSharedFlow(),
 ) {
@@ -67,7 +70,10 @@ fun AttendanceListContent(
         true ->
             AttendanceList(
                 items = items,
-                updateItems = updateItems,
+                filter = filter,
+                updateFilter = updateFilter,
+                sort = sort,
+                updateSort = updateSort,
                 modifier = modifier,
                 scrollToTopEvent = scrollToTopEvent,
             )
@@ -79,12 +85,13 @@ fun AttendanceListContent(
 @Composable
 private fun AttendanceList(
     items: List<AttendanceHistoryItem>,
-    updateItems: (AttendanceHistoryFilter, AttendanceHistorySort) -> Unit,
+    filter: AttendanceHistoryFilter,
+    updateFilter: (AttendanceHistoryFilter) -> Unit,
+    sort: AttendanceHistorySort,
+    updateSort: (AttendanceHistorySort) -> Unit,
     modifier: Modifier = Modifier,
     scrollToTopEvent: SharedFlow<Unit> = MutableSharedFlow(),
 ) {
-    var filter: AttendanceHistoryFilter by rememberSaveable { mutableStateOf(AttendanceHistoryFilter.ALL) }
-    var sort: AttendanceHistorySort by rememberSaveable { mutableStateOf(AttendanceHistorySort.LATEST) }
     var detailItemPosition: Int? by rememberSaveable { mutableStateOf(if (items.isNotEmpty()) FIRST_INDEX else null) }
 
     val lazyListState: LazyListState = rememberLazyListState()
@@ -114,8 +121,7 @@ private fun AttendanceList(
                 filter = filter,
                 onClick = { newFilter: AttendanceHistoryFilter ->
                     if (filter != newFilter) {
-                        filter = newFilter
-                        updateItems(newFilter, sort)
+                        updateFilter(newFilter)
                         detailItemPosition = if (items.isNotEmpty()) FIRST_INDEX else null
                     }
                 },
@@ -123,12 +129,8 @@ private fun AttendanceList(
             AttendanceHistorySortSwitch(
                 sort = sort,
                 onClick = {
-                    sort =
-                        when (sort) {
-                            AttendanceHistorySort.LATEST -> AttendanceHistorySort.OLDEST
-                            AttendanceHistorySort.OLDEST -> AttendanceHistorySort.LATEST
-                        }
-                    updateItems(filter, sort)
+                    val newSort: AttendanceHistorySort = sort.toggle()
+                    updateSort(newSort)
                     detailItemPosition = if (items.isNotEmpty()) FIRST_INDEX else null
                 },
             )
@@ -306,7 +308,10 @@ private fun AttendanceHistorySortSwitch(
 private fun AttendanceListPreview() {
     AttendanceList(
         items = ATTENDANCE_HISTORY_ITEMS,
-        updateItems = { _, _ -> },
+        filter = AttendanceHistoryFilter.ALL,
+        updateFilter = {},
+        sort = AttendanceHistorySort.LATEST,
+        updateSort = {},
     )
 }
 

--- a/android/app/src/main/java/com/yagubogu/ui/attendance/component/YearMonthPickerDialog.kt
+++ b/android/app/src/main/java/com/yagubogu/ui/attendance/component/YearMonthPickerDialog.kt
@@ -13,6 +13,7 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
@@ -38,6 +39,9 @@ import com.yagubogu.ui.theme.Primary050
 import com.yagubogu.ui.theme.Primary500
 import java.time.YearMonth
 
+private const val FIRST_MONTH = 1
+private const val LAST_MONTH = 12
+
 @Composable
 fun YearMonthPickerDialog(
     startMonth: YearMonth,
@@ -54,7 +58,20 @@ fun YearMonthPickerDialog(
         remember(startMonth, endMonth) {
             (startMonth.year..endMonth.year).toList()
         }
-    val months: List<Int> = remember { (1..12).toList() }
+    val months: List<Int> =
+        remember(year, startMonth, endMonth) {
+            when (year) {
+                startMonth.year -> (startMonth.monthValue..LAST_MONTH).toList()
+                endMonth.year -> (FIRST_MONTH..endMonth.monthValue).toList()
+                else -> (FIRST_MONTH..LAST_MONTH).toList()
+            }
+        }
+
+    LaunchedEffect(months) {
+        if (month !in months) {
+            month = months.first()
+        }
+    }
 
     val yearFormat: String = stringResource(R.string.attendance_history_year)
     val monthFormat: String = stringResource(R.string.attendance_history_month)

--- a/android/app/src/main/java/com/yagubogu/ui/attendance/component/YearMonthPickerDialog.kt
+++ b/android/app/src/main/java/com/yagubogu/ui/attendance/component/YearMonthPickerDialog.kt
@@ -61,10 +61,10 @@ fun YearMonthPickerDialog(
     val months: List<Int> =
         remember(year, startMonth, endMonth) {
             when (year) {
-                startMonth.year -> (startMonth.monthValue..LAST_MONTH).toList()
-                endMonth.year -> (FIRST_MONTH..endMonth.monthValue).toList()
-                else -> (FIRST_MONTH..LAST_MONTH).toList()
-            }
+                startMonth.year -> (startMonth.monthValue..LAST_MONTH)
+                endMonth.year -> (FIRST_MONTH..endMonth.monthValue)
+                else -> (FIRST_MONTH..LAST_MONTH)
+            }.toList()
         }
 
     LaunchedEffect(months) {

--- a/android/app/src/main/java/com/yagubogu/ui/attendance/component/YearMonthPickerDialog.kt
+++ b/android/app/src/main/java/com/yagubogu/ui/attendance/component/YearMonthPickerDialog.kt
@@ -46,13 +46,13 @@ private const val LAST_MONTH = 12
 fun YearMonthPickerDialog(
     startMonth: YearMonth,
     endMonth: YearMonth,
-    currentMonth: YearMonth,
+    selectedMonth: YearMonth,
     onConfirm: (YearMonth) -> Unit,
     onCancel: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    var year: Int by rememberSaveable { mutableIntStateOf(currentMonth.year) }
-    var month: Int by rememberSaveable { mutableIntStateOf(currentMonth.monthValue) }
+    var year: Int by rememberSaveable { mutableIntStateOf(selectedMonth.year) }
+    var month: Int by rememberSaveable { mutableIntStateOf(selectedMonth.monthValue) }
 
     val years: List<Int> =
         remember(startMonth, endMonth) {
@@ -175,7 +175,7 @@ private fun YearMonthPickerDialogPreview() {
     YearMonthPickerDialog(
         startMonth = YearMonth.now().minusYears(1),
         endMonth = YearMonth.now(),
-        currentMonth = YearMonth.now(),
+        selectedMonth = YearMonth.now(),
         onConfirm = {},
         onCancel = {},
     )

--- a/android/app/src/main/java/com/yagubogu/ui/attendance/model/AttendanceHistorySort.kt
+++ b/android/app/src/main/java/com/yagubogu/ui/attendance/model/AttendanceHistorySort.kt
@@ -1,6 +1,12 @@
 package com.yagubogu.ui.attendance.model
 
 enum class AttendanceHistorySort {
-    LATEST,
-    OLDEST,
+    LATEST {
+        override fun toggle(): AttendanceHistorySort = OLDEST
+    },
+    OLDEST {
+        override fun toggle(): AttendanceHistorySort = LATEST
+    }, ;
+
+    abstract fun toggle(): AttendanceHistorySort
 }


### PR DESCRIPTION
## 📌 관련 이슈
- close #822 

## ✨ 변경 내용
### 월별 직관 내역 조회 API 연동 및 파라미터 수정
직관 내역을 불러올 때 전체가 아닌, 특정 년도와 월을 파라미터로 전달하여 해당 기간의 데이터만 조회하도록 API 호출 로직을 수정했습니다.

## 🎸 기타 참고 사항
- 스크린샷, 참고 링크, 추가 설명 등 (없으면 생략 가능)

https://github.com/user-attachments/assets/bd8fe52a-8210-42ca-a50c-8ec20905599a

