### PR TITLE
feat: 과거 직관 내역 추가 시 Shimmer 효과 적용

### DIFF
--- a/android/app/src/main/java/com/yagubogu/ui/attendance/AttendanceHistoryScreen.kt
+++ b/android/app/src/main/java/com/yagubogu/ui/attendance/AttendanceHistoryScreen.kt
@@ -50,7 +50,7 @@ import com.yagubogu.ui.attendance.model.AttendanceHistoryFilter
 import com.yagubogu.ui.attendance.model.AttendanceHistoryItem
 import com.yagubogu.ui.attendance.model.AttendanceHistorySort
 import com.yagubogu.ui.attendance.model.AttendanceHistoryViewType
-import com.yagubogu.ui.attendance.model.PastGameUiModel
+import com.yagubogu.ui.attendance.model.PastGameUiState
 import com.yagubogu.ui.theme.Black
 import com.yagubogu.ui.theme.Gray050
 import com.yagubogu.ui.theme.Gray200
@@ -78,7 +78,7 @@ fun AttendanceHistoryScreen(
     val currentDate: LocalDate by viewModel.currentDate.collectAsStateWithLifecycle()
     val filter: AttendanceHistoryFilter by viewModel.filter.collectAsStateWithLifecycle()
     val sort: AttendanceHistorySort by viewModel.sort.collectAsStateWithLifecycle()
-    val pastGames: List<PastGameUiModel> by viewModel.pastGames.collectAsStateWithLifecycle()
+    val pastGameUiState: PastGameUiState by viewModel.pastGameUiState.collectAsStateWithLifecycle()
 
     val startMonth: YearMonth = AttendanceHistoryViewModel.START_MONTH
     val endMonth: YearMonth = AttendanceHistoryViewModel.END_MONTH
@@ -120,7 +120,7 @@ fun AttendanceHistoryScreen(
         updateFilter = viewModel::updateFilter,
         sort = sort,
         updateSort = viewModel::updateSort,
-        pastGames = pastGames,
+        pastGameUiState = pastGameUiState,
         onRequestGames = viewModel::fetchPastGames,
         onPastCheckIn = viewModel::addPastCheckIn,
         modifier = modifier,
@@ -143,7 +143,7 @@ private fun AttendanceHistoryScreen(
     updateFilter: (AttendanceHistoryFilter) -> Unit,
     sort: AttendanceHistorySort,
     updateSort: (AttendanceHistorySort) -> Unit,
-    pastGames: List<PastGameUiModel>,
+    pastGameUiState: PastGameUiState,
     onRequestGames: (LocalDate) -> Unit,
     onPastCheckIn: (Long) -> Unit,
     modifier: Modifier = Modifier,
@@ -176,7 +176,7 @@ private fun AttendanceHistoryScreen(
                     onMonthChange = onMonthChange,
                     currentDate = currentDate,
                     onDateChange = onDateChange,
-                    pastGames = pastGames,
+                    pastGameUiState = pastGameUiState,
                     onRequestGames = onRequestGames,
                     onPastCheckIn = onPastCheckIn,
                     scrollToTopEvent = scrollToTopEvent,
@@ -358,7 +358,7 @@ private fun AttendanceCalenderScreenPreview() {
         updateFilter = {},
         sort = AttendanceHistorySort.LATEST,
         updateSort = {},
-        pastGames = listOf(),
+        pastGameUiState = PastGameUiState.Loading,
         onRequestGames = {},
         onPastCheckIn = {},
     )
@@ -381,7 +381,7 @@ private fun AttendanceListScreenPreview() {
         updateFilter = {},
         sort = AttendanceHistorySort.LATEST,
         updateSort = {},
-        pastGames = listOf(),
+        pastGameUiState = PastGameUiState.Loading,
         onRequestGames = {},
         onPastCheckIn = {},
     )

--- a/android/app/src/main/java/com/yagubogu/ui/attendance/component/AttendanceAdditionBottomSheet.kt
+++ b/android/app/src/main/java/com/yagubogu/ui/attendance/component/AttendanceAdditionBottomSheet.kt
@@ -150,7 +150,7 @@ private fun PastGamesContent(
 @Composable
 private fun EmptyPastGameContent(modifier: Modifier = Modifier) {
     Column(
-        modifier = modifier.padding(20.dp),
+        modifier = modifier.padding(horizontal = 20.dp, vertical = 40.dp),
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
         Text(

--- a/android/app/src/main/java/com/yagubogu/ui/attendance/component/AttendanceAdditionBottomSheet.kt
+++ b/android/app/src/main/java/com/yagubogu/ui/attendance/component/AttendanceAdditionBottomSheet.kt
@@ -69,17 +69,36 @@ fun AttendanceAdditionBottomSheet(
         containerColor = Gray050,
         modifier = modifier,
     ) {
-        when (pastGameUiState) {
-            PastGameUiState.Loading -> PastGameLoadingContent()
-            is PastGameUiState.Success -> {
-                when (pastGameUiState.pastGames.isNotEmpty()) {
-                    true ->
-                        PastGamesContent(
-                            items = pastGameUiState.pastGames,
-                            onPastCheckIn = onPastCheckIn,
-                        )
+        val lazyListState: LazyListState = rememberLazyListState()
+        LazyColumn(
+            state = lazyListState,
+            modifier = modifier.fillMaxWidth(),
+            contentPadding = PaddingValues(20.dp),
+            verticalArrangement = Arrangement.spacedBy(20.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            when (pastGameUiState) {
+                PastGameUiState.Loading -> {
+                    item { AttendanceHeader() }
+                    items(3) { PastGameLoadingItem() }
+                }
 
-                    false -> EmptyPastGameContent()
+                is PastGameUiState.Success -> {
+                    when (pastGameUiState.pastGames.isNotEmpty()) {
+                        true -> {
+                            item { AttendanceHeader() }
+                            items(
+                                items = pastGameUiState.pastGames,
+                                key = { item: PastGameUiModel -> item.gameId },
+                            ) { item: PastGameUiModel ->
+                                PastGameItem(
+                                    item = item,
+                                    onPastCheckIn = onPastCheckIn,
+                                )
+                            }
+                        }
+                        false -> item { EmptyPastGameContent() }
+                    }
                 }
             }
         }
@@ -87,90 +106,27 @@ fun AttendanceAdditionBottomSheet(
 }
 
 @Composable
-private fun PastGameLoadingContent(modifier: Modifier = Modifier) {
-    LazyColumn(
-        modifier = modifier.fillMaxWidth(),
-        contentPadding = PaddingValues(20.dp),
-        verticalArrangement = Arrangement.spacedBy(20.dp),
-        horizontalAlignment = Alignment.CenterHorizontally,
-    ) {
-        item {
-            Text(
-                text = stringResource(R.string.attendance_history_add_attendance_description),
-                style = PretendardSemiBold16,
-            )
-        }
-        items(3) {
-            Box(
-                modifier =
-                    Modifier
-                        .fillMaxWidth()
-                        .height(120.dp)
-                        .clip(RoundedCornerShape(12.dp))
-                        .shimmerLoading(),
-            )
-        }
-    }
+private fun AttendanceHeader() {
+    Text(
+        text = stringResource(R.string.attendance_history_add_attendance_description),
+        style = PretendardSemiBold16,
+    )
 }
 
 @Composable
-private fun PastGamesContent(
-    items: List<PastGameUiModel>,
-    onPastCheckIn: (Long) -> Unit,
-    modifier: Modifier = Modifier,
-) {
-    val lazyListState: LazyListState = rememberLazyListState()
-
-    LazyColumn(
-        state = lazyListState,
-        modifier = modifier.fillMaxWidth(),
-        contentPadding = PaddingValues(20.dp),
-        verticalArrangement = Arrangement.spacedBy(20.dp),
-        horizontalAlignment = Alignment.CenterHorizontally,
-    ) {
-        item {
-            Text(
-                text = stringResource(R.string.attendance_history_add_attendance_description),
-                style = PretendardSemiBold16,
-            )
-        }
-
-        items(
-            items = items,
-            key = { item: PastGameUiModel -> item.gameId },
-        ) { item: PastGameUiModel ->
-            PastAttendanceItem(
-                item = item,
-                onPastCheckIn = onPastCheckIn,
-            )
-        }
-    }
+private fun PastGameLoadingItem(modifier: Modifier = Modifier) {
+    Box(
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .height(120.dp)
+                .clip(RoundedCornerShape(12.dp))
+                .shimmerLoading(),
+    )
 }
 
 @Composable
-private fun EmptyPastGameContent(modifier: Modifier = Modifier) {
-    Column(
-        modifier = modifier.padding(horizontal = 20.dp, vertical = 40.dp),
-        horizontalAlignment = Alignment.CenterHorizontally,
-    ) {
-        Text(
-            text = stringResource(R.string.attendance_history_no_game_description),
-            style = PretendardMedium.copy(fontSize = 18.sp, color = Gray400),
-        )
-        Spacer(modifier = Modifier.height(20.dp))
-        Image(
-            painter = painterResource(id = R.drawable.img_baseball_fly_error),
-            contentDescription = null,
-            modifier =
-                Modifier
-                    .height(200.dp)
-                    .fillMaxWidth(),
-        )
-    }
-}
-
-@Composable
-private fun PastAttendanceItem(
+private fun PastGameItem(
     item: PastGameUiModel,
     onPastCheckIn: (Long) -> Unit,
     modifier: Modifier = Modifier,
@@ -230,6 +186,28 @@ private fun PastAttendanceItem(
     }
 }
 
+@Composable
+private fun EmptyPastGameContent(modifier: Modifier = Modifier) {
+    Column(
+        modifier = modifier.padding(horizontal = 20.dp, vertical = 40.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Text(
+            text = stringResource(R.string.attendance_history_no_game_description),
+            style = PretendardMedium.copy(fontSize = 18.sp, color = Gray400),
+        )
+        Spacer(modifier = Modifier.height(20.dp))
+        Image(
+            painter = painterResource(id = R.drawable.img_baseball_fly_error),
+            contentDescription = null,
+            modifier =
+                Modifier
+                    .height(200.dp)
+                    .fillMaxWidth(),
+        )
+    }
+}
+
 @Preview
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -268,8 +246,8 @@ private fun EmptyAttendanceAdditionBottomSheetPreview() {
 
 @Preview
 @Composable
-private fun PastAttendanceItemPreview() {
-    PastAttendanceItem(
+private fun PastGameItemPreview() {
+    PastGameItem(
         item = PAST_GAME_UI_MODELS[0],
         onPastCheckIn = { },
     )

--- a/android/app/src/main/java/com/yagubogu/ui/attendance/component/AttendanceCalendarContent.kt
+++ b/android/app/src/main/java/com/yagubogu/ui/attendance/component/AttendanceCalendarContent.kt
@@ -37,7 +37,7 @@ import com.google.firebase.Firebase
 import com.google.firebase.analytics.analytics
 import com.yagubogu.R
 import com.yagubogu.ui.attendance.model.AttendanceHistoryItem
-import com.yagubogu.ui.attendance.model.PastGameUiModel
+import com.yagubogu.ui.attendance.model.PastGameUiState
 import com.yagubogu.ui.theme.PretendardBold16
 import com.yagubogu.ui.theme.Primary500
 import com.yagubogu.ui.theme.White
@@ -56,7 +56,7 @@ fun AttendanceCalendarContent(
     onMonthChange: (YearMonth) -> Unit,
     currentDate: LocalDate,
     onDateChange: (LocalDate) -> Unit,
-    pastGames: List<PastGameUiModel>,
+    pastGameUiState: PastGameUiState,
     onRequestGames: (LocalDate) -> Unit,
     onPastCheckIn: (Long) -> Unit,
     modifier: Modifier = Modifier,
@@ -76,7 +76,7 @@ fun AttendanceCalendarContent(
 
     if (showBottomSheet) {
         AttendanceAdditionBottomSheet(
-            items = pastGames,
+            pastGameUiState = pastGameUiState,
             date = currentDate,
             onPastCheckIn = { gameId: Long ->
                 onPastCheckIn(gameId)
@@ -186,7 +186,7 @@ private fun AttendanceCalendarContentPreview() {
         onMonthChange = {},
         currentDate = LocalDate.now(),
         onDateChange = {},
-        pastGames = listOf(),
+        pastGameUiState = PastGameUiState.Loading,
         onRequestGames = {},
         onPastCheckIn = {},
     )
@@ -203,7 +203,7 @@ private fun AttendanceCalendarContentNoItemPreview() {
         onMonthChange = {},
         currentDate = LocalDate.now(),
         onDateChange = {},
-        pastGames = listOf(),
+        pastGameUiState = PastGameUiState.Loading,
         onRequestGames = {},
         onPastCheckIn = {},
     )

--- a/android/app/src/main/java/com/yagubogu/ui/attendance/model/PastGameUiState.kt
+++ b/android/app/src/main/java/com/yagubogu/ui/attendance/model/PastGameUiState.kt
@@ -1,0 +1,9 @@
+package com.yagubogu.ui.attendance.model
+
+sealed class PastGameUiState {
+    data object Loading : PastGameUiState()
+
+    data class Success(
+        val pastGames: List<PastGameUiModel>,
+    ) : PastGameUiState()
+}


### PR DESCRIPTION
## 📌 관련 이슈
- close #828 

## ✨ 변경 내용
과거 직관 내역을 추가할 때 데이터 로딩 중에 Shimmer 효과를 적용했습니다.
`PastGameUiState`를 `Loading`과 `Success`로 구분하여 `Loading`인 경우 Shimmer UI를 보여주도록 구현했습니다.

## 🎸 기타 참고 사항
- 스크린샷, 참고 링크, 추가 설명 등 (없으면 생략 가능)

https://github.com/user-attachments/assets/888af8c1-c165-4eef-9e92-4615e857c07f


