### PR TITLE
refactor: 의존성 라이브러리 카테고리별 그룹화

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -8,7 +8,6 @@ plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlinx.serialization)
-    alias(libs.plugins.kotlin.kapt)
     alias(libs.plugins.google.services)
     alias(libs.plugins.firebase.crashlytics)
     alias(libs.plugins.kotlin.parcelize)
@@ -119,9 +118,7 @@ dependencies {
     implementation(libs.androidx.core.splashscreen)
     implementation(libs.androidx.appcompat)
     implementation(libs.androidx.activity)
-    implementation(libs.androidx.constraintlayout)
     implementation(libs.androidx.fragment.ktx)
-    implementation(libs.androidx.viewpager2)
     implementation(libs.androidx.datastore.preferences)
 
     // Kotlinx
@@ -162,7 +159,6 @@ dependencies {
     implementation(libs.androidx.ui)
     implementation(libs.androidx.ui.graphics)
     implementation(libs.androidx.ui.tooling.preview)
-    implementation(libs.androidx.runtime.livedata)
     implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.lifecycle.runtime.compose)
 
@@ -179,13 +175,10 @@ dependencies {
     // Image Loading
     implementation(libs.coil.compose)
     implementation(libs.coil.network.okhttp)
-    implementation(libs.glide)
     implementation(libs.ucrop)
 
     // UI Components
     implementation(libs.material)
-    implementation(libs.shimmer)
-    implementation(libs.balloon)
     implementation(libs.balloon.compose)
     implementation(libs.calendar.compose)
 

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -114,86 +114,95 @@ kotlin {
 }
 
 dependencies {
+    // AndroidX Core
     implementation(libs.androidx.core.ktx)
+    implementation(libs.androidx.core.splashscreen)
     implementation(libs.androidx.appcompat)
-    implementation(libs.material)
     implementation(libs.androidx.activity)
     implementation(libs.androidx.constraintlayout)
     implementation(libs.androidx.fragment.ktx)
+    implementation(libs.androidx.viewpager2)
+    implementation(libs.androidx.datastore.preferences)
+
+    // Kotlinx
     implementation(libs.kotlinx.serialization.json)
     implementation(libs.kotlinx.datetime)
-    implementation(libs.androidx.viewpager2)
-    implementation(libs.play.services.location)
-    implementation(libs.androidx.core.splashscreen)
-    implementation(libs.timber)
-    implementation(libs.androidx.datastore.preferences)
-    implementation(libs.glide)
-    implementation(libs.play.services.oss.licenses)
-    implementation(libs.shimmer)
-    implementation(libs.balloon)
-    implementation(libs.balloon.compose)
-    implementation(libs.ucrop)
-    implementation(libs.calendar.compose)
 
     // Ktor & Ktorfit
     implementation(libs.ktorfit.lib)
     implementation(libs.ktor.client.core)
+    implementation(libs.ktor.client.okhttp)
     implementation(libs.ktor.client.content.negotiation)
     implementation(libs.ktor.serialization.kotlinx.json)
-    implementation(libs.ktor.client.okhttp)
     implementation(libs.ktor.client.auth)
     implementation(libs.ktor.client.logging)
 
-    // firebase
+    // Firebase
     implementation(platform(libs.firebase.bom))
     implementation(libs.firebase.analytics)
     implementation(libs.firebase.crashlytics.ndk)
 
-    // google credentials
+    // Google Credentials
     implementation(libs.androidx.credentials)
     implementation(libs.androidx.credentials.play.services.auth)
     implementation(libs.google.googleid)
 
-    // play in-app update
+    // Google Services
+    implementation(libs.play.services.location)
+    implementation(libs.play.services.oss.licenses)
+
+    // Play In-App Update
     implementation(libs.app.update)
     implementation(libs.app.update.ktx)
 
-    // compose
+    // Compose
     implementation(libs.androidx.activity.compose)
     implementation(platform(libs.androidx.compose.bom))
     implementation(libs.androidx.material3)
-    implementation(libs.androidx.runtime.livedata)
-    implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.ui)
     implementation(libs.androidx.ui.graphics)
     implementation(libs.androidx.ui.tooling.preview)
+    implementation(libs.androidx.runtime.livedata)
+    implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.lifecycle.runtime.compose)
 
-    // navigation3
+    // Navigation3
     implementation(libs.androidx.navigation3.ui)
     implementation(libs.androidx.navigation3.runtime)
     implementation(libs.androidx.lifecycle.viewmodel.navigation3)
     implementation(libs.androidx.hilt.navigation.compose)
 
-    // coil
-    implementation(libs.coil.compose)
-    implementation(libs.coil.network.okhttp)
-
-    // kotest
-    testImplementation(libs.kotest.runner.junit5)
-    testImplementation(libs.kotest.assertions.core)
-
-    // hilt
+    // Hilt
     implementation(libs.hilt.android)
     ksp(libs.hilt.android.compiler)
 
-    testImplementation(libs.kotlinx.coroutines.test)
+    // Image Loading
+    implementation(libs.coil.compose)
+    implementation(libs.coil.network.okhttp)
+    implementation(libs.glide)
+    implementation(libs.ucrop)
+
+    // UI Components
+    implementation(libs.material)
+    implementation(libs.shimmer)
+    implementation(libs.balloon)
+    implementation(libs.balloon.compose)
+    implementation(libs.calendar.compose)
+
+    // Logging
+    implementation(libs.timber)
+
+    // Testing
     testImplementation(libs.junit)
+    testImplementation(libs.kotest.runner.junit5)
+    testImplementation(libs.kotest.assertions.core)
+    testImplementation(libs.kotlinx.coroutines.test)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
     androidTestImplementation(platform(libs.androidx.compose.bom))
     androidTestImplementation(libs.androidx.ui.test.junit4)
 
+    // Debug
     debugImplementation(libs.androidx.ui.tooling)
     debugImplementation(libs.androidx.ui.test.manifest)
 }

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -14,9 +14,7 @@ coreSplashscreen = "1.2.0"
 appcompat = "1.7.1"
 activity = "1.10.1"
 activityCompose = "1.10.1"
-constraintlayout = "2.2.1"
 fragmentKtx = "1.8.8"
-viewpager2 = "1.1.0"
 datastorePreferences = "1.1.7"
 credentials = "1.5.0"
 
@@ -57,12 +55,10 @@ appUpdate = "2.1.0"
 # Image Loading
 coilCompose = "3.3.0"
 coilNetworkOkhttp = "3.3.0"
-glide = "4.16.0"
 ucrop = "2.2.11"
 
 # UI Components
 material = "1.12.0"
-shimmer = "0.5.0"
 balloon = "1.6.13"
 calendar = "2.9.0"
 
@@ -82,9 +78,7 @@ androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = 
 androidx-core-splashscreen = { module = "androidx.core:core-splashscreen", version.ref = "coreSplashscreen" }
 androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
 androidx-activity = { group = "androidx.activity", name = "activity", version.ref = "activity" }
-androidx-constraintlayout = { group = "androidx.constraintlayout", name = "constraintlayout", version.ref = "constraintlayout" }
 androidx-fragment-ktx = { module = "androidx.fragment:fragment-ktx", version.ref = "fragmentKtx" }
-androidx-viewpager2 = { module = "androidx.viewpager2:viewpager2", version.ref = "viewpager2" }
 androidx-datastore-preferences = { module = "androidx.datastore:datastore-preferences", version.ref = "datastorePreferences" }
 
 # AndroidX Lifecycle
@@ -106,7 +100,6 @@ androidx-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling" }
 androidx-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview" }
 androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
-androidx-runtime-livedata = { module = "androidx.compose.runtime:runtime-livedata" }
 
 # Navigation3
 androidx-navigation3-runtime = { module = "androidx.navigation3:navigation3-runtime", version.ref = "nav3Core" }
@@ -148,13 +141,10 @@ app-update-ktx = { module = "com.google.android.play:app-update-ktx", version.re
 # Image Loading
 coil-compose = { module = "io.coil-kt.coil3:coil-compose", version.ref = "coilCompose" }
 coil-network-okhttp = { module = "io.coil-kt.coil3:coil-network-okhttp", version.ref = "coilNetworkOkhttp" }
-glide = { module = "com.github.bumptech.glide:glide", version.ref = "glide" }
 ucrop = { module = "com.github.yalantis:ucrop", version.ref = "ucrop" }
 
 # UI Components
 material = { group = "com.google.android.material", name = "material", version.ref = "material" }
-shimmer = { module = "com.facebook.shimmer:shimmer", version.ref = "shimmer" }
-balloon = { module = "com.github.skydoves:balloon", version.ref = "balloon" }
 balloon-compose = { module = "com.github.skydoves:balloon-compose", version.ref = "balloon" }
 calendar-compose = { module = "com.kizitonwose.calendar:compose", version.ref = "calendar" }
 
@@ -174,7 +164,6 @@ kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlint" }
 kotlinx-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
-kotlin-kapt = { id = "org.jetbrains.kotlin.kapt" }
 google-services = { id = "com.google.gms.google-services", version.ref = "googleServices" }
 firebase-crashlytics = { id = "com.google.firebase.crashlytics", version.ref = "firebaseCrashlytics" }
 kotlin-parcelize = { id = "org.jetbrains.kotlin.plugin.parcelize" }

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -1,64 +1,102 @@
 [versions]
+# Build Tools & Plugins
 agp = "8.12.3"
-balloon = "1.6.13"
-appUpdate = "2.1.0"
-calendar = "2.9.0"
-coilCompose = "3.3.0"
-coilNetworkOkhttp = "3.3.0"
-coreSplashscreen = "1.2.0"
-credentials = "1.5.0"
-datastorePreferences = "1.1.7"
-firebaseBom = "34.0.0"
-fragmentKtx = "1.8.8"
-hiltAndroid = "2.57.2"
-hiltNavigationCompose = "1.3.0"
-kotestAssertionsCore = "6.0.3"
-kotestRunnerJunit5 = "6.0.3"
 kotlin = "2.2.20"
-coreKtx = "1.16.0"
-junit = "4.13.2"
-junitVersion = "1.2.1"
-espressoCore = "3.6.1"
-appcompat = "1.7.1"
-kotlinxCoroutinesTest = "1.10.2"
-kotlinxDatetime = "0.7.1"
-kotlinxSerializationJson = "1.9.0"
-lifecycleRuntime = "2.10.0"
-material = "1.12.0"
-activity = "1.10.1"
-constraintlayout = "2.2.1"
+ksp = "2.3.4"
 ktlint = "13.0.0"
-playServicesOssLicenses = "17.2.2"
-shimmer = "0.5.0"
-timber = "5.0.1"
-ucrop = "2.2.11"
-viewpager2 = "1.1.0"
-playServicesLocation = "21.3.0"
 googleServices = "4.4.3"
 firebaseCrashlytics = "3.0.5"
-googleidVersion = "1.1.1"
-glide = "4.16.0"
 googleOssLicenses = "0.10.7"
+
+# AndroidX Core
+coreKtx = "1.16.0"
+coreSplashscreen = "1.2.0"
+appcompat = "1.7.1"
+activity = "1.10.1"
 activityCompose = "1.10.1"
-composeBom = "2025.08.01"
-ksp = "2.3.4"
-nav3Core = "1.0.0"
+constraintlayout = "2.2.1"
+fragmentKtx = "1.8.8"
+viewpager2 = "1.1.0"
+datastorePreferences = "1.1.7"
+credentials = "1.5.0"
+
+# AndroidX Lifecycle
+lifecycleRuntime = "2.10.0"
 lifecycleViewmodelNav3 = "2.10.0"
+
+# Compose
+composeBom = "2025.08.01"
+
+# Navigation3
+nav3Core = "1.0.0"
+hiltNavigationCompose = "1.3.0"
+
+# Hilt
+hiltAndroid = "2.57.2"
+
+# Ktor & Ktorfit
 ktor = "3.3.3"
 ktorfit = "2.7.1"
 
+# Kotlinx
+kotlinxSerializationJson = "1.9.0"
+kotlinxDatetime = "0.7.1"
+kotlinxCoroutinesTest = "1.10.2"
+
+# Firebase
+firebaseBom = "34.0.0"
+
+# Google Services
+googleidVersion = "1.1.1"
+playServicesLocation = "21.3.0"
+playServicesOssLicenses = "17.2.2"
+
+# Play In-App Update
+appUpdate = "2.1.0"
+
+# Image Loading
+coilCompose = "3.3.0"
+coilNetworkOkhttp = "3.3.0"
+glide = "4.16.0"
+ucrop = "2.2.11"
+
+# UI Components
+material = "1.12.0"
+shimmer = "0.5.0"
+balloon = "1.6.13"
+calendar = "2.9.0"
+
+# Logging
+timber = "5.0.1"
+
+# Testing
+junit = "4.13.2"
+junitVersion = "1.2.1"
+espressoCore = "3.6.1"
+kotestAssertionsCore = "6.0.3"
+kotestRunnerJunit5 = "6.0.3"
+
 [libraries]
+# AndroidX Core
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
 androidx-core-splashscreen = { module = "androidx.core:core-splashscreen", version.ref = "coreSplashscreen" }
-androidx-credentials = { module = "androidx.credentials:credentials", version.ref = "credentials" }
-androidx-credentials-play-services-auth = { module = "androidx.credentials:credentials-play-services-auth", version.ref = "credentials" }
-androidx-datastore-preferences = { module = "androidx.datastore:datastore-preferences", version.ref = "datastorePreferences" }
+androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
+androidx-activity = { group = "androidx.activity", name = "activity", version.ref = "activity" }
+androidx-constraintlayout = { group = "androidx.constraintlayout", name = "constraintlayout", version.ref = "constraintlayout" }
 androidx-fragment-ktx = { module = "androidx.fragment:fragment-ktx", version.ref = "fragmentKtx" }
+androidx-viewpager2 = { module = "androidx.viewpager2:viewpager2", version.ref = "viewpager2" }
+androidx-datastore-preferences = { module = "androidx.datastore:datastore-preferences", version.ref = "datastorePreferences" }
+
+# AndroidX Lifecycle
 androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycleRuntime" }
 androidx-lifecycle-runtime-compose = { group = "androidx.lifecycle", name = "lifecycle-runtime-compose", version.ref = "lifecycleRuntime" }
-androidx-hilt-navigation-compose = { module = "androidx.hilt:hilt-navigation-compose", version.ref = "hiltNavigationCompose" }
-androidx-runtime-livedata = { module = "androidx.compose.runtime:runtime-livedata" }
-androidx-viewpager2 = { module = "androidx.viewpager2:viewpager2", version.ref = "viewpager2" }
+androidx-lifecycle-viewmodel-navigation3 = { module = "androidx.lifecycle:lifecycle-viewmodel-navigation3", version.ref = "lifecycleViewmodelNav3" }
+
+# AndroidX Credentials
+androidx-credentials = { module = "androidx.credentials:credentials", version.ref = "credentials" }
+androidx-credentials-play-services-auth = { module = "androidx.credentials:credentials-play-services-auth", version.ref = "credentials" }
+
+# Compose
 androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activityCompose" }
 androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "composeBom" }
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
@@ -68,47 +106,67 @@ androidx-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling" }
 androidx-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview" }
 androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
-balloon = { module = "com.github.skydoves:balloon", version.ref = "balloon" }
-balloon-compose = { module = "com.github.skydoves:balloon-compose", version.ref = "balloon" }
-app-update = { module = "com.google.android.play:app-update", version.ref = "appUpdate" }
-app-update-ktx = { module = "com.google.android.play:app-update-ktx", version.ref = "appUpdate" }
-calendar-compose = { module = "com.kizitonwose.calendar:compose", version.ref = "calendar" }
-coil-network-okhttp = { module = "io.coil-kt.coil3:coil-network-okhttp", version.ref = "coilNetworkOkhttp" }
-coil-compose = { module = "io.coil-kt.coil3:coil-compose", version.ref = "coilCompose" }
-firebase-analytics = { module = "com.google.firebase:firebase-analytics" }
-firebase-bom = { module = "com.google.firebase:firebase-bom", version.ref = "firebaseBom" }
-firebase-crashlytics-ndk = { module = "com.google.firebase:firebase-crashlytics-ndk" }
+androidx-runtime-livedata = { module = "androidx.compose.runtime:runtime-livedata" }
+
+# Navigation3
+androidx-navigation3-runtime = { module = "androidx.navigation3:navigation3-runtime", version.ref = "nav3Core" }
+androidx-navigation3-ui = { module = "androidx.navigation3:navigation3-ui", version.ref = "nav3Core" }
+androidx-hilt-navigation-compose = { module = "androidx.hilt:hilt-navigation-compose", version.ref = "hiltNavigationCompose" }
+
+# Hilt
 hilt-android = { module = "com.google.dagger:hilt-android", version.ref = "hiltAndroid" }
 hilt-android-compiler = { module = "com.google.dagger:hilt-android-compiler", version.ref = "hiltAndroid" }
+
+# Ktor & Ktorfit
+ktorfit-lib = { module = "de.jensklingenberg.ktorfit:ktorfit-lib", version.ref = "ktorfit" }
+ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
+ktor-client-okhttp = { module = "io.ktor:ktor-client-okhttp", version.ref = "ktor" }
+ktor-client-content-negotiation = { module = "io.ktor:ktor-client-content-negotiation", version.ref = "ktor" }
+ktor-serialization-kotlinx-json = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktor" }
+ktor-client-auth = { module = "io.ktor:ktor-client-auth", version.ref = "ktor" }
+ktor-client-logging = { module = "io.ktor:ktor-client-logging", version.ref = "ktor" }
+
+# Kotlinx
+kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerializationJson" }
+kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "kotlinxDatetime" }
+kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinxCoroutinesTest" }
+
+# Firebase
+firebase-bom = { module = "com.google.firebase:firebase-bom", version.ref = "firebaseBom" }
+firebase-analytics = { module = "com.google.firebase:firebase-analytics" }
+firebase-crashlytics-ndk = { module = "com.google.firebase:firebase-crashlytics-ndk" }
+
+# Google Services
+google-googleid = { group = "com.google.android.libraries.identity.googleid", name = "googleid", version.ref = "googleidVersion" }
+play-services-location = { group = "com.google.android.gms", name = "play-services-location", version.ref = "playServicesLocation" }
+play-services-oss-licenses = { module = "com.google.android.gms:play-services-oss-licenses", version.ref = "playServicesOssLicenses" }
+
+# Play In-App Update
+app-update = { module = "com.google.android.play:app-update", version.ref = "appUpdate" }
+app-update-ktx = { module = "com.google.android.play:app-update-ktx", version.ref = "appUpdate" }
+
+# Image Loading
+coil-compose = { module = "io.coil-kt.coil3:coil-compose", version.ref = "coilCompose" }
+coil-network-okhttp = { module = "io.coil-kt.coil3:coil-network-okhttp", version.ref = "coilNetworkOkhttp" }
+glide = { module = "com.github.bumptech.glide:glide", version.ref = "glide" }
+ucrop = { module = "com.github.yalantis:ucrop", version.ref = "ucrop" }
+
+# UI Components
+material = { group = "com.google.android.material", name = "material", version.ref = "material" }
+shimmer = { module = "com.facebook.shimmer:shimmer", version.ref = "shimmer" }
+balloon = { module = "com.github.skydoves:balloon", version.ref = "balloon" }
+balloon-compose = { module = "com.github.skydoves:balloon-compose", version.ref = "balloon" }
+calendar-compose = { module = "com.kizitonwose.calendar:compose", version.ref = "calendar" }
+
+# Logging
+timber = { module = "com.jakewharton.timber:timber", version.ref = "timber" }
+
+# Testing
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }
-androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
 kotest-assertions-core = { module = "io.kotest:kotest-assertions-core", version.ref = "kotestAssertionsCore" }
 kotest-runner-junit5 = { module = "io.kotest:kotest-runner-junit5", version.ref = "kotestRunnerJunit5" }
-kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinxCoroutinesTest" }
-kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "kotlinxDatetime" }
-kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerializationJson" }
-ktor-client-auth = { module = "io.ktor:ktor-client-auth", version.ref = "ktor" }
-ktor-client-logging = { module = "io.ktor:ktor-client-logging", version.ref = "ktor" }
-ktor-client-okhttp = { module = "io.ktor:ktor-client-okhttp", version.ref = "ktor" }
-ktor-serialization-kotlinx-json = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktor" }
-ktor-client-content-negotiation = { module = "io.ktor:ktor-client-content-negotiation", version.ref = "ktor" }
-ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
-ktorfit-lib = { module = "de.jensklingenberg.ktorfit:ktorfit-lib", version.ref = "ktorfit" }
-material = { group = "com.google.android.material", name = "material", version.ref = "material" }
-androidx-activity = { group = "androidx.activity", name = "activity", version.ref = "activity" }
-androidx-constraintlayout = { group = "androidx.constraintlayout", name = "constraintlayout", version.ref = "constraintlayout" }
-play-services-location = { group = "com.google.android.gms", name = "play-services-location", version.ref = "playServicesLocation" }
-play-services-oss-licenses = { module = "com.google.android.gms:play-services-oss-licenses", version.ref = "playServicesOssLicenses" }
-shimmer = { module = "com.facebook.shimmer:shimmer", version.ref = "shimmer" }
-timber = { module = "com.jakewharton.timber:timber", version.ref = "timber" }
-google-googleid = { group = "com.google.android.libraries.identity.googleid", name = "googleid", version.ref = "googleidVersion" }
-glide = { module = "com.github.bumptech.glide:glide", version.ref = "glide" }
-androidx-navigation3-runtime = { module = "androidx.navigation3:navigation3-runtime", version.ref = "nav3Core" }
-androidx-navigation3-ui = { module = "androidx.navigation3:navigation3-ui", version.ref = "nav3Core" }
-androidx-lifecycle-viewmodel-navigation3 = { module = "androidx.lifecycle:lifecycle-viewmodel-navigation3", version.ref = "lifecycleViewmodelNav3" }
-ucrop = { module = "com.github.yalantis:ucrop", version.ref = "ucrop" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## 📌 관련 이슈
- close #843 

## ✨ 변경 내용
### 변경 사항
- [versions] 섹션: 버전 정의를 카테고리별 주석으로 그룹화                                                                                                                                              
- [libraries] 섹션: 라이브러리 선언을 카테고리별 주석으로 그룹화                                                                                                                                       
- dependencies 블록: 의존성 선언을 카테고리별 주석으로 그룹화

### 목적
- 의존성 관리 가독성 향상                                                                                                                                                                              
- 관련 라이브러리를 쉽게 찾고 관리할 수 있도록 개선

## 🎸 기타 참고 사항
- 스크린샷, 참고 링크, 추가 설명 등 (없으면 생략 가능)