### PR TITLE
feat: 명예의 전당 api 구현

### DIFF
--- a/backend/app/src/main/java/com/yagubogu/checkin/repository/CheckInRepository.java
+++ b/backend/app/src/main/java/com/yagubogu/checkin/repository/CheckInRepository.java
@@ -3,7 +3,7 @@ package com.yagubogu.checkin.repository;
 import com.yagubogu.checkin.domain.CheckIn;
 import com.yagubogu.checkin.domain.CheckInType;
 import com.yagubogu.game.domain.Game;
-import com.yagubogu.leaderboard.dto.LeaderboardItemResponse;
+import com.yagubogu.leaderboard.dto.LeaderboardRow;
 import com.yagubogu.member.domain.Member;
 import com.yagubogu.stat.dto.StadiumStatsParam;
 import java.time.LocalDate;
@@ -72,31 +72,35 @@ public interface CheckInRepository extends JpaRepository<CheckIn, Long>, CustomC
 
     @Query(value = """
             WITH member_counts AS (
-              SELECT
-                m.member_id AS memberId,
-                m.nickname AS nickname,
-                t.short_name AS favoriteTeam,
-                m.image_url AS profileImageUrl,
-                COUNT(*) AS checkInCount
-              FROM check_ins ci
-              JOIN games g   ON g.game_id = ci.game_id
-              JOIN members m ON m.member_id = ci.member_id
-              JOIN teams t   ON t.team_id = m.team_id
-              WHERE g.date >= '2025-01-01' AND g.date < '2026-01-01'
-                AND m.deleted_at IS NULL
-                AND m.team_id IS NOT NULL
-              GROUP BY m.member_id, m.nickname, t.short_name, m.image_url
-            ),
-            ranked AS (
-              SELECT
-                DENSE_RANK() OVER (ORDER BY checkInCount DESC) AS `rank`,
-                memberId, nickname, favoriteTeam, profileImageUrl, checkInCount
-              FROM member_counts
-            )
-            SELECT `rank`, memberId, nickname, favoriteTeam, profileImageUrl
-            FROM ranked
-            WHERE `rank` <= :limit
-            ORDER BY `rank` ASC, memberId ASC
+               SELECT
+                 ci.member_id AS memberId,
+                 COUNT(*) AS checkInCount
+               FROM check_ins ci
+               JOIN games g ON g.game_id = ci.game_id
+               WHERE g.date >= '2025-01-01' AND g.date < '2026-01-01'
+               GROUP BY ci.member_id
+             ),
+             ranked AS (
+               SELECT
+                 DENSE_RANK() OVER (ORDER BY mc.checkInCount DESC) AS `rank`,
+                 mc.memberId,
+                 mc.checkInCount
+               FROM member_counts mc
+             )
+             SELECT
+               r.`rank` AS `rank`,
+               m.member_id AS memberId,
+               m.nickname AS nickname,
+               t.short_name AS favoriteTeam,
+               m.image_url AS profileImageUrl,
+               r.checkInCount AS score
+             FROM ranked r
+             JOIN members m ON m.member_id = r.memberId
+             JOIN teams t ON t.team_id = m.team_id
+             WHERE r.`rank` <= :limit
+               AND m.deleted_at IS NULL
+               AND m.team_id IS NOT NULL
+             ORDER BY r.`rank` ASC, m.member_id ASC
             """, nativeQuery = true)
-    List<LeaderboardItemResponse> findMostCheckInWinner(@Param("limit") int limit);
+    List<LeaderboardRow> findMostCheckInWinner(@Param("limit") int limit);
 }

--- a/backend/app/src/main/java/com/yagubogu/checkin/repository/CheckInRepository.java
+++ b/backend/app/src/main/java/com/yagubogu/checkin/repository/CheckInRepository.java
@@ -3,6 +3,7 @@ package com.yagubogu.checkin.repository;
 import com.yagubogu.checkin.domain.CheckIn;
 import com.yagubogu.checkin.domain.CheckInType;
 import com.yagubogu.game.domain.Game;
+import com.yagubogu.leaderboard.dto.LeaderboardItemResponse;
 import com.yagubogu.member.domain.Member;
 import com.yagubogu.stat.dto.StadiumStatsParam;
 import java.time.LocalDate;
@@ -68,4 +69,34 @@ public interface CheckInRepository extends JpaRepository<CheckIn, Long>, CustomC
     );
 
     boolean existsByGameAndMember(Game game, Member member);
+
+    @Query(value = """
+            WITH member_counts AS (
+              SELECT
+                m.member_id AS memberId,
+                m.nickname AS nickname,
+                t.short_name AS favoriteTeam,
+                m.image_url AS profileImageUrl,
+                COUNT(*) AS checkInCount
+              FROM check_ins ci
+              JOIN games g   ON g.game_id = ci.game_id
+              JOIN members m ON m.member_id = ci.member_id
+              JOIN teams t   ON t.team_id = m.team_id
+              WHERE g.date >= '2025-01-01' AND g.date < '2026-01-01'
+                AND m.deleted_at IS NULL
+                AND m.team_id IS NOT NULL
+              GROUP BY m.member_id, m.nickname, t.short_name, m.image_url
+            ),
+            ranked AS (
+              SELECT
+                DENSE_RANK() OVER (ORDER BY checkInCount DESC) AS `rank`,
+                memberId, nickname, favoriteTeam, profileImageUrl, checkInCount
+              FROM member_counts
+            )
+            SELECT `rank`, memberId, nickname, favoriteTeam, profileImageUrl
+            FROM ranked
+            WHERE `rank` <= :limit
+            ORDER BY `rank` ASC, memberId ASC
+            """, nativeQuery = true)
+    List<LeaderboardItemResponse> findMostCheckInWinner(@Param("limit") int limit);
 }

--- a/backend/app/src/main/java/com/yagubogu/checkin/repository/CheckInRepository.java
+++ b/backend/app/src/main/java/com/yagubogu/checkin/repository/CheckInRepository.java
@@ -78,7 +78,10 @@ public interface CheckInRepository extends JpaRepository<CheckIn, Long>, CustomC
                  COUNT(*) AS checkInCount
                FROM check_ins ci
                JOIN games g ON g.game_id = ci.game_id
+               JOIN members m ON m.member_id = ci.member_id
                WHERE g.date >= :startAt AND g.date < :endAt
+                    AND m.deleted_at IS NULL
+                    AND m.team_id IS NOT NULL
                GROUP BY ci.member_id
              ),
              ranked AS (
@@ -99,8 +102,6 @@ public interface CheckInRepository extends JpaRepository<CheckIn, Long>, CustomC
              JOIN members m ON m.member_id = r.memberId
              JOIN teams t ON t.team_id = m.team_id
              WHERE r.rnk <= :limit
-               AND m.deleted_at IS NULL
-               AND m.team_id IS NOT NULL
              ORDER BY r.rnk ASC, m.member_id ASC
             """, nativeQuery = true)
     List<LeaderboardRow> findMostCheckInWinner(

--- a/backend/app/src/main/java/com/yagubogu/checkin/repository/CheckInRepository.java
+++ b/backend/app/src/main/java/com/yagubogu/checkin/repository/CheckInRepository.java
@@ -7,6 +7,7 @@ import com.yagubogu.leaderboard.dto.LeaderboardRow;
 import com.yagubogu.member.domain.Member;
 import com.yagubogu.stat.dto.StadiumStatsParam;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -77,7 +78,7 @@ public interface CheckInRepository extends JpaRepository<CheckIn, Long>, CustomC
                  COUNT(*) AS checkInCount
                FROM check_ins ci
                JOIN games g ON g.game_id = ci.game_id
-               WHERE g.date >= '2025-01-01' AND g.date < '2026-01-01'
+               WHERE g.date >= :startAt AND g.date < :endAt
                GROUP BY ci.member_id
              ),
              ranked AS (
@@ -93,7 +94,7 @@ public interface CheckInRepository extends JpaRepository<CheckIn, Long>, CustomC
                m.nickname AS nickname,
                t.short_name AS favoriteTeam,
                m.image_url AS profileImageUrl,
-               r.checkInCount AS score
+               CAST(r.checkInCount AS DOUBLE) AS score
              FROM ranked r
              JOIN members m ON m.member_id = r.memberId
              JOIN teams t ON t.team_id = m.team_id
@@ -102,5 +103,9 @@ public interface CheckInRepository extends JpaRepository<CheckIn, Long>, CustomC
                AND m.team_id IS NOT NULL
              ORDER BY r.rnk ASC, m.member_id ASC
             """, nativeQuery = true)
-    List<LeaderboardRow> findMostCheckInWinner(@Param("limit") int limit);
+    List<LeaderboardRow> findMostCheckInWinner(
+            @Param("limit") int limit,
+            @Param("startAt") LocalDateTime startAt,
+            @Param("endAt") LocalDateTime endAt
+    );
 }

--- a/backend/app/src/main/java/com/yagubogu/checkin/repository/CheckInRepository.java
+++ b/backend/app/src/main/java/com/yagubogu/checkin/repository/CheckInRepository.java
@@ -82,13 +82,13 @@ public interface CheckInRepository extends JpaRepository<CheckIn, Long>, CustomC
              ),
              ranked AS (
                SELECT
-                 DENSE_RANK() OVER (ORDER BY mc.checkInCount DESC) AS `rank`,
+                 DENSE_RANK() OVER (ORDER BY mc.checkInCount DESC) AS rnk,
                  mc.memberId,
                  mc.checkInCount
                FROM member_counts mc
              )
              SELECT
-               r.`rank` AS `rank`,
+               r.rnk AS rank_no,
                m.member_id AS memberId,
                m.nickname AS nickname,
                t.short_name AS favoriteTeam,
@@ -97,10 +97,10 @@ public interface CheckInRepository extends JpaRepository<CheckIn, Long>, CustomC
              FROM ranked r
              JOIN members m ON m.member_id = r.memberId
              JOIN teams t ON t.team_id = m.team_id
-             WHERE r.`rank` <= :limit
+             WHERE r.rnk <= :limit
                AND m.deleted_at IS NULL
                AND m.team_id IS NOT NULL
-             ORDER BY r.`rank` ASC, m.member_id ASC
+             ORDER BY r.rnk ASC, m.member_id ASC
             """, nativeQuery = true)
     List<LeaderboardRow> findMostCheckInWinner(@Param("limit") int limit);
 }

--- a/backend/app/src/main/java/com/yagubogu/leaderboard/controller/v1/LeaderboardController.java
+++ b/backend/app/src/main/java/com/yagubogu/leaderboard/controller/v1/LeaderboardController.java
@@ -17,6 +17,7 @@ public class LeaderboardController implements LeaderboardControllerInterface {
     @Override
     public ResponseEntity<LeaderboardsResponse> findAllTop(final int limit) {
         var responses = leaderboardService.findAllTop(limit);
+        
         return ResponseEntity.ok(LeaderboardsResponse.of(responses));
     }
 }

--- a/backend/app/src/main/java/com/yagubogu/leaderboard/controller/v1/LeaderboardController.java
+++ b/backend/app/src/main/java/com/yagubogu/leaderboard/controller/v1/LeaderboardController.java
@@ -1,0 +1,24 @@
+package com.yagubogu.leaderboard.controller.v1;
+
+import com.yagubogu.auth.annotation.RequireRole;
+import com.yagubogu.leaderboard.domain.LeaderboardType;
+import com.yagubogu.leaderboard.dto.LeaderboardResponse;
+import com.yagubogu.leaderboard.service.LeaderboardService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RequireRole
+@RestController
+public class LeaderboardController implements LeaderboardControllerInterface {
+
+    private final LeaderboardService leaderboardService;
+
+    @Override
+    public ResponseEntity<LeaderboardResponse> findTop(final LeaderboardType type, final int limit) {
+
+        LeaderboardResponse response = leaderboardService.findTop(type, limit);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/backend/app/src/main/java/com/yagubogu/leaderboard/controller/v1/LeaderboardController.java
+++ b/backend/app/src/main/java/com/yagubogu/leaderboard/controller/v1/LeaderboardController.java
@@ -1,9 +1,9 @@
 package com.yagubogu.leaderboard.controller.v1;
 
 import com.yagubogu.auth.annotation.RequireRole;
-import com.yagubogu.leaderboard.domain.LeaderboardType;
 import com.yagubogu.leaderboard.dto.LeaderboardResponse;
 import com.yagubogu.leaderboard.service.LeaderboardService;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RestController;
@@ -16,9 +16,8 @@ public class LeaderboardController implements LeaderboardControllerInterface {
     private final LeaderboardService leaderboardService;
 
     @Override
-    public ResponseEntity<LeaderboardResponse> findTop(final LeaderboardType type, final int limit) {
-
-        LeaderboardResponse response = leaderboardService.findTop(type, limit);
-        return ResponseEntity.ok(response);
+    public ResponseEntity<List<LeaderboardResponse>> findAllTop(final int limit) {
+        var responses = leaderboardService.findAllTop(limit);
+        return ResponseEntity.ok(responses);
     }
 }

--- a/backend/app/src/main/java/com/yagubogu/leaderboard/controller/v1/LeaderboardController.java
+++ b/backend/app/src/main/java/com/yagubogu/leaderboard/controller/v1/LeaderboardController.java
@@ -1,9 +1,8 @@
 package com.yagubogu.leaderboard.controller.v1;
 
 import com.yagubogu.auth.annotation.RequireRole;
-import com.yagubogu.leaderboard.dto.LeaderboardResponse;
+import com.yagubogu.leaderboard.dto.LeaderboardsResponse;
 import com.yagubogu.leaderboard.service.LeaderboardService;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RestController;
@@ -16,8 +15,8 @@ public class LeaderboardController implements LeaderboardControllerInterface {
     private final LeaderboardService leaderboardService;
 
     @Override
-    public ResponseEntity<List<LeaderboardResponse>> findAllTop(final int limit) {
+    public ResponseEntity<LeaderboardsResponse> findAllTop(final int limit) {
         var responses = leaderboardService.findAllTop(limit);
-        return ResponseEntity.ok(responses);
+        return ResponseEntity.ok(LeaderboardsResponse.of(responses));
     }
 }

--- a/backend/app/src/main/java/com/yagubogu/leaderboard/controller/v1/LeaderboardControllerInterface.java
+++ b/backend/app/src/main/java/com/yagubogu/leaderboard/controller/v1/LeaderboardControllerInterface.java
@@ -1,13 +1,12 @@
 package com.yagubogu.leaderboard.controller.v1;
 
-import com.yagubogu.leaderboard.dto.LeaderboardResponse;
+import com.yagubogu.leaderboard.dto.LeaderboardsResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Positive;
-import java.util.List;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -23,7 +22,7 @@ public interface LeaderboardControllerInterface {
             @ApiResponse(responseCode = "204", description = "데이터 없음")
     })
     @GetMapping
-    ResponseEntity<List<LeaderboardResponse>> findAllTop(
+    ResponseEntity<LeaderboardsResponse> findAllTop(
             @RequestParam(name = "limit", defaultValue = "1") @Positive @Max(10) int limit
     );
 }

--- a/backend/app/src/main/java/com/yagubogu/leaderboard/controller/v1/LeaderboardControllerInterface.java
+++ b/backend/app/src/main/java/com/yagubogu/leaderboard/controller/v1/LeaderboardControllerInterface.java
@@ -1,14 +1,13 @@
 package com.yagubogu.leaderboard.controller.v1;
 
-import com.yagubogu.leaderboard.domain.LeaderboardType;
 import com.yagubogu.leaderboard.dto.LeaderboardResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.Max;
-import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
+import java.util.List;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -18,14 +17,13 @@ import org.springframework.web.bind.annotation.RequestParam;
 @RequestMapping("/leaderboards")
 public interface LeaderboardControllerInterface {
 
-    @Operation(summary = "명예 전당 TopN 조회", description = "Type에 해당되는 TopN 랭킹을 조회합니다.")
+    @Operation(summary = "명예 전당 TopN 전체 조회", description = "모든 타입의 TopN 랭킹을 한 번에 조회합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "조회 성공"),
             @ApiResponse(responseCode = "204", description = "데이터 없음")
     })
     @GetMapping
-    ResponseEntity<LeaderboardResponse> findTop(
-            @RequestParam("type") @NotNull LeaderboardType type,
+    ResponseEntity<List<LeaderboardResponse>> findAllTop(
             @RequestParam(name = "limit", defaultValue = "1") @Positive @Max(10) int limit
     );
 }

--- a/backend/app/src/main/java/com/yagubogu/leaderboard/controller/v1/LeaderboardControllerInterface.java
+++ b/backend/app/src/main/java/com/yagubogu/leaderboard/controller/v1/LeaderboardControllerInterface.java
@@ -1,0 +1,31 @@
+package com.yagubogu.leaderboard.controller.v1;
+
+import com.yagubogu.leaderboard.domain.LeaderboardType;
+import com.yagubogu.leaderboard.dto.LeaderboardResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Tag(name = "Leaderboard", description = "명예의 전당 API")
+@RequestMapping("/leaderboards")
+public interface LeaderboardControllerInterface {
+
+    @Operation(summary = "명예 전당 TopN 조회", description = "Type에 해당되는 TopN 랭킹을 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "204", description = "데이터 없음")
+    })
+    @GetMapping
+    ResponseEntity<LeaderboardResponse> findTop(
+            @RequestParam("type") @NotNull LeaderboardType type,
+            @RequestParam(name = "limit", defaultValue = "1") @Positive @Max(10) int limit
+    );
+}

--- a/backend/app/src/main/java/com/yagubogu/leaderboard/domain/LeaderboardType.java
+++ b/backend/app/src/main/java/com/yagubogu/leaderboard/domain/LeaderboardType.java
@@ -1,0 +1,8 @@
+package com.yagubogu.leaderboard.domain;
+
+public enum LeaderboardType {
+    WIN_FAIRY,
+    MOST_CHECK_IN,
+    CHATTIEST,
+    LOSE_FAIRY
+}

--- a/backend/app/src/main/java/com/yagubogu/leaderboard/domain/LeaderboardType.java
+++ b/backend/app/src/main/java/com/yagubogu/leaderboard/domain/LeaderboardType.java
@@ -1,8 +1,18 @@
 package com.yagubogu.leaderboard.domain;
 
 public enum LeaderboardType {
-    WIN_FAIRY,
-    MOST_CHECK_IN,
-    CHATTIEST,
-    LOSE_FAIRY
+    WIN_FAIRY("승리요정"),
+    MOST_CHECK_IN("최다직관"),
+    CHATTIEST("최다채팅"),
+    LOSE_FAIRY("패배요정");
+
+    private final String scoreLabel;
+
+    LeaderboardType(final String scoreLabel) {
+        this.scoreLabel = scoreLabel;
+    }
+
+    public String getScoreLabel() {
+        return scoreLabel;
+    }
 }

--- a/backend/app/src/main/java/com/yagubogu/leaderboard/domain/LeaderboardType.java
+++ b/backend/app/src/main/java/com/yagubogu/leaderboard/domain/LeaderboardType.java
@@ -1,18 +1,8 @@
 package com.yagubogu.leaderboard.domain;
 
 public enum LeaderboardType {
-    WIN_FAIRY("승리요정"),
-    MOST_CHECK_IN("최다직관"),
-    CHATTIEST("최다채팅"),
-    LOSE_FAIRY("패배요정");
-
-    private final String scoreLabel;
-
-    LeaderboardType(final String scoreLabel) {
-        this.scoreLabel = scoreLabel;
-    }
-
-    public String getScoreLabel() {
-        return scoreLabel;
-    }
+    WIN_FAIRY,
+    MOST_CHECK_IN,
+    CHATTIEST,
+    LOSE_FAIRY
 }

--- a/backend/app/src/main/java/com/yagubogu/leaderboard/dto/LeaderboardItemResponse.java
+++ b/backend/app/src/main/java/com/yagubogu/leaderboard/dto/LeaderboardItemResponse.java
@@ -6,6 +6,6 @@ public record LeaderboardItemResponse(
         String nickname,
         String favoriteTeam,
         String profileImageUrl,
-        double score
+        Double score
 ) {
 }

--- a/backend/app/src/main/java/com/yagubogu/leaderboard/dto/LeaderboardItemResponse.java
+++ b/backend/app/src/main/java/com/yagubogu/leaderboard/dto/LeaderboardItemResponse.java
@@ -6,7 +6,6 @@ public record LeaderboardItemResponse(
         String nickname,
         String favoriteTeam,
         String profileImageUrl,
-        double score,
-        String scoreLabel
+        double score
 ) {
 }

--- a/backend/app/src/main/java/com/yagubogu/leaderboard/dto/LeaderboardItemResponse.java
+++ b/backend/app/src/main/java/com/yagubogu/leaderboard/dto/LeaderboardItemResponse.java
@@ -1,0 +1,10 @@
+package com.yagubogu.leaderboard.dto;
+
+public record LeaderboardItemResponse(
+        int rank,
+        long memberId,
+        String nickname,
+        String favoriteTeam,
+        String profileImageUrl
+) {
+}

--- a/backend/app/src/main/java/com/yagubogu/leaderboard/dto/LeaderboardResponse.java
+++ b/backend/app/src/main/java/com/yagubogu/leaderboard/dto/LeaderboardResponse.java
@@ -1,0 +1,13 @@
+package com.yagubogu.leaderboard.dto;
+
+import com.yagubogu.leaderboard.domain.LeaderboardType;
+import java.util.List;
+
+public record LeaderboardResponse(
+        LeaderboardType type,
+        List<LeaderboardItemResponse> items
+) {
+    public static LeaderboardResponse of(LeaderboardType type, List<LeaderboardItemResponse> items) {
+        return new LeaderboardResponse(type, items);
+    }
+}

--- a/backend/app/src/main/java/com/yagubogu/leaderboard/dto/LeaderboardRow.java
+++ b/backend/app/src/main/java/com/yagubogu/leaderboard/dto/LeaderboardRow.java
@@ -1,12 +1,11 @@
 package com.yagubogu.leaderboard.dto;
 
-public record LeaderboardItemResponse(
-        int rank,
+public record LeaderboardRow(
+        long rank,
         long memberId,
         String nickname,
         String favoriteTeam,
         String profileImageUrl,
-        double score,
-        String scoreLabel
+        double score
 ) {
 }

--- a/backend/app/src/main/java/com/yagubogu/leaderboard/dto/LeaderboardRow.java
+++ b/backend/app/src/main/java/com/yagubogu/leaderboard/dto/LeaderboardRow.java
@@ -6,6 +6,6 @@ public record LeaderboardRow(
         String nickname,
         String favoriteTeam,
         String profileImageUrl,
-        double score
+        Double score
 ) {
 }

--- a/backend/app/src/main/java/com/yagubogu/leaderboard/dto/LeaderboardsResponse.java
+++ b/backend/app/src/main/java/com/yagubogu/leaderboard/dto/LeaderboardsResponse.java
@@ -1,0 +1,12 @@
+package com.yagubogu.leaderboard.dto;
+
+import java.util.List;
+
+public record LeaderboardsResponse(
+        List<LeaderboardResponse> leaderboards
+) {
+    public static LeaderboardsResponse of(List<LeaderboardResponse> leaderboards) {
+        return new LeaderboardsResponse(leaderboards);
+    }
+}
+

--- a/backend/app/src/main/java/com/yagubogu/leaderboard/service/ChattiestLeaderboardQuery.java
+++ b/backend/app/src/main/java/com/yagubogu/leaderboard/service/ChattiestLeaderboardQuery.java
@@ -3,6 +3,9 @@ package com.yagubogu.leaderboard.service;
 import com.yagubogu.leaderboard.domain.LeaderboardType;
 import com.yagubogu.leaderboard.dto.LeaderboardRow;
 import com.yagubogu.talk.repository.TalkRepository;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.Year;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -20,6 +23,10 @@ public class ChattiestLeaderboardQuery implements LeaderboardQuery {
 
     @Override
     public List<LeaderboardRow> findTop(final int limit) {
-        return talkRepository.findChattiestWinner(limit);
+        int lastYear = Year.now().minusYears(1).getValue();
+        LocalDateTime startAt = LocalDate.of(lastYear, 1, 1).atStartOfDay();
+        LocalDateTime endAt = LocalDate.of(lastYear + 1, 1, 1).atStartOfDay();
+
+        return talkRepository.findChattiestWinner(limit, startAt, endAt);
     }
 }

--- a/backend/app/src/main/java/com/yagubogu/leaderboard/service/ChattiestLeaderboardQuery.java
+++ b/backend/app/src/main/java/com/yagubogu/leaderboard/service/ChattiestLeaderboardQuery.java
@@ -1,0 +1,25 @@
+package com.yagubogu.leaderboard.service;
+
+import com.yagubogu.leaderboard.domain.LeaderboardType;
+import com.yagubogu.leaderboard.dto.LeaderboardItemResponse;
+import com.yagubogu.talk.repository.TalkRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class ChattiestLeaderboardQuery implements LeaderboardQuery {
+
+    private final TalkRepository talkRepository;
+
+    @Override
+    public LeaderboardType supports() {
+        return LeaderboardType.LOSE_FAIRY;
+    }
+
+    @Override
+    public List<LeaderboardItemResponse> findTop(final int limit) {
+        return talkRepository.findChattiestWinner(limit);
+    }
+}

--- a/backend/app/src/main/java/com/yagubogu/leaderboard/service/ChattiestLeaderboardQuery.java
+++ b/backend/app/src/main/java/com/yagubogu/leaderboard/service/ChattiestLeaderboardQuery.java
@@ -1,7 +1,7 @@
 package com.yagubogu.leaderboard.service;
 
 import com.yagubogu.leaderboard.domain.LeaderboardType;
-import com.yagubogu.leaderboard.dto.LeaderboardItemResponse;
+import com.yagubogu.leaderboard.dto.LeaderboardRow;
 import com.yagubogu.talk.repository.TalkRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -15,11 +15,11 @@ public class ChattiestLeaderboardQuery implements LeaderboardQuery {
 
     @Override
     public LeaderboardType supports() {
-        return LeaderboardType.LOSE_FAIRY;
+        return LeaderboardType.CHATTIEST;
     }
 
     @Override
-    public List<LeaderboardItemResponse> findTop(final int limit) {
+    public List<LeaderboardRow> findTop(final int limit) {
         return talkRepository.findChattiestWinner(limit);
     }
 }

--- a/backend/app/src/main/java/com/yagubogu/leaderboard/service/LeaderboardQuery.java
+++ b/backend/app/src/main/java/com/yagubogu/leaderboard/service/LeaderboardQuery.java
@@ -1,12 +1,12 @@
 package com.yagubogu.leaderboard.service;
 
 import com.yagubogu.leaderboard.domain.LeaderboardType;
-import com.yagubogu.leaderboard.dto.LeaderboardItemResponse;
+import com.yagubogu.leaderboard.dto.LeaderboardRow;
 import java.util.List;
 
 public interface LeaderboardQuery {
 
     LeaderboardType supports();
 
-    List<LeaderboardItemResponse> findTop(int limit);
+    List<LeaderboardRow> findTop(int limit);
 }

--- a/backend/app/src/main/java/com/yagubogu/leaderboard/service/LeaderboardQuery.java
+++ b/backend/app/src/main/java/com/yagubogu/leaderboard/service/LeaderboardQuery.java
@@ -1,0 +1,12 @@
+package com.yagubogu.leaderboard.service;
+
+import com.yagubogu.leaderboard.domain.LeaderboardType;
+import com.yagubogu.leaderboard.dto.LeaderboardItemResponse;
+import java.util.List;
+
+public interface LeaderboardQuery {
+
+    LeaderboardType supports();
+
+    List<LeaderboardItemResponse> findTop(int limit);
+}

--- a/backend/app/src/main/java/com/yagubogu/leaderboard/service/LeaderboardQueryRegistry.java
+++ b/backend/app/src/main/java/com/yagubogu/leaderboard/service/LeaderboardQueryRegistry.java
@@ -1,0 +1,33 @@
+package com.yagubogu.leaderboard.service;
+
+import com.yagubogu.leaderboard.domain.LeaderboardType;
+import jakarta.annotation.PostConstruct;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class LeaderboardQueryRegistry {
+
+    private final List<LeaderboardQuery> queries;
+    private Map<LeaderboardType, LeaderboardQuery> map;
+
+    @PostConstruct
+    void init() {
+        map = new EnumMap<>(LeaderboardType.class);
+        for (LeaderboardQuery query : queries) {
+            map.put(query.supports(), query);
+        }
+    }
+
+    public LeaderboardQuery getQuery(LeaderboardType type) {
+        LeaderboardQuery query = map.get(type);
+        if (query == null) {
+            throw new IllegalStateException("No LeaderboardQuery registered for type: " + type);
+        }
+        return query;
+    }
+}

--- a/backend/app/src/main/java/com/yagubogu/leaderboard/service/LeaderboardService.java
+++ b/backend/app/src/main/java/com/yagubogu/leaderboard/service/LeaderboardService.java
@@ -1,7 +1,9 @@
 package com.yagubogu.leaderboard.service;
 
 import com.yagubogu.leaderboard.domain.LeaderboardType;
+import com.yagubogu.leaderboard.dto.LeaderboardItemResponse;
 import com.yagubogu.leaderboard.dto.LeaderboardResponse;
+import com.yagubogu.leaderboard.dto.LeaderboardRow;
 import jakarta.annotation.PostConstruct;
 import java.util.EnumMap;
 import java.util.List;
@@ -25,7 +27,28 @@ public class LeaderboardService {
 
     public LeaderboardResponse findTop(LeaderboardType type, int limit) {
         LeaderboardQuery query = map.get(type);
+        if (query == null) {
+            // throw new
+        }
 
-        return LeaderboardResponse.of(type, query.findTop(limit));
+        String label = type.getScoreLabel();
+
+        List<LeaderboardItemResponse> responses = query.findTop(limit).stream()
+                .map(r -> toItem(r, label))
+                .toList();
+
+        return LeaderboardResponse.of(type, responses);
+    }
+
+    private LeaderboardItemResponse toItem(LeaderboardRow row, String label) {
+        return new LeaderboardItemResponse(
+                Math.toIntExact(row.rank()),
+                row.memberId(),
+                row.nickname(),
+                row.favoriteTeam(),
+                row.profileImageUrl(),
+                row.score(),
+                label
+        );
     }
 }

--- a/backend/app/src/main/java/com/yagubogu/leaderboard/service/LeaderboardService.java
+++ b/backend/app/src/main/java/com/yagubogu/leaderboard/service/LeaderboardService.java
@@ -8,6 +8,7 @@ import jakarta.annotation.PostConstruct;
 import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -25,19 +26,21 @@ public class LeaderboardService {
         }
     }
 
-    public LeaderboardResponse findTop(LeaderboardType type, int limit) {
-        LeaderboardQuery query = map.get(type);
-        if (query == null) {
-            // throw new
-        }
-
-        String label = type.getScoreLabel();
-
-        List<LeaderboardItemResponse> responses = query.findTop(limit).stream()
-                .map(r -> toItem(r, label))
+    public List<LeaderboardResponse> findAllTop(int limit) {
+        return java.util.Arrays.stream(LeaderboardType.values())
+                .map(type -> {
+                    LeaderboardQuery query = map.get(type);
+                    if (query == null) {
+                        return null; // todo throw new
+                    }
+                    String label = type.getScoreLabel();
+                    List<LeaderboardItemResponse> items = query.findTop(limit).stream()
+                            .map(r -> toItem(r, label))
+                            .toList();
+                    return LeaderboardResponse.of(type, items);
+                })
+                .filter(Objects::nonNull)
                 .toList();
-
-        return LeaderboardResponse.of(type, responses);
     }
 
     private LeaderboardItemResponse toItem(LeaderboardRow row, String label) {

--- a/backend/app/src/main/java/com/yagubogu/leaderboard/service/LeaderboardService.java
+++ b/backend/app/src/main/java/com/yagubogu/leaderboard/service/LeaderboardService.java
@@ -1,5 +1,7 @@
 package com.yagubogu.leaderboard.service;
 
+import static java.util.Arrays.stream;
+
 import com.yagubogu.leaderboard.domain.LeaderboardType;
 import com.yagubogu.leaderboard.dto.LeaderboardItemResponse;
 import com.yagubogu.leaderboard.dto.LeaderboardResponse;
@@ -8,7 +10,6 @@ import jakarta.annotation.PostConstruct;
 import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -27,18 +28,17 @@ public class LeaderboardService {
     }
 
     public List<LeaderboardResponse> findAllTop(int limit) {
-        return java.util.Arrays.stream(LeaderboardType.values())
+        return stream(LeaderboardType.values())
                 .map(type -> {
                     LeaderboardQuery query = map.get(type);
                     if (query == null) {
-                        return null; // todo throw new
+                        throw new IllegalStateException("No LeaderboardQuery registered for type:" + type);
                     }
                     List<LeaderboardItemResponse> items = query.findTop(limit).stream()
                             .map(this::toItem)
                             .toList();
                     return LeaderboardResponse.of(type, items);
                 })
-                .filter(Objects::nonNull)
                 .toList();
     }
 

--- a/backend/app/src/main/java/com/yagubogu/leaderboard/service/LeaderboardService.java
+++ b/backend/app/src/main/java/com/yagubogu/leaderboard/service/LeaderboardService.java
@@ -6,10 +6,7 @@ import com.yagubogu.leaderboard.domain.LeaderboardType;
 import com.yagubogu.leaderboard.dto.LeaderboardItemResponse;
 import com.yagubogu.leaderboard.dto.LeaderboardResponse;
 import com.yagubogu.leaderboard.dto.LeaderboardRow;
-import jakarta.annotation.PostConstruct;
-import java.util.EnumMap;
 import java.util.List;
-import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -17,24 +14,13 @@ import org.springframework.stereotype.Service;
 @Service
 public class LeaderboardService {
 
-    private final Map<LeaderboardType, LeaderboardQuery> map = new EnumMap<>(LeaderboardType.class);
-    private final List<LeaderboardQuery> queries;
-
-    @PostConstruct
-    void init() {
-        for (LeaderboardQuery query : queries) {
-            map.put(query.supports(), query);
-        }
-    }
+    private final LeaderboardQueryRegistry registry;
 
     public List<LeaderboardResponse> findAllTop(int limit) {
         return stream(LeaderboardType.values())
                 .map(type -> {
-                    LeaderboardQuery query = map.get(type);
-                    if (query == null) {
-                        throw new IllegalStateException("No LeaderboardQuery registered for type:" + type);
-                    }
-                    List<LeaderboardItemResponse> items = query.findTop(limit).stream()
+                    List<LeaderboardItemResponse> items = registry.getQuery(type)
+                            .findTop(limit).stream()
                             .map(this::toItem)
                             .toList();
                     return LeaderboardResponse.of(type, items);

--- a/backend/app/src/main/java/com/yagubogu/leaderboard/service/LeaderboardService.java
+++ b/backend/app/src/main/java/com/yagubogu/leaderboard/service/LeaderboardService.java
@@ -1,0 +1,30 @@
+package com.yagubogu.leaderboard.service;
+
+import com.yagubogu.leaderboard.domain.LeaderboardType;
+import com.yagubogu.leaderboard.dto.LeaderboardResponse;
+import jakarta.annotation.PostConstruct;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class LeaderboardService {
+
+    private final Map<LeaderboardType, LeaderboardQuery> map = new EnumMap<>(LeaderboardType.class);
+
+    @PostConstruct
+    void init(List<LeaderboardQuery> queries) {
+        for (LeaderboardQuery query : queries) {
+            map.put(query.supports(), query);
+        }
+    }
+
+    public LeaderboardResponse findTop(LeaderboardType type, int limit) {
+        LeaderboardQuery query = map.get(type);
+
+        return LeaderboardResponse.of(type, query.findTop(limit));
+    }
+}

--- a/backend/app/src/main/java/com/yagubogu/leaderboard/service/LeaderboardService.java
+++ b/backend/app/src/main/java/com/yagubogu/leaderboard/service/LeaderboardService.java
@@ -14,9 +14,10 @@ import org.springframework.stereotype.Service;
 public class LeaderboardService {
 
     private final Map<LeaderboardType, LeaderboardQuery> map = new EnumMap<>(LeaderboardType.class);
+    private final List<LeaderboardQuery> queries;
 
     @PostConstruct
-    void init(List<LeaderboardQuery> queries) {
+    void init() {
         for (LeaderboardQuery query : queries) {
             map.put(query.supports(), query);
         }

--- a/backend/app/src/main/java/com/yagubogu/leaderboard/service/LeaderboardService.java
+++ b/backend/app/src/main/java/com/yagubogu/leaderboard/service/LeaderboardService.java
@@ -33,9 +33,8 @@ public class LeaderboardService {
                     if (query == null) {
                         return null; // todo throw new
                     }
-                    String label = type.getScoreLabel();
                     List<LeaderboardItemResponse> items = query.findTop(limit).stream()
-                            .map(r -> toItem(r, label))
+                            .map(this::toItem)
                             .toList();
                     return LeaderboardResponse.of(type, items);
                 })
@@ -43,15 +42,14 @@ public class LeaderboardService {
                 .toList();
     }
 
-    private LeaderboardItemResponse toItem(LeaderboardRow row, String label) {
+    private LeaderboardItemResponse toItem(LeaderboardRow row) {
         return new LeaderboardItemResponse(
                 Math.toIntExact(row.rank()),
                 row.memberId(),
                 row.nickname(),
                 row.favoriteTeam(),
                 row.profileImageUrl(),
-                row.score(),
-                label
+                row.score()
         );
     }
 }

--- a/backend/app/src/main/java/com/yagubogu/leaderboard/service/LoseFairyLeaderboardQuery.java
+++ b/backend/app/src/main/java/com/yagubogu/leaderboard/service/LoseFairyLeaderboardQuery.java
@@ -3,7 +3,7 @@ package com.yagubogu.leaderboard.service;
 import com.yagubogu.checkin.dto.VictoryFairyRankParam;
 import com.yagubogu.checkin.dto.v1.TeamFilter;
 import com.yagubogu.leaderboard.domain.LeaderboardType;
-import com.yagubogu.leaderboard.dto.LeaderboardItemResponse;
+import com.yagubogu.leaderboard.dto.LeaderboardRow;
 import com.yagubogu.stat.repository.VictoryFairyRankingRepository;
 import java.time.Year;
 import java.util.List;
@@ -23,7 +23,7 @@ public class LoseFairyLeaderboardQuery implements LeaderboardQuery {
     }
 
     @Override
-    public List<LeaderboardItemResponse> findTop(final int limit) {
+    public List<LeaderboardRow> findTop(final int limit) {
         int lastYear = Year.now().minusYears(1).getValue();
         List<VictoryFairyRankParam> victoryFairyRankings = victoryFairyRankingRepository.findBottomRankingByTeamFilterAndYear(
                 TeamFilter.ALL,
@@ -32,12 +32,13 @@ public class LoseFairyLeaderboardQuery implements LeaderboardQuery {
         );
 
         return victoryFairyRankings.stream()
-                .map(r -> new LeaderboardItemResponse(
-                        Math.toIntExact(r.rank()),
+                .map(r -> new LeaderboardRow(
+                        r.rank(),
                         r.memberId(),
                         r.nickname(),
                         r.teamShortName(),
-                        r.profileImageUrl()
+                        r.profileImageUrl(),
+                        r.score()
                 ))
                 .collect(Collectors.toList());
     }

--- a/backend/app/src/main/java/com/yagubogu/leaderboard/service/LoseFairyLeaderboardQuery.java
+++ b/backend/app/src/main/java/com/yagubogu/leaderboard/service/LoseFairyLeaderboardQuery.java
@@ -1,0 +1,44 @@
+package com.yagubogu.leaderboard.service;
+
+import com.yagubogu.checkin.dto.VictoryFairyRankParam;
+import com.yagubogu.checkin.dto.v1.TeamFilter;
+import com.yagubogu.leaderboard.domain.LeaderboardType;
+import com.yagubogu.leaderboard.dto.LeaderboardItemResponse;
+import com.yagubogu.stat.repository.VictoryFairyRankingRepository;
+import java.time.Year;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class LoseFairyLeaderboardQuery implements LeaderboardQuery {
+
+    private final VictoryFairyRankingRepository victoryFairyRankingRepository;
+
+    @Override
+    public LeaderboardType supports() {
+        return LeaderboardType.LOSE_FAIRY;
+    }
+
+    @Override
+    public List<LeaderboardItemResponse> findTop(final int limit) {
+        int lastYear = Year.now().minusYears(1).getValue();
+        List<VictoryFairyRankParam> victoryFairyRankings = victoryFairyRankingRepository.findBottomRankingByTeamFilterAndYear(
+                TeamFilter.ALL,
+                limit,
+                lastYear
+        );
+
+        return victoryFairyRankings.stream()
+                .map(r -> new LeaderboardItemResponse(
+                        Math.toIntExact(r.rank()),
+                        r.memberId(),
+                        r.nickname(),
+                        r.teamShortName(),
+                        r.profileImageUrl()
+                ))
+                .collect(Collectors.toList());
+    }
+}

--- a/backend/app/src/main/java/com/yagubogu/leaderboard/service/MostCheckInLeaderboardQuery.java
+++ b/backend/app/src/main/java/com/yagubogu/leaderboard/service/MostCheckInLeaderboardQuery.java
@@ -3,6 +3,9 @@ package com.yagubogu.leaderboard.service;
 import com.yagubogu.checkin.repository.CheckInRepository;
 import com.yagubogu.leaderboard.domain.LeaderboardType;
 import com.yagubogu.leaderboard.dto.LeaderboardRow;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.Year;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -20,6 +23,10 @@ public class MostCheckInLeaderboardQuery implements LeaderboardQuery {
 
     @Override
     public List<LeaderboardRow> findTop(final int limit) {
-        return checkInRepository.findMostCheckInWinner(limit);
+        int lastYear = Year.now().minusYears(1).getValue();
+        LocalDateTime startAt = LocalDate.of(lastYear, 1, 1).atStartOfDay();
+        LocalDateTime endAt = LocalDate.of(lastYear + 1, 1, 1).atStartOfDay();
+
+        return checkInRepository.findMostCheckInWinner(limit, startAt, endAt);
     }
 }

--- a/backend/app/src/main/java/com/yagubogu/leaderboard/service/MostCheckInLeaderboardQuery.java
+++ b/backend/app/src/main/java/com/yagubogu/leaderboard/service/MostCheckInLeaderboardQuery.java
@@ -2,7 +2,7 @@ package com.yagubogu.leaderboard.service;
 
 import com.yagubogu.checkin.repository.CheckInRepository;
 import com.yagubogu.leaderboard.domain.LeaderboardType;
-import com.yagubogu.leaderboard.dto.LeaderboardItemResponse;
+import com.yagubogu.leaderboard.dto.LeaderboardRow;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -19,7 +19,7 @@ public class MostCheckInLeaderboardQuery implements LeaderboardQuery {
     }
 
     @Override
-    public List<LeaderboardItemResponse> findTop(final int limit) {
+    public List<LeaderboardRow> findTop(final int limit) {
         return checkInRepository.findMostCheckInWinner(limit);
     }
 }

--- a/backend/app/src/main/java/com/yagubogu/leaderboard/service/MostCheckInLeaderboardQuery.java
+++ b/backend/app/src/main/java/com/yagubogu/leaderboard/service/MostCheckInLeaderboardQuery.java
@@ -1,0 +1,25 @@
+package com.yagubogu.leaderboard.service;
+
+import com.yagubogu.checkin.repository.CheckInRepository;
+import com.yagubogu.leaderboard.domain.LeaderboardType;
+import com.yagubogu.leaderboard.dto.LeaderboardItemResponse;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class MostCheckInLeaderboardQuery implements LeaderboardQuery {
+
+    private final CheckInRepository checkInRepository;
+
+    @Override
+    public LeaderboardType supports() {
+        return LeaderboardType.MOST_CHECK_IN;
+    }
+
+    @Override
+    public List<LeaderboardItemResponse> findTop(final int limit) {
+        return checkInRepository.findMostCheckInWinner(limit);
+    }
+}

--- a/backend/app/src/main/java/com/yagubogu/leaderboard/service/WinFairyLeaderboardQuery.java
+++ b/backend/app/src/main/java/com/yagubogu/leaderboard/service/WinFairyLeaderboardQuery.java
@@ -1,0 +1,44 @@
+package com.yagubogu.leaderboard.service;
+
+import com.yagubogu.checkin.dto.VictoryFairyRankParam;
+import com.yagubogu.checkin.dto.v1.TeamFilter;
+import com.yagubogu.leaderboard.domain.LeaderboardType;
+import com.yagubogu.leaderboard.dto.LeaderboardItemResponse;
+import com.yagubogu.stat.repository.VictoryFairyRankingRepository;
+import java.time.Year;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class WinFairyLeaderboardQuery implements LeaderboardQuery {
+
+    private final VictoryFairyRankingRepository victoryFairyRankingRepository;
+
+    @Override
+    public LeaderboardType supports() {
+        return LeaderboardType.WIN_FAIRY;
+    }
+
+    @Override
+    public List<LeaderboardItemResponse> findTop(final int limit) {
+        int lastYear = Year.now().minusYears(1).getValue();
+        List<VictoryFairyRankParam> victoryFairyRankings = victoryFairyRankingRepository.findTopRankingByTeamFilterAndYear(
+                TeamFilter.ALL,
+                limit,
+                lastYear
+        );
+
+        return victoryFairyRankings.stream()
+                .map(r -> new LeaderboardItemResponse(
+                        Math.toIntExact(r.rank()),
+                        r.memberId(),
+                        r.nickname(),
+                        r.teamShortName(),
+                        r.profileImageUrl()
+                ))
+                .collect(Collectors.toList());
+    }
+}

--- a/backend/app/src/main/java/com/yagubogu/leaderboard/service/WinFairyLeaderboardQuery.java
+++ b/backend/app/src/main/java/com/yagubogu/leaderboard/service/WinFairyLeaderboardQuery.java
@@ -3,7 +3,7 @@ package com.yagubogu.leaderboard.service;
 import com.yagubogu.checkin.dto.VictoryFairyRankParam;
 import com.yagubogu.checkin.dto.v1.TeamFilter;
 import com.yagubogu.leaderboard.domain.LeaderboardType;
-import com.yagubogu.leaderboard.dto.LeaderboardItemResponse;
+import com.yagubogu.leaderboard.dto.LeaderboardRow;
 import com.yagubogu.stat.repository.VictoryFairyRankingRepository;
 import java.time.Year;
 import java.util.List;
@@ -23,7 +23,7 @@ public class WinFairyLeaderboardQuery implements LeaderboardQuery {
     }
 
     @Override
-    public List<LeaderboardItemResponse> findTop(final int limit) {
+    public List<LeaderboardRow> findTop(final int limit) {
         int lastYear = Year.now().minusYears(1).getValue();
         List<VictoryFairyRankParam> victoryFairyRankings = victoryFairyRankingRepository.findTopRankingByTeamFilterAndYear(
                 TeamFilter.ALL,
@@ -32,12 +32,13 @@ public class WinFairyLeaderboardQuery implements LeaderboardQuery {
         );
 
         return victoryFairyRankings.stream()
-                .map(r -> new LeaderboardItemResponse(
-                        Math.toIntExact(r.rank()),
+                .map(r -> new LeaderboardRow(
+                        r.rank(),
                         r.memberId(),
                         r.nickname(),
                         r.teamShortName(),
-                        r.profileImageUrl()
+                        r.profileImageUrl(),
+                        r.score()
                 ))
                 .collect(Collectors.toList());
     }

--- a/backend/app/src/main/java/com/yagubogu/stat/repository/VictoryFairyRankingRepository.java
+++ b/backend/app/src/main/java/com/yagubogu/stat/repository/VictoryFairyRankingRepository.java
@@ -93,4 +93,42 @@ public interface VictoryFairyRankingRepository extends JpaRepository<VictoryFair
             @Param("limit") int limit,
             @Param("gameYear") int gameYear
     );
+
+    @Query(value = """
+            SELECT
+                RANK() OVER (ORDER BY T.score ASC) AS `rank`,
+                T.memberId,
+                T.score,
+                T.nickname,
+                T.imageUrl,
+                T.shortName
+            FROM (
+                SELECT STRAIGHT_JOIN
+                    m.member_id AS memberId,
+                    vfr.score,
+                    m.nickname,
+                    m.image_url AS imageUrl,
+                    t.short_name AS shortName
+                FROM
+                    victory_fairy_rankings vfr
+                JOIN
+                    members m ON m.member_id = vfr.member_id
+                JOIN
+                    teams t ON t.team_id = m.team_id
+                WHERE
+                    vfr.game_year = :gameYear
+                    AND m.deleted_at IS NULL
+                    AND m.team_id IS NOT NULL
+                    AND (:#{#teamFilter.name()} = 'ALL' OR t.team_code = :#{#teamFilter.name()})
+                ORDER BY
+                    vfr.score ASC
+                LIMIT :limit
+            ) AS T
+            ORDER BY T.score ASC
+            """, nativeQuery = true)
+    List<VictoryFairyRankParam> findBottomRankingByTeamFilterAndYear(
+            @Param("teamFilter") TeamFilter teamFilter,
+            @Param("limit") int limit,
+            @Param("gameYear") int gameYear
+    );
 }

--- a/backend/app/src/main/java/com/yagubogu/stat/repository/VictoryFairyRankingRepository.java
+++ b/backend/app/src/main/java/com/yagubogu/stat/repository/VictoryFairyRankingRepository.java
@@ -57,36 +57,36 @@ public interface VictoryFairyRankingRepository extends JpaRepository<VictoryFair
     );
 
     @Query(value = """
-            SELECT
-                RANK() OVER (ORDER BY T.score DESC) AS `rank`,
-                T.memberId,
-                T.score,
-                T.nickname,
-                T.imageUrl,
-                T.shortName
-            FROM (
-                SELECT STRAIGHT_JOIN
-                    m.member_id AS memberId,
-                    vfr.score,
-                    m.nickname,
-                    m.image_url AS imageUrl,
-                    t.short_name AS shortName
-                FROM
-                    victory_fairy_rankings vfr
-                JOIN
-                    members m ON m.member_id = vfr.member_id
-                JOIN
-                    teams t ON t.team_id = m.team_id
-                WHERE
-                    vfr.game_year = :gameYear
-                    AND m.deleted_at IS NULL
-                    AND m.team_id IS NOT NULL
-                    AND (:#{#teamFilter.name()} = 'ALL' OR t.team_code = :#{#teamFilter.name()})
-                ORDER BY
-                    vfr.score DESC
-                LIMIT :limit
-            ) AS T
-            ORDER BY T.score DESC
+                SELECT
+                   RANK() OVER (ORDER BY T.score DESC) AS rank_no,
+                   T.memberId,
+                   T.score,
+                   T.nickname,
+                   T.profileImageUrl,
+                   T.teamShortName
+               FROM (
+                   SELECT
+                       m.member_id AS memberId,
+                       vfr.score,
+                       m.nickname,
+                       m.image_url AS profileImageUrl,
+                       t.short_name AS teamShortName
+                   FROM
+                       victory_fairy_rankings vfr
+                   JOIN
+                       members m ON m.member_id = vfr.member_id
+                   JOIN
+                       teams t ON t.team_id = m.team_id
+                   WHERE
+                       vfr.game_year = :gameYear
+                       AND m.deleted_at IS NULL
+                       AND m.team_id IS NOT NULL
+                       AND (:#{#teamFilter.name()} = 'ALL' OR t.team_code = :#{#teamFilter.name()})
+                   ORDER BY
+                       vfr.score DESC
+                   LIMIT :limit
+               ) AS T
+               ORDER BY T.score DESC
             """, nativeQuery = true)
     List<VictoryFairyRankParam> findTopRankingByTeamFilterAndYear(
             @Param("teamFilter") TeamFilter teamFilter,
@@ -96,19 +96,19 @@ public interface VictoryFairyRankingRepository extends JpaRepository<VictoryFair
 
     @Query(value = """
             SELECT
-                RANK() OVER (ORDER BY T.score ASC) AS `rank`,
+                RANK() OVER (ORDER BY T.score ASC) AS rank_no,
                 T.memberId,
                 T.score,
                 T.nickname,
-                T.imageUrl,
-                T.shortName
+                T.profileImageUrl,
+                T.teamShortName
             FROM (
-                SELECT STRAIGHT_JOIN
+                SELECT
                     m.member_id AS memberId,
                     vfr.score,
                     m.nickname,
-                    m.image_url AS imageUrl,
-                    t.short_name AS shortName
+                    m.image_url AS profileImageUrl,
+                    t.short_name AS teamShortName
                 FROM
                     victory_fairy_rankings vfr
                 JOIN

--- a/backend/app/src/main/java/com/yagubogu/talk/repository/TalkRepository.java
+++ b/backend/app/src/main/java/com/yagubogu/talk/repository/TalkRepository.java
@@ -1,6 +1,6 @@
 package com.yagubogu.talk.repository;
 
-import com.yagubogu.leaderboard.dto.LeaderboardItemResponse;
+import com.yagubogu.leaderboard.dto.LeaderboardRow;
 import com.yagubogu.talk.domain.Talk;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -91,7 +91,8 @@ public interface TalkRepository extends JpaRepository<Talk, Long> {
             ranked AS (
               SELECT
                 DENSE_RANK() OVER (ORDER BY talkCount DESC) AS `rank`,
-                memberId
+                memberId,
+                talkCount
               FROM member_counts
             )
             SELECT
@@ -99,12 +100,13 @@ public interface TalkRepository extends JpaRepository<Talk, Long> {
               m.member_id AS memberId,
               m.nickname AS nickname,
               t.short_name AS favoriteTeam,
-              m.image_url AS profileImageUrl
+              m.image_url AS profileImageUrl,
+              r.talkCount AS score
             FROM ranked r
             JOIN members m ON m.member_id = r.memberId
             JOIN teams t   ON t.team_id = m.team_id
             WHERE r.`rank` <= :limit
             ORDER BY r.`rank` ASC, m.member_id ASC
             """, nativeQuery = true)
-    List<LeaderboardItemResponse> findChattiestWinner(@Param("limit") int limit);
+    List<LeaderboardRow> findChattiestWinner(@Param("limit") int limit);
 }

--- a/backend/app/src/main/java/com/yagubogu/talk/repository/TalkRepository.java
+++ b/backend/app/src/main/java/com/yagubogu/talk/repository/TalkRepository.java
@@ -90,13 +90,13 @@ public interface TalkRepository extends JpaRepository<Talk, Long> {
             ),
             ranked AS (
               SELECT
-                DENSE_RANK() OVER (ORDER BY talkCount DESC) AS `rank`,
+                DENSE_RANK() OVER (ORDER BY talkCount DESC) AS rnk,
                 memberId,
                 talkCount
               FROM member_counts
             )
             SELECT
-              r.`rank` AS `rank`,
+              r.rnk AS rank_no,
               m.member_id AS memberId,
               m.nickname AS nickname,
               t.short_name AS favoriteTeam,
@@ -105,8 +105,8 @@ public interface TalkRepository extends JpaRepository<Talk, Long> {
             FROM ranked r
             JOIN members m ON m.member_id = r.memberId
             JOIN teams t   ON t.team_id = m.team_id
-            WHERE r.`rank` <= :limit
-            ORDER BY r.`rank` ASC, m.member_id ASC
+            WHERE r.rnk <= :limit
+            ORDER BY r.rnk ASC, m.member_id ASC
             """, nativeQuery = true)
     List<LeaderboardRow> findChattiestWinner(@Param("limit") int limit);
 }

--- a/backend/app/src/main/java/com/yagubogu/talk/repository/TalkRepository.java
+++ b/backend/app/src/main/java/com/yagubogu/talk/repository/TalkRepository.java
@@ -1,7 +1,9 @@
 package com.yagubogu.talk.repository;
 
+import com.yagubogu.leaderboard.dto.LeaderboardItemResponse;
 import com.yagubogu.talk.domain.Talk;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -67,4 +69,42 @@ public interface TalkRepository extends JpaRepository<Talk, Long> {
             @Param("content") String content,
             @Param("threshold") LocalDateTime threshold
     );
+
+    @Query(value = """
+            WITH member_counts AS (
+              SELECT
+                tk.member_id AS memberId,
+                COUNT(*) AS talkCount
+              FROM talks tk
+              JOIN members m ON m.member_id = tk.member_id
+              WHERE
+                tk.created_at >= '2025-01-01' AND tk.created_at < '2026-01-01'
+                AND m.deleted_at IS NULL
+                AND m.team_id IS NOT NULL
+                AND NOT EXISTS (
+                  SELECT 1
+                  FROM talk_reports tr
+                  WHERE tr.talk_id = tk.talk_id
+                )
+              GROUP BY tk.member_id
+            ),
+            ranked AS (
+              SELECT
+                DENSE_RANK() OVER (ORDER BY talkCount DESC) AS `rank`,
+                memberId
+              FROM member_counts
+            )
+            SELECT
+              r.`rank` AS `rank`,
+              m.member_id AS memberId,
+              m.nickname AS nickname,
+              t.short_name AS favoriteTeam,
+              m.image_url AS profileImageUrl
+            FROM ranked r
+            JOIN members m ON m.member_id = r.memberId
+            JOIN teams t   ON t.team_id = m.team_id
+            WHERE r.`rank` <= :limit
+            ORDER BY r.`rank` ASC, m.member_id ASC
+            """, nativeQuery = true)
+    List<LeaderboardItemResponse> findChattiestWinner(@Param("limit") int limit);
 }

--- a/backend/app/src/main/java/com/yagubogu/talk/repository/TalkRepository.java
+++ b/backend/app/src/main/java/com/yagubogu/talk/repository/TalkRepository.java
@@ -78,7 +78,7 @@ public interface TalkRepository extends JpaRepository<Talk, Long> {
               FROM talks tk
               JOIN members m ON m.member_id = tk.member_id
               WHERE
-                tk.created_at >= '2025-01-01' AND tk.created_at < '2026-01-01'
+                tk.created_at >= :startAt AND tk.created_at < :endAt
                 AND m.deleted_at IS NULL
                 AND m.team_id IS NOT NULL
                 AND NOT EXISTS (
@@ -101,12 +101,16 @@ public interface TalkRepository extends JpaRepository<Talk, Long> {
               m.nickname AS nickname,
               t.short_name AS favoriteTeam,
               m.image_url AS profileImageUrl,
-              r.talkCount AS score
+              CAST(r.talkCount AS DOUBLE) AS score
             FROM ranked r
             JOIN members m ON m.member_id = r.memberId
             JOIN teams t   ON t.team_id = m.team_id
             WHERE r.rnk <= :limit
             ORDER BY r.rnk ASC, m.member_id ASC
             """, nativeQuery = true)
-    List<LeaderboardRow> findChattiestWinner(@Param("limit") int limit);
+    List<LeaderboardRow> findChattiestWinner(
+            @Param("limit") int limit,
+            @Param("startAt") LocalDateTime startAt,
+            @Param("endAt") LocalDateTime endAt
+    );
 }

--- a/backend/app/src/test/java/com/yagubogu/leaderboard/LeaderboardE2eTest.java
+++ b/backend/app/src/test/java/com/yagubogu/leaderboard/LeaderboardE2eTest.java
@@ -10,6 +10,7 @@ import com.yagubogu.global.config.JpaAuditingConfig;
 import com.yagubogu.leaderboard.domain.LeaderboardType;
 import com.yagubogu.leaderboard.dto.LeaderboardItemResponse;
 import com.yagubogu.leaderboard.dto.LeaderboardResponse;
+import com.yagubogu.leaderboard.dto.LeaderboardsResponse;
 import com.yagubogu.member.domain.Member;
 import com.yagubogu.member.domain.Role;
 import com.yagubogu.stadium.domain.Stadium;
@@ -112,7 +113,7 @@ public class LeaderboardE2eTest extends E2eTestBase {
         String token = authFactory.getAccessTokenByMemberId(fora.getId(), Role.USER);
 
         // when
-        LeaderboardResponse[] array = RestAssured.given().log().all()
+        LeaderboardsResponse wrapper = RestAssured.given().log().all()
                 .contentType(ContentType.JSON)
                 .header(HttpHeaders.AUTHORIZATION, token)
                 .queryParam("limit", 1)
@@ -120,9 +121,9 @@ public class LeaderboardE2eTest extends E2eTestBase {
                 .then().log().all()
                 .statusCode(200)
                 .extract()
-                .as(LeaderboardResponse[].class);
+                .as(LeaderboardsResponse.class);
 
-        List<LeaderboardResponse> responses = Arrays.asList(array);
+        List<LeaderboardResponse> responses = wrapper.leaderboards();
 
         // then: 모든 타입이 포함되어 있고, MOST_CHECK_IN 1위는 fora
         assertThat(responses).hasSize(LeaderboardType.values().length);

--- a/backend/app/src/test/java/com/yagubogu/leaderboard/LeaderboardE2eTest.java
+++ b/backend/app/src/test/java/com/yagubogu/leaderboard/LeaderboardE2eTest.java
@@ -141,6 +141,5 @@ public class LeaderboardE2eTest extends E2eTestBase {
         assertThat(top.favoriteTeam()).isEqualTo(lotte.getShortName());
         assertThat(top.profileImageUrl()).isEqualTo(fora.getImageUrl());
         assertThat(top.score()).isEqualTo(2.0);
-        assertThat(top.scoreLabel()).isEqualTo(LeaderboardType.MOST_CHECK_IN.getScoreLabel());
     }
 }

--- a/backend/app/src/test/java/com/yagubogu/leaderboard/LeaderboardE2eTest.java
+++ b/backend/app/src/test/java/com/yagubogu/leaderboard/LeaderboardE2eTest.java
@@ -1,0 +1,146 @@
+package com.yagubogu.leaderboard;
+
+import static java.util.stream.Collectors.toMap;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.yagubogu.auth.config.AuthTestConfig;
+import com.yagubogu.game.domain.Game;
+import com.yagubogu.game.domain.GameState;
+import com.yagubogu.global.config.JpaAuditingConfig;
+import com.yagubogu.leaderboard.domain.LeaderboardType;
+import com.yagubogu.leaderboard.dto.LeaderboardItemResponse;
+import com.yagubogu.leaderboard.dto.LeaderboardResponse;
+import com.yagubogu.member.domain.Member;
+import com.yagubogu.member.domain.Role;
+import com.yagubogu.stadium.domain.Stadium;
+import com.yagubogu.stadium.repository.StadiumRepository;
+import com.yagubogu.support.TestFixture;
+import com.yagubogu.support.auth.AuthFactory;
+import com.yagubogu.support.base.E2eTestBase;
+import com.yagubogu.support.checkin.CheckInFactory;
+import com.yagubogu.support.game.GameFactory;
+import com.yagubogu.support.member.MemberFactory;
+import com.yagubogu.team.domain.Team;
+import com.yagubogu.team.repository.TeamRepository;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpHeaders;
+
+@Import({AuthTestConfig.class, JpaAuditingConfig.class})
+public class LeaderboardE2eTest extends E2eTestBase {
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private MemberFactory memberFactory;
+
+    @Autowired
+    private GameFactory gameFactory;
+
+    @Autowired
+    private CheckInFactory checkInFactory;
+
+    @Autowired
+    private TeamRepository teamRepository;
+
+    @Autowired
+    private StadiumRepository stadiumRepository;
+
+    @Autowired
+    private AuthFactory authFactory;
+
+    private Team kia, lotte;
+    private Stadium stadiumJamsil, stadiumGocheok;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+
+        kia = teamRepository.findByTeamCode("HT").orElseThrow();
+        lotte = teamRepository.findByTeamCode("LT").orElseThrow();
+
+        stadiumJamsil = stadiumRepository.findById(2L).orElseThrow();
+        stadiumGocheok = stadiumRepository.findById(3L).orElseThrow();
+    }
+
+    @DisplayName("명예의 전당 전체 조회는 각 타입 TopN을 반환한다")
+    @Test
+    void getAllLeaderboards() {
+        // given: 2025년 데이터로 MOST_CHECK_IN 1위 만들기
+        Member fora = memberFactory.save(b -> b.team(lotte).nickname("fora"));
+        Member pobi = memberFactory.save(builder -> builder.team(kia).nickname("pobi"));
+
+        LocalDate d1 = LocalDate.of(2025, 1, 10);
+        LocalDate d2 = LocalDate.of(2025, 2, 10);
+
+        Game g1 = gameFactory.save(builder -> builder
+                .stadium(stadiumGocheok)
+                .date(d1)
+                .homeTeam(lotte).awayTeam(kia)
+                .homeScore(3).awayScore(1)
+                .homeScoreBoard(TestFixture.getHomeScoreBoard())
+                .awayScoreBoard(TestFixture.getAwayScoreBoard())
+                .gameState(GameState.COMPLETED)
+        );
+
+        Game g2 = gameFactory.save(builder -> builder
+                .stadium(stadiumJamsil)
+                .date(d2)
+                .homeTeam(kia).awayTeam(lotte)
+                .homeScore(2).awayScore(4)
+                .homeScoreBoard(TestFixture.getHomeScoreBoard())
+                .awayScoreBoard(TestFixture.getAwayScoreBoard())
+                .gameState(GameState.COMPLETED)
+        );
+
+        // fora: 2회 체크인(2경기), pobi: 1회 체크인(1경기)
+        checkInFactory.save(bld -> bld.game(g1).member(fora).team(lotte));
+        checkInFactory.save(bld -> bld.game(g2).member(fora).team(lotte));
+        checkInFactory.save(bld -> bld.game(g1).member(pobi).team(kia));
+
+        String token = authFactory.getAccessTokenByMemberId(fora.getId(), Role.USER);
+
+        // when
+        LeaderboardResponse[] array = RestAssured.given().log().all()
+                .contentType(ContentType.JSON)
+                .header(HttpHeaders.AUTHORIZATION, token)
+                .queryParam("limit", 1)
+                .when().get("/api/v1/leaderboards")
+                .then().log().all()
+                .statusCode(200)
+                .extract()
+                .as(LeaderboardResponse[].class);
+
+        List<LeaderboardResponse> responses = Arrays.asList(array);
+
+        // then: 모든 타입이 포함되어 있고, MOST_CHECK_IN 1위는 fora
+        assertThat(responses).hasSize(LeaderboardType.values().length);
+
+        Map<LeaderboardType, LeaderboardResponse> byType = responses.stream()
+                .collect(toMap(LeaderboardResponse::type, r -> r));
+
+        LeaderboardResponse mostCheckIn = byType.get(LeaderboardType.MOST_CHECK_IN);
+        assertThat(mostCheckIn).isNotNull();
+        assertThat(mostCheckIn.items()).hasSize(1);
+
+        LeaderboardItemResponse top = mostCheckIn.items().get(0);
+        assertThat(top.rank()).isEqualTo(1);
+        assertThat(top.memberId()).isEqualTo(fora.getId());
+        assertThat(top.nickname()).isEqualTo("fora");
+        assertThat(top.favoriteTeam()).isEqualTo(lotte.getShortName());
+        assertThat(top.profileImageUrl()).isEqualTo(fora.getImageUrl());
+        assertThat(top.score()).isEqualTo(2.0);
+        assertThat(top.scoreLabel()).isEqualTo(LeaderboardType.MOST_CHECK_IN.getScoreLabel());
+    }
+}

--- a/backend/app/src/test/java/com/yagubogu/leaderboard/service/ChattiestLeaderboardQueryTest.java
+++ b/backend/app/src/test/java/com/yagubogu/leaderboard/service/ChattiestLeaderboardQueryTest.java
@@ -1,0 +1,186 @@
+package com.yagubogu.leaderboard.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.yagubogu.auth.config.AuthTestConfig;
+import com.yagubogu.game.domain.Game;
+import com.yagubogu.global.config.JpaAuditingConfig;
+import com.yagubogu.leaderboard.dto.LeaderboardRow;
+import com.yagubogu.member.domain.Member;
+import com.yagubogu.stadium.domain.Stadium;
+import com.yagubogu.stadium.repository.StadiumRepository;
+import com.yagubogu.support.game.GameFactory;
+import com.yagubogu.support.member.MemberFactory;
+import com.yagubogu.support.talk.TalkFactory;
+import com.yagubogu.support.talk.TalkReportFactory;
+import com.yagubogu.talk.domain.Talk;
+import com.yagubogu.talk.repository.TalkRepository;
+import com.yagubogu.team.domain.Team;
+import com.yagubogu.team.repository.TeamRepository;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+@ExtendWith(MockitoExtension.class)
+@Import({AuthTestConfig.class, JpaAuditingConfig.class})
+@DataJpaTest
+class ChattiestLeaderboardQueryTest {
+
+    private ChattiestLeaderboardQuery chattiestLeaderboardQuery;
+
+    @Autowired
+    private TalkRepository talkRepository;
+
+    @Autowired
+    private TeamRepository teamRepository;
+
+    @Autowired
+    private StadiumRepository stadiumRepository;
+
+    @Autowired
+    private MemberFactory memberFactory;
+
+    @Autowired
+    private GameFactory gameFactory;
+
+    @Autowired
+    private TalkFactory talkFactory;
+
+    @Autowired
+    private TalkReportFactory talkReportFactory;
+
+    private Team kia, kt, lg, samsung, doosan, lotte;
+    private Stadium stadiumJamsil, stadiumGocheok, stadiumIncheon;
+
+    @BeforeEach
+    void setUp() {
+        chattiestLeaderboardQuery = new ChattiestLeaderboardQuery(talkRepository);
+
+        kia = teamRepository.findByTeamCode("HT").orElseThrow();
+        kt = teamRepository.findByTeamCode("KT").orElseThrow();
+        lg = teamRepository.findByTeamCode("LG").orElseThrow();
+        samsung = teamRepository.findByTeamCode("SS").orElseThrow();
+        doosan = teamRepository.findByTeamCode("OB").orElseThrow();
+        lotte = teamRepository.findByTeamCode("LT").orElseThrow();
+
+        stadiumJamsil = stadiumRepository.findById(2L).orElseThrow();
+        stadiumGocheok = stadiumRepository.findById(3L).orElseThrow();
+        stadiumIncheon = stadiumRepository.findById(7L).orElseThrow();
+    }
+
+    @DisplayName("2025년 수다쟁이: 신고된 톡은 제외하고, 공동 1등이면 모두 rank=1로 반환한다.")
+    @Test
+    void findTop_excludeReported() {
+        // given
+        Member fora = memberFactory.save(builder -> builder.team(kia));
+        Member mint = memberFactory.save(builder -> builder.team(kia));
+        Member duri = memberFactory.save(builder -> builder.team(kia));
+
+        Game game2025 = gameFactory.save(builder -> builder
+                .homeTeam(kia)
+                .awayTeam(lg)
+                .stadium(stadiumJamsil)
+                .date(LocalDate.of(2025, 7, 25)));
+        Game game2024 = gameFactory.save(builder -> builder
+                .homeTeam(kia)
+                .awayTeam(lg)
+                .stadium(stadiumJamsil)
+                .date(LocalDate.of(2024, 7, 25)));
+
+        LocalDateTime time2025 = LocalDateTime.of(2025, 7, 25, 10, 0);
+        LocalDateTime time2024 = LocalDateTime.of(2024, 7, 25, 10, 0);
+
+        // fora 2025 talk 3개 중 1개 신고 -> 공동 1등
+        Talk talk1 = talkFactory.save(builder -> builder
+                .member(fora)
+                .game(game2025)
+                .createdAt(time2025));
+        Talk talk2 = talkFactory.save(builder -> builder
+                .member(fora)
+                .game(game2025)
+                .createdAt(time2025));
+        Talk talk3 = talkFactory.save(builder -> builder
+                .member(fora)
+                .game(game2025)
+                .createdAt(time2025));
+        talkReportFactory.save(builder -> builder
+                .talk(talk3)
+                .reporter(fora)
+        );
+
+        // mint 2025 talk 2개 -> 공동 1등
+        talkFactory.save(builder -> builder
+                .member(mint)
+                .game(game2025)
+                .createdAt(time2025));
+        talkFactory.save(builder -> builder
+                .member(mint)
+                .game(game2025)
+                .createdAt(time2025));
+
+        // duri 2025 talk 1개 -> 2등
+        talkFactory.save(builder -> builder
+                .member(duri)
+                .game(game2025)
+                .createdAt(time2025));
+
+        // 2024 talk 집계 제외
+        talkFactory.save(builder -> builder
+                .member(fora)
+                .game(game2024)
+                .createdAt(time2024));
+        talkFactory.save(builder -> builder
+                .member(fora)
+                .game(game2024)
+                .createdAt(time2024));
+
+        // when
+        List<LeaderboardRow> rows = chattiestLeaderboardQuery.findTop(1);
+
+        // then
+        assertThat(rows).hasSize(2);
+        assertThat(rows).allMatch(r -> r.rank() == 1L);
+        assertThat(rows).extracting(LeaderboardRow::memberId)
+                .containsExactlyInAnyOrder(fora.getId(), mint.getId());
+        assertThat(rows).allMatch(r -> r.score() == 2.0);
+    }
+
+    @DisplayName("limit=2이면 공동 1등 + 2등까지 포함된다.")
+    @Test
+    void findTop_limit2_includeRank2() {
+        // given
+        Member fora = memberFactory.save(builder -> builder.team(kia));
+        Member mint = memberFactory.save(builder -> builder.team(kia));
+        Member duri = memberFactory.save(builder -> builder.team(kia));
+
+        Game game2025 = gameFactory.save(builder -> builder
+                .homeTeam(kia)
+                .awayTeam(lg)
+                .stadium(stadiumJamsil)
+                .date(LocalDate.of(2025, 7, 25)));
+
+        LocalDateTime time2025 = LocalDateTime.of(2025, 7, 25, 10, 0);
+        talkFactory.save(builder -> builder.member(fora).game(game2025).createdAt(time2025));
+        talkFactory.save(builder -> builder.member(fora).game(game2025).createdAt(time2025));
+        talkFactory.save(builder -> builder.member(mint).game(game2025).createdAt(time2025));
+        talkFactory.save(builder -> builder.member(mint).game(game2025).createdAt(time2025));
+        talkFactory.save(builder -> builder.member(duri).game(game2025).createdAt(time2025));
+
+        // when
+        List<LeaderboardRow> rows = chattiestLeaderboardQuery.findTop(2);
+
+        // then
+        assertThat(rows).hasSize(3);
+        assertThat(rows).extracting(LeaderboardRow::rank).contains(1L, 2L);
+        assertThat(rows).extracting(LeaderboardRow::memberId)
+                .containsExactlyInAnyOrder(fora.getId(), mint.getId(), duri.getId());
+    }
+}

--- a/backend/app/src/test/java/com/yagubogu/leaderboard/service/ChattiestLeaderboardQueryTest.java
+++ b/backend/app/src/test/java/com/yagubogu/leaderboard/service/ChattiestLeaderboardQueryTest.java
@@ -57,23 +57,17 @@ class ChattiestLeaderboardQueryTest {
     @Autowired
     private TalkReportFactory talkReportFactory;
 
-    private Team kia, kt, lg, samsung, doosan, lotte;
-    private Stadium stadiumJamsil, stadiumGocheok, stadiumIncheon;
+    private Team kia, lg;
+    private Stadium stadiumJamsil;
 
     @BeforeEach
     void setUp() {
         chattiestLeaderboardQuery = new ChattiestLeaderboardQuery(talkRepository);
 
         kia = teamRepository.findByTeamCode("HT").orElseThrow();
-        kt = teamRepository.findByTeamCode("KT").orElseThrow();
         lg = teamRepository.findByTeamCode("LG").orElseThrow();
-        samsung = teamRepository.findByTeamCode("SS").orElseThrow();
-        doosan = teamRepository.findByTeamCode("OB").orElseThrow();
-        lotte = teamRepository.findByTeamCode("LT").orElseThrow();
 
         stadiumJamsil = stadiumRepository.findById(2L).orElseThrow();
-        stadiumGocheok = stadiumRepository.findById(3L).orElseThrow();
-        stadiumIncheon = stadiumRepository.findById(7L).orElseThrow();
     }
 
     @DisplayName("2025년 수다쟁이: 신고된 톡은 제외하고, 공동 1등이면 모두 rank=1로 반환한다.")

--- a/backend/app/src/test/java/com/yagubogu/leaderboard/service/LoseFairyLeaderboardQueryTest.java
+++ b/backend/app/src/test/java/com/yagubogu/leaderboard/service/LoseFairyLeaderboardQueryTest.java
@@ -1,0 +1,129 @@
+package com.yagubogu.leaderboard.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.yagubogu.auth.config.AuthTestConfig;
+import com.yagubogu.global.config.JpaAuditingConfig;
+import com.yagubogu.leaderboard.dto.LeaderboardRow;
+import com.yagubogu.member.domain.Member;
+import com.yagubogu.stat.repository.VictoryFairyRankingRepository;
+import com.yagubogu.support.member.MemberFactory;
+import com.yagubogu.team.domain.Team;
+import com.yagubogu.team.repository.TeamRepository;
+import java.time.Year;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+@ExtendWith(MockitoExtension.class)
+@Import({AuthTestConfig.class, JpaAuditingConfig.class})
+@DataJpaTest
+class LoseFairyLeaderboardQueryTest {
+
+    private LoseFairyLeaderboardQuery loseFairyLeaderboardQuery;
+
+    @Autowired
+    VictoryFairyRankingRepository victoryFairyRankingRepository;
+
+    @Autowired
+    JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    TeamRepository teamRepository;
+
+    @Autowired
+    private MemberFactory memberFactory;
+
+    private Team kia, lg;
+
+    @BeforeEach
+    void setUp() {
+        loseFairyLeaderboardQuery = new LoseFairyLeaderboardQuery(victoryFairyRankingRepository);
+
+        kia = teamRepository.findByTeamCode("HT").orElseThrow();
+        lg = teamRepository.findByTeamCode("LG").orElseThrow();
+    }
+
+    @DisplayName("패배요정 랭킹은 lastYear 기준 score 오름차순으로 Top1을 반환한다.")
+    @Test
+    void findTop_lastYear_top1() {
+        // given
+        int lastYear = Year.now().minusYears(1).getValue();
+        Member fora = memberFactory.save(builder -> builder.team(kia));
+        Member mint = memberFactory.save(builder -> builder.team(lg));
+
+        insertVictoryFairyRanking(fora.getId(), lastYear, 90.0);
+        insertVictoryFairyRanking(mint.getId(), lastYear, 78.0);
+
+        // when
+        List<LeaderboardRow> rows = loseFairyLeaderboardQuery.findTop(1);
+
+        // then
+        assertThat(rows).hasSize(1);
+        LeaderboardRow top = rows.get(0);
+
+        assertThat(top.rank()).isEqualTo(1L);
+        assertThat(top.memberId()).isEqualTo(mint.getId());
+        assertThat(top.favoriteTeam()).isEqualTo(lg.getShortName());
+        assertThat(top.score()).isEqualTo(78.0);
+    }
+
+    @DisplayName("패배요정 명예의 전당에서 다른 연도 데이터는 집계에서 제외된다.")
+    @Test
+    void findTop_excludeOtherYear() {
+        // given
+        int lastYear = Year.now().minusYears(1).getValue();
+        Member fora = memberFactory.save(builder -> builder.team(kia));
+        Member mint = memberFactory.save(builder -> builder.team(lg));
+
+        insertVictoryFairyRanking(fora.getId(), lastYear - 1, 16.0);
+        insertVictoryFairyRanking(mint.getId(), lastYear, 99.0);
+
+        // when
+        List<LeaderboardRow> rows = loseFairyLeaderboardQuery.findTop(1);
+
+        // then
+        assertThat(rows).hasSize(1);
+        assertThat(rows.get(0).memberId()).isEqualTo(mint.getId());
+        assertThat(rows.get(0).score()).isEqualTo(99.0);
+    }
+
+    @DisplayName("패배요정 명예의 전당에서 limit=2이면 1등~2등까지 반환한다.")
+    @Test
+    void findTop_limit2() {
+        // given
+        int lastYear = Year.now().minusYears(1).getValue(); // 2025
+        Member fora = memberFactory.save(b -> b.team(kia));
+        Member mint = memberFactory.save(b -> b.team(kia));
+        Member duri = memberFactory.save(b -> b.team(kia));
+
+        insertVictoryFairyRanking(fora.getId(), lastYear, 63.0);
+        insertVictoryFairyRanking(mint.getId(), lastYear, 86.0);
+        insertVictoryFairyRanking(duri.getId(), lastYear, 94.0);
+
+        // when
+        List<LeaderboardRow> rows = loseFairyLeaderboardQuery.findTop(2);
+
+        // then
+        assertThat(rows).hasSize(2);
+        assertThat(rows).extracting(LeaderboardRow::rank).containsExactly(1L, 2L);
+        assertThat(rows).extracting(LeaderboardRow::memberId)
+                .containsExactly(fora.getId(), mint.getId());
+    }
+
+    private void insertVictoryFairyRanking(long memberId, int gameYear, double score) {
+        jdbcTemplate.update("""
+                INSERT INTO victory_fairy_rankings
+                  (member_id, score, win_count, check_in_count, game_year, updated_at)
+                VALUES
+                  (?, ?, 0, 0, ?, NULL)
+                """, memberId, score, gameYear);
+    }
+}

--- a/backend/app/src/test/java/com/yagubogu/leaderboard/service/MostCheckInLeaderboardQueryTest.java
+++ b/backend/app/src/test/java/com/yagubogu/leaderboard/service/MostCheckInLeaderboardQueryTest.java
@@ -1,0 +1,160 @@
+package com.yagubogu.leaderboard.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.yagubogu.auth.config.AuthTestConfig;
+import com.yagubogu.checkin.domain.CheckInType;
+import com.yagubogu.checkin.repository.CheckInRepository;
+import com.yagubogu.game.domain.Game;
+import com.yagubogu.global.config.JpaAuditingConfig;
+import com.yagubogu.leaderboard.dto.LeaderboardRow;
+import com.yagubogu.member.domain.Member;
+import com.yagubogu.stadium.domain.Stadium;
+import com.yagubogu.stadium.repository.StadiumRepository;
+import com.yagubogu.support.checkin.CheckInFactory;
+import com.yagubogu.support.game.GameFactory;
+import com.yagubogu.support.member.MemberFactory;
+import com.yagubogu.team.domain.Team;
+import com.yagubogu.team.repository.TeamRepository;
+import java.time.LocalDate;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+@ExtendWith(MockitoExtension.class)
+@Import({AuthTestConfig.class, JpaAuditingConfig.class})
+@DataJpaTest
+class MostCheckInLeaderboardQueryTest {
+
+    private MostCheckInLeaderboardQuery mostCheckInLeaderboardQuery;
+
+    @Autowired
+    private CheckInRepository checkInRepository;
+
+    @Autowired
+    private TeamRepository teamRepository;
+
+    @Autowired
+    private StadiumRepository stadiumRepository;
+
+    @Autowired
+    private MemberFactory memberFactory;
+
+    @Autowired
+    private GameFactory gameFactory;
+
+    @Autowired
+    private CheckInFactory checkInFactory;
+
+    private Team kia, lg, kt;
+    private Stadium stadiumJamsil;
+
+    @BeforeEach
+    void setUp() {
+        mostCheckInLeaderboardQuery = new MostCheckInLeaderboardQuery(checkInRepository);
+
+        kia = teamRepository.findByTeamCode("HT").orElseThrow();
+        lg = teamRepository.findByTeamCode("LG").orElseThrow();
+        kt = teamRepository.findByTeamCode("KT").orElseThrow();
+
+        stadiumJamsil = stadiumRepository.findById(2L).orElseThrow();
+    }
+
+    @DisplayName("최다직관 명예의 전당에서 공동 1등이면 rank=1로 반환한다.")
+    @Test
+    void findTop_rank1_allReturned() {
+        // given
+        Member fora = memberFactory.save(b -> b.team(kia).nickname("포라"));
+        Member mint = memberFactory.save(b -> b.team(lg).nickname("밍트"));
+        Member duri = memberFactory.save(b -> b.team(kt).nickname("두리"));
+
+        Game game2025 = gameFactory.save(b -> b
+                .homeTeam(kia).awayTeam(lg)
+                .stadium(stadiumJamsil)
+                .date(LocalDate.of(2025, 7, 25))
+        );
+        Game game2024 = gameFactory.save(b -> b
+                .homeTeam(kia).awayTeam(lg)
+                .stadium(stadiumJamsil)
+                .date(LocalDate.of(2024, 7, 25))
+        );
+
+        // fora 2025 체크인 2개 (공동 1등)
+        checkIn(fora, game2025);
+        checkIn(fora, gameFactory.save(
+                b -> b.homeTeam(kia).awayTeam(kt).stadium(stadiumJamsil).date(LocalDate.of(2025, 7, 26))));
+
+        // mint 2025 체크인 2개 (공동 1등)
+        checkIn(mint, game2025);
+        checkIn(mint, gameFactory.save(
+                b -> b.homeTeam(lg).awayTeam(kt).stadium(stadiumJamsil).date(LocalDate.of(2025, 7, 27))));
+
+        // duri 2025 체크인 1개 (2등)
+        checkIn(duri, game2025);
+
+        // 2024 체크인은 집계 제외되어야 함
+        checkIn(fora, game2024);
+        checkIn(duri, game2024);
+
+        // when
+        List<LeaderboardRow> rows = mostCheckInLeaderboardQuery.findTop(1);
+
+        // then
+        assertThat(rows).hasSize(2);
+        assertThat(rows).allMatch(r -> r.rank() == 1L);
+        assertThat(rows).extracting(LeaderboardRow::memberId)
+                .containsExactlyInAnyOrder(fora.getId(), mint.getId());
+        assertThat(rows).allMatch(r -> r.score() == 2.0);
+    }
+
+    @DisplayName("limit=2이면 공동 1등 + 2등까지 포함된다.")
+    @Test
+    void findTop_limit2_includeRank2() {
+        // given
+        Member fora = memberFactory.save(b -> b.team(kia).nickname("포라"));
+        Member mint = memberFactory.save(b -> b.team(lg).nickname("밍트"));
+        Member duri = memberFactory.save(b -> b.team(kt).nickname("두리"));
+
+        Game g1 = gameFactory.save(
+                b -> b.homeTeam(kia).awayTeam(lg).stadium(stadiumJamsil).date(LocalDate.of(2025, 7, 25)));
+        Game g2 = gameFactory.save(
+                b -> b.homeTeam(kia).awayTeam(kt).stadium(stadiumJamsil).date(LocalDate.of(2025, 7, 26)));
+
+        // fora 2회
+        checkIn(fora, g1);
+        checkIn(fora, g2);
+
+        // mint 2회 (공동 1등)
+        checkIn(mint, g1);
+        checkIn(mint, g2);
+
+        // duri 1회 (2등)
+        checkIn(duri, g1);
+
+        // when
+        List<LeaderboardRow> rows = mostCheckInLeaderboardQuery.findTop(2);
+
+        // then
+        assertThat(rows).hasSize(3);
+        assertThat(rows).extracting(LeaderboardRow::rank).contains(1L, 2L);
+        assertThat(rows).extracting(LeaderboardRow::memberId)
+                .containsExactlyInAnyOrder(fora.getId(), mint.getId(), duri.getId());
+        assertThat(rows.stream().filter(r -> r.memberId() == duri.getId()).findFirst().orElseThrow().score())
+                .isEqualTo(1.0);
+    }
+
+    private void checkIn(Member member, Game game) {
+        checkInFactory.save(builder -> builder
+                .member(member)
+                .game(game)
+                .team(member.getTeam())
+                .checkInType(CheckInType.NON_LOCATION_CHECK_IN)
+        );
+    }
+}

--- a/backend/app/src/test/java/com/yagubogu/leaderboard/service/WinFairyLeaderboardQueryTest.java
+++ b/backend/app/src/test/java/com/yagubogu/leaderboard/service/WinFairyLeaderboardQueryTest.java
@@ -1,0 +1,154 @@
+package com.yagubogu.leaderboard.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.yagubogu.auth.config.AuthTestConfig;
+import com.yagubogu.global.config.JpaAuditingConfig;
+import com.yagubogu.leaderboard.dto.LeaderboardRow;
+import com.yagubogu.member.domain.Member;
+import com.yagubogu.stat.repository.VictoryFairyRankingRepository;
+import com.yagubogu.support.member.MemberFactory;
+import com.yagubogu.team.domain.Team;
+import com.yagubogu.team.repository.TeamRepository;
+import java.time.Year;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+@ExtendWith(MockitoExtension.class)
+@Import({AuthTestConfig.class, JpaAuditingConfig.class})
+@DataJpaTest
+class WinFairyLeaderboardQueryTest {
+
+    private WinFairyLeaderboardQuery winFairyLeaderboardQuery;
+
+    @Autowired
+    VictoryFairyRankingRepository victoryFairyRankingRepository;
+
+    @Autowired
+    JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    TeamRepository teamRepository;
+
+    @Autowired
+    private MemberFactory memberFactory;
+
+    private Team kia, lg;
+
+    @BeforeEach
+    void setUp() {
+        winFairyLeaderboardQuery = new WinFairyLeaderboardQuery(victoryFairyRankingRepository);
+
+        kia = teamRepository.findByTeamCode("HT").orElseThrow();
+        lg = teamRepository.findByTeamCode("LG").orElseThrow();
+    }
+
+    @DisplayName("승리요정 랭킹은 lastYear 기준 score 내림차순으로 Top1을 반환한다.")
+    @Test
+    void findTop_lastYear_top1() {
+        // given
+        int lastYear = Year.now().minusYears(1).getValue();
+        Member fora = memberFactory.save(builder -> builder.team(kia));
+        Member mint = memberFactory.save(builder -> builder.team(lg));
+
+        insertVictoryFairyRanking(fora.getId(), lastYear, 90.0);
+        insertVictoryFairyRanking(mint.getId(), lastYear, 78.0);
+
+        // when
+        List<LeaderboardRow> rows = winFairyLeaderboardQuery.findTop(1);
+
+        // then
+        assertThat(rows).hasSize(1);
+        LeaderboardRow top = rows.get(0);
+
+        assertThat(top.rank()).isEqualTo(1L);
+        assertThat(top.memberId()).isEqualTo(fora.getId());
+        assertThat(top.favoriteTeam()).isEqualTo(kia.getShortName());
+        assertThat(top.score()).isEqualTo(90.0);
+    }
+
+    @DisplayName("승리요정 명예의 전당에서 다른 연도 데이터는 집계에서 제외된다.")
+    @Test
+    void findTop_excludeOtherYear() {
+        // given
+        int lastYear = Year.now().minusYears(1).getValue();
+        Member fora = memberFactory.save(builder -> builder.team(kia));
+        Member mint = memberFactory.save(builder -> builder.team(lg));
+
+        insertVictoryFairyRanking(fora.getId(), lastYear - 1, 99.0);
+        insertVictoryFairyRanking(mint.getId(), lastYear, 16.0);
+
+        // when
+        List<LeaderboardRow> rows = winFairyLeaderboardQuery.findTop(1);
+
+        // then
+        assertThat(rows).hasSize(1);
+        assertThat(rows.get(0).memberId()).isEqualTo(mint.getId());
+        assertThat(rows.get(0).score()).isEqualTo(16.0);
+    }
+
+    @DisplayName("승리요정 명예의 전당에서 limit=2이면 1등~2등까지 반환한다.")
+    @Test
+    void findTop_limit2() {
+        // given
+        int lastYear = Year.now().minusYears(1).getValue(); // 2025
+        Member fora = memberFactory.save(b -> b.team(kia));
+        Member mint = memberFactory.save(b -> b.team(kia));
+        Member duri = memberFactory.save(b -> b.team(kia));
+
+        insertVictoryFairyRanking(fora.getId(), lastYear, 94.0);
+        insertVictoryFairyRanking(mint.getId(), lastYear, 86.0);
+        insertVictoryFairyRanking(duri.getId(), lastYear, 63.0);
+
+        // when
+        List<LeaderboardRow> rows = winFairyLeaderboardQuery.findTop(2);
+
+        // then
+        assertThat(rows).hasSize(2);
+        assertThat(rows).extracting(LeaderboardRow::rank).containsExactly(1L, 2L);
+        assertThat(rows).extracting(LeaderboardRow::memberId)
+                .containsExactly(fora.getId(), mint.getId());
+    }
+//
+//    @DisplayName("승리요정 명예의 전당에서 동점이면 공동 1등이 rank=1로 모두 반환된다 (limit=1이어도).")
+//    @Test
+//    void findTop_rank1_allReturned() {
+//        // given
+//        int lastYear = Year.now().minusYears(1).getValue(); // 2025
+//        Member fora = memberFactory.save(b -> b.team(kia));
+//        Member mint = memberFactory.save(b -> b.team(kia));
+//        Member duri = memberFactory.save(b -> b.team(kia));
+//
+//        // fora/mint 동점 1등
+//        insertVictoryFairyRanking(fora.getId(), lastYear, 96.0);
+//        insertVictoryFairyRanking(mint.getId(), lastYear, 96.0);
+//        insertVictoryFairyRanking(duri.getId(), lastYear, 35.0);
+//
+//        // when
+//        List<LeaderboardRow> rows = winFairyLeaderboardQuery.findTop(1);
+//
+//        // then
+//        assertThat(rows).hasSize(2);
+//        assertThat(rows).allMatch(r -> r.rank() == 1L);
+//        assertThat(rows).extracting(LeaderboardRow::memberId)
+//                .containsExactlyInAnyOrder(fora.getId(), mint.getId());
+//        assertThat(rows).allMatch(r -> r.score() == 96.0);
+//    }
+
+    private void insertVictoryFairyRanking(long memberId, int gameYear, double score) {
+        jdbcTemplate.update("""
+                INSERT INTO victory_fairy_rankings
+                  (member_id, score, win_count, check_in_count, game_year, updated_at)
+                VALUES
+                  (?, ?, 0, 0, ?, NULL)
+                """, memberId, score, gameYear);
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈
- close #830 

## ✨ 변경 내용
- 명예의 전당 전체 조회 API 추가
- 컨트롤러: /api/v1/leaderboards GET 추가
- 서비스: LeaderboardService + 전략 인터페이스 LeaderboardQuery
- 쿼리 구현:
    - WinFairyLeaderboardQuery: 승리요정 상위 N
    - LoseFairyLeaderboardQuery: 패배요정 상위 N
    - MostCheckInLeaderboardQuery: 최다 직관 상위 N
    - ChattiestLeaderboardQuery: 수다쟁이 상위 N

## API 설명
- 엔드포인트: GET /api/v1/leaderboards
- 응답 바디 예시:
```
{
  "leaderboards": [
    {
      "type": "WIN_FAIRY",
      "items": []
    },
    {
      "type": "MOST_CHECK_IN",
      "items": [
        {
          "rank": 1,
          "memberId": 5007,
          "nickname": "기아2",
          "favoriteTeam": "KIA",
          "profileImageUrl": "https://image.com/기아2.png",
          "score": 3
        },
        {
          "rank": 1,
          "memberId": 5008,
          "nickname": "기아3",
          "favoriteTeam": "KIA",
          "profileImageUrl": "https://image.com/기아3.png",
          "score": 3
        },
        {
          "rank": 1,
          "memberId": 5009,
          "nickname": "엘지3",
          "favoriteTeam": "LG",
          "profileImageUrl": "https://image.com/엘지3.png",
          "score": 3
        },
        {
          "rank": 1,
          "memberId": 5010,
          "nickname": "롯데1",
          "favoriteTeam": "롯데",
          "profileImageUrl": "https://image.com/롯데1.png",
          "score": 3
        }
      ]
    },
    {
      "type": "CHATTIEST",
      "items": []
    },
    {
      "type": "LOSE_FAIRY",
      "items": []
    }
  ]
}
```
- 동점(공동 순위)일 경우 해당 순위의 모든 사용자를 반환함. (ex 공동 1등이 3명이면 3명 모두 반환)
- 상태 코드:
    - 정상: 200 OK (현재 구현은 데이터 없음이어도 빈 리스트로 200 반환)

## 집계 기준
- WIN_FAIRY/LOSE_FAIRY: victory_fairy_rankings 스코어 기준 상·하위 N
- MOST_CHECK_IN: 전년도 check_ins 수 기준 상위 N
- CHATTIEST: 전년도 talks 수 기준 상위 N
    - 제외: 신고된 톡
    
## 🎸 기타 참고 사항
- 스크린샷, 참고 링크, 추가 설명 등 (없으면 생략 가능)