### PR TITLE
feat: 통계 조회 시 전체 시즌 조회 기능 추가

### DIFF
--- a/backend/app/src/main/java/com/yagubogu/checkin/controller/v1/CheckInController.java
+++ b/backend/app/src/main/java/com/yagubogu/checkin/controller/v1/CheckInController.java
@@ -47,7 +47,7 @@ public class CheckInController implements CheckInControllerInterface {
     @Override
     public ResponseEntity<CheckInHistoryResponse> findCheckInHistory(
             final MemberClaims memberClaims,
-            @RequestParam final int year,
+            @RequestParam(required = false) final Integer year,
             @RequestParam(required = false) final Integer month,
             @RequestParam(name = "result", defaultValue = "ALL") final CheckInResultFilter resultFilter,
             @RequestParam(name = "order", defaultValue = "LATEST") final CheckInOrderFilter orderFilter
@@ -83,7 +83,7 @@ public class CheckInController implements CheckInControllerInterface {
 
     public ResponseEntity<StadiumCheckInCountsResponse> findStadiumCheckInCount(
             final MemberClaims memberClaims,
-            @RequestParam final int year
+            @RequestParam(required = false) final Integer year
     ) {
         StadiumCheckInCountsResponse response = checkInService.findStadiumCheckInCounts(memberClaims.id(), year);
 

--- a/backend/app/src/main/java/com/yagubogu/checkin/controller/v1/CheckInControllerInterface.java
+++ b/backend/app/src/main/java/com/yagubogu/checkin/controller/v1/CheckInControllerInterface.java
@@ -56,7 +56,7 @@ public interface CheckInControllerInterface {
     @GetMapping("/members")
     ResponseEntity<CheckInHistoryResponse> findCheckInHistory(
             @Parameter(hidden = true) MemberClaims memberClaims,
-            @RequestParam final int year,
+            @RequestParam(required = false) final Integer year,
             @RequestParam(required = false) final Integer month,
             @RequestParam(name = "result", defaultValue = "ALL") CheckInResultFilter resultFilter,
             @RequestParam(name = "order", defaultValue = "LATEST") CheckInOrderFilter orderFilter
@@ -92,6 +92,6 @@ public interface CheckInControllerInterface {
     @GetMapping("/stadiums/counts")
     ResponseEntity<StadiumCheckInCountsResponse> findStadiumCheckInCount(
             @Parameter(hidden = true) MemberClaims memberClaims,
-            @RequestParam int year
+            @RequestParam(required = false) Integer year
     );
 }

--- a/backend/app/src/main/java/com/yagubogu/checkin/repository/CheckInRepository.java
+++ b/backend/app/src/main/java/com/yagubogu/checkin/repository/CheckInRepository.java
@@ -4,9 +4,7 @@ import com.yagubogu.checkin.domain.CheckIn;
 import com.yagubogu.checkin.domain.CheckInType;
 import com.yagubogu.game.domain.Game;
 import com.yagubogu.member.domain.Member;
-import com.yagubogu.stat.dto.StadiumStatsParam;
 import java.time.LocalDate;
-import java.util.List;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -33,27 +31,27 @@ public interface CheckInRepository extends JpaRepository<CheckIn, Long>, CustomC
             """)
     boolean isFirstMainStadiumVisit(@Param("member") Member member, @Param("stadiumId") Long stadiumId);
 
-    @Query("""
-                SELECT new com.yagubogu.stat.dto.StadiumStatsParam(
-                           g.stadium.shortName,
-                           SUM(CASE WHEN ci.team.id = ci.member.team.id
-                                        AND ((ci.team.id = g.awayTeam.id AND g.awayScore > g.homeScore)
-                                          OR (ci.team.id = g.homeTeam.id AND g.homeScore > g.awayScore))
-                                   THEN 1 ELSE 0 END),
-                           SUM(CASE WHEN ci.team.id = ci.member.team.id
-                                        AND g.awayScore <> g.homeScore
-                                   THEN 1 ELSE 0 END)
-                       )
-                FROM CheckIn ci
-                JOIN ci.game g
-                WHERE ci.member.id = :memberId
-                  AND g.gameState = 'COMPLETED'
-                  AND g.date BETWEEN :startDate AND :endDate
-                GROUP BY g.stadium.id
-            """)
-    List<StadiumStatsParam> findWinAndNonDrawCountByStadium(@Param("memberId") Long memberId,
-                                                            @Param("startDate") LocalDate startDate,
-                                                            @Param("endDate") LocalDate endDate);
+//    @Query("""
+//                SELECT new com.yagubogu.stat.dto.StadiumStatsParam(
+//                           g.stadium.shortName,
+//                           SUM(CASE WHEN ci.team.id = ci.member.team.id
+//                                        AND ((ci.team.id = g.awayTeam.id AND g.awayScore > g.homeScore)
+//                                          OR (ci.team.id = g.homeTeam.id AND g.homeScore > g.awayScore))
+//                                   THEN 1 ELSE 0 END),
+//                           SUM(CASE WHEN ci.team.id = ci.member.team.id
+//                                        AND g.awayScore <> g.homeScore
+//                                   THEN 1 ELSE 0 END)
+//                       )
+//                FROM CheckIn ci
+//                JOIN ci.game g
+//                WHERE ci.member.id = :memberId
+//                  AND g.gameState = 'COMPLETED'
+//                  AND g.date BETWEEN :startDate AND :endDate
+//                GROUP BY g.stadium.id
+//            """)
+//    List<StadiumStatsParam> findWinAndNonDrawCountByStadium(@Param("memberId") Long memberId,
+//                                                            @Param("startDate") LocalDate startDate,
+//                                                            @Param("endDate") LocalDate endDate);
 
     @Query("""
             SELECT DISTINCT c.member.id

--- a/backend/app/src/main/java/com/yagubogu/checkin/repository/CustomCheckInRepository.java
+++ b/backend/app/src/main/java/com/yagubogu/checkin/repository/CustomCheckInRepository.java
@@ -10,6 +10,7 @@ import com.yagubogu.checkin.dto.VictoryFairyCountResult;
 import com.yagubogu.member.domain.Member;
 import com.yagubogu.stat.dto.AverageStatisticParam;
 import com.yagubogu.stat.dto.OpponentWinRateRowParam;
+import com.yagubogu.stat.dto.StadiumStatsParam;
 import com.yagubogu.team.domain.Team;
 import java.time.LocalDate;
 import java.util.List;
@@ -18,13 +19,13 @@ public interface CustomCheckInRepository {
 
     LocalDate findRecentCheckInGameDate(Member member);
 
-    StatCountsParam findStatCounts(Member member, int year);
+    StatCountsParam findStatCounts(Member member, Integer year);
 
-    int findWinCounts(Member member, int year);
+    int findWinCounts(Member member, Integer year);
 
-    int findLoseCounts(Member member, int year);
+    int findLoseCounts(Member member, Integer year);
 
-    int findDrawCounts(Member member, int year);
+    int findDrawCounts(Member member, Integer year);
 
     List<VictoryFairyCountResult> findCheckInAndWinCountBatch(List<Long> memberIds, int year);
 
@@ -51,22 +52,24 @@ public interface CustomCheckInRepository {
     List<OpponentWinRateRowParam> findOpponentWinRates(
             Member member,
             Team team,
-            int year
+            Integer year
     );
 
     double calculateTotalAverageWinRate(int year);
 
     double calculateAverageCheckInCount(int year);
 
-    int findRecentGamesDrawCounts(Member member, int year, int limit);
+    int findRecentGamesDrawCounts(Member member, Integer year, int limit);
 
-    int findRecentGamesLoseCounts(Member member, int year, int limit);
+    int findRecentGamesLoseCounts(Member member, Integer year, int limit);
 
-    int findRecentGamesWinCounts(Member member, int year, int limit);
+    int findRecentGamesWinCounts(Member member, Integer year, int limit);
 
     List<Long> findWinMemberIdByGameId(long gameId);
 
     List<Long> findLoseMemberIdByGameId(long gameId);
 
     List<Long> findDrawMemberIdByGameId(long gameId);
+
+    List<StadiumStatsParam> findWinAndNonDrawCountByStadium(Long memberId, Integer year);
 }

--- a/backend/app/src/main/java/com/yagubogu/checkin/repository/CustomCheckInRepository.java
+++ b/backend/app/src/main/java/com/yagubogu/checkin/repository/CustomCheckInRepository.java
@@ -34,7 +34,7 @@ public interface CustomCheckInRepository {
     List<CheckInGameParam> findCheckInHistory(
             Member member,
             Team team,
-            int year,
+            Integer year,
             Integer month,
             CheckInResultFilter resultFilter,
             CheckInOrderFilter orderFilter
@@ -46,7 +46,7 @@ public interface CustomCheckInRepository {
 
     List<StadiumCheckInCountParam> findStadiumCheckInCounts(
             Member member,
-            int year
+            Integer year
     );
 
     List<OpponentWinRateRowParam> findOpponentWinRates(

--- a/backend/app/src/main/java/com/yagubogu/checkin/repository/CustomCheckInRepositoryImpl.java
+++ b/backend/app/src/main/java/com/yagubogu/checkin/repository/CustomCheckInRepositoryImpl.java
@@ -237,7 +237,7 @@ public class CustomCheckInRepositoryImpl implements CustomCheckInRepository {
     public List<CheckInGameParam> findCheckInHistory(
             final Member member,
             final Team team,
-            final int year,
+            final Integer year,
             final Integer month,
             final CheckInResultFilter resultFilter,
             final CheckInOrderFilter orderFilter
@@ -355,7 +355,7 @@ public class CustomCheckInRepositoryImpl implements CustomCheckInRepository {
 
     public List<StadiumCheckInCountParam> findStadiumCheckInCounts(
             Member member,
-            int year
+            Integer year
     ) {
         return jpaQueryFactory
                 .select(
@@ -656,21 +656,27 @@ public class CustomCheckInRepositoryImpl implements CustomCheckInRepository {
         return checkIn.team.eq(member.getTeam());
     }
 
-    private Predicate dateFilter(final QGame game, final int year, final Integer month) {
+    private Predicate dateFilter(final QGame game, final Integer year, final Integer month) {
         if (month == null) {
             return isBetweenYear(game, year);
         }
         return isBetweenYearMonth(game, year, month);
     }
 
-    private BooleanExpression isBetweenYear(final QGame game, final int year) {
+    private BooleanExpression isBetweenYear(final QGame game, final Integer year) {
+        if (year == null) {
+            return null;
+        }
         LocalDate start = LocalDate.of(year, 1, 1);
         LocalDate end = LocalDate.of(year, 12, 31);
 
         return game.date.between(start, end);
     }
 
-    private BooleanExpression isBetweenYearMonth(final QGame game, final int year, final int month) {
+    private BooleanExpression isBetweenYearMonth(final QGame game, final Integer year, final int month) {
+        if (year == null) {
+            return null;
+        }
         YearMonth yearMonth = YearMonth.of(year, month);
         LocalDate start = yearMonth.atDay(1);
         LocalDate end = yearMonth.atEndOfMonth();

--- a/backend/app/src/main/java/com/yagubogu/checkin/repository/CustomCheckInRepositoryImpl.java
+++ b/backend/app/src/main/java/com/yagubogu/checkin/repository/CustomCheckInRepositoryImpl.java
@@ -27,6 +27,7 @@ import com.yagubogu.stadium.domain.QStadium;
 import com.yagubogu.stadium.domain.StadiumLevel;
 import com.yagubogu.stat.dto.AverageStatisticParam;
 import com.yagubogu.stat.dto.OpponentWinRateRowParam;
+import com.yagubogu.stat.dto.StadiumStatsParam;
 import com.yagubogu.team.domain.QTeam;
 import com.yagubogu.team.domain.Team;
 import com.yagubogu.team.domain.TeamStatus;
@@ -59,10 +60,7 @@ public class CustomCheckInRepositoryImpl implements CustomCheckInRepository {
     }
 
     @Override
-    public StatCountsParam findStatCounts(final Member member, final int year) {
-        LocalDate start = LocalDate.of(year, 1, 1);
-        LocalDate end = LocalDate.of(year, 12, 31);
-
+    public StatCountsParam findStatCounts(final Member member, final Integer year) {
         NumberExpression<Integer> winExpr = new CaseBuilder().when(winCondition(CHECK_IN, GAME)).then(1).otherwise(0);
         NumberExpression<Integer> drawExpr = new CaseBuilder().when(drawCondition(CHECK_IN, GAME)).then(1).otherwise(0);
         NumberExpression<Integer> loseExpr = new CaseBuilder().when(loseCondition(CHECK_IN, GAME)).then(1).otherwise(0);
@@ -77,23 +75,23 @@ public class CustomCheckInRepositoryImpl implements CustomCheckInRepository {
                 .join(CHECK_IN.game, CustomCheckInRepositoryImpl.GAME).on(isComplete())
                 .where(
                         CHECK_IN.member.eq(member),
-                        GAME.date.between(start, end),
+                        isBetweenYear(year),
                         isMyCurrentFavorite(member, CHECK_IN)
                 ).fetchOne();
     }
 
     @Override
-    public int findWinCounts(final Member member, final int year) {
+    public int findWinCounts(final Member member, final Integer year) {
         return conditionCount(member, year, winCondition(QCheckIn.checkIn, QGame.game));
     }
 
     @Override
-    public int findLoseCounts(final Member member, final int year) {
+    public int findLoseCounts(final Member member, final Integer year) {
         return conditionCount(member, year, loseCondition(QCheckIn.checkIn, QGame.game));
     }
 
     @Override
-    public int findDrawCounts(final Member member, final int year) {
+    public int findDrawCounts(final Member member, final Integer year) {
         return conditionCount(member, year, drawCondition(QCheckIn.checkIn, QGame.game));
     }
 
@@ -130,7 +128,7 @@ public class CustomCheckInRepositoryImpl implements CustomCheckInRepository {
     }
 
     @Override
-    public int findRecentGamesWinCounts(final Member member, final int year, final int limit) {
+    public int findRecentGamesWinCounts(final Member member, final Integer year, final int limit) {
         return conditionCountOnRecentGames(member, year, winCondition(QCheckIn.checkIn, QGame.game), limit);
     }
 
@@ -162,7 +160,7 @@ public class CustomCheckInRepositoryImpl implements CustomCheckInRepository {
     }
 
     @Override
-    public int findRecentGamesLoseCounts(final Member member, final int year, final int limit) {
+    public int findRecentGamesLoseCounts(final Member member, final Integer year, final int limit) {
         return conditionCountOnRecentGames(member, year, loseCondition(QCheckIn.checkIn, QGame.game), limit);
     }
 
@@ -230,7 +228,7 @@ public class CustomCheckInRepositoryImpl implements CustomCheckInRepository {
 
 
     @Override
-    public int findRecentGamesDrawCounts(final Member member, final int year, final int limit) {
+    public int findRecentGamesDrawCounts(final Member member, final Integer year, final int limit) {
         return conditionCountOnRecentGames(member, year, drawCondition(QCheckIn.checkIn, QGame.game), limit);
     }
 
@@ -376,10 +374,11 @@ public class CustomCheckInRepositoryImpl implements CustomCheckInRepository {
                 .groupBy(STADIUM.id, STADIUM.location)
                 .fetch();
     }
+
     public List<OpponentWinRateRowParam> findOpponentWinRates(
             Member member,
             Team team,
-            int year
+            Integer year
     ) {
         QTeam opponentTeam = QTeam.team;
 
@@ -435,12 +434,46 @@ public class CustomCheckInRepositoryImpl implements CustomCheckInRepository {
                 .fetch();
     }
 
-    private int conditionCount(final Member member, final int year, final BooleanExpression condition) {
+    @Override
+    public List<StadiumStatsParam> findWinAndNonDrawCountByStadium(Long memberId, Integer year) {
+        BooleanExpression isMyCurrentTeam = CHECK_IN.team.eq(CHECK_IN.member.team);
+
+        NumberExpression<Integer> winCount = new CaseBuilder()
+                .when(isMyCurrentTeam.and(winCondition(CHECK_IN, GAME)))
+                .then(1)
+                .otherwise(0)
+                .sum();
+
+        NumberExpression<Integer> nonDrawCount = new CaseBuilder()
+                .when(isMyCurrentTeam.and(GAME.homeScore.ne(GAME.awayScore)))
+                .then(1)
+                .otherwise(0)
+                .sum();
+
+        return jpaQueryFactory.select(
+                        Projections.constructor(
+                                StadiumStatsParam.class,
+                                STADIUM.shortName,
+                                winCount,
+                                nonDrawCount
+                        )
+                )
+                .from(CHECK_IN)
+                .join(CHECK_IN.game, GAME)
+                .join(GAME.stadium, STADIUM)
+                .join(CHECK_IN.member, MEMBER)
+                .where(
+                        CHECK_IN.member.id.eq(memberId),
+                        isBetweenYear(year),
+                        isComplete()
+                )
+                .groupBy(STADIUM.id, STADIUM.shortName)
+                .fetch();
+    }
+
+    private int conditionCount(final Member member, final Integer year, final BooleanExpression condition) {
         QCheckIn qCheckIn = QCheckIn.checkIn;
         QGame qGame = QGame.game;
-
-        LocalDate start = LocalDate.of(year, 1, 1);
-        LocalDate end = LocalDate.of(year, 12, 31);
 
         Long result = jpaQueryFactory
                 .select(qCheckIn.id.count())
@@ -448,7 +481,7 @@ public class CustomCheckInRepositoryImpl implements CustomCheckInRepository {
                 .join(qCheckIn.game, qGame)
                 .where(
                         qCheckIn.member.eq(member),
-                        qGame.date.between(start, end),
+                        isBetweenYear(year),
                         qGame.gameState.eq(GameState.COMPLETED),
                         isMyCurrentFavorite(member, CHECK_IN),
                         condition
@@ -517,7 +550,7 @@ public class CustomCheckInRepositoryImpl implements CustomCheckInRepository {
 
     private int conditionCountOnRecentGames(
             final Member member,
-            final int year,
+            final Integer year,
             final BooleanExpression condition,
             final int limit
     ) {
@@ -543,12 +576,9 @@ public class CustomCheckInRepositoryImpl implements CustomCheckInRepository {
         return result == null ? 0 : result.intValue();
     }
 
-    private List<Long> findRecentGameIdsByYear(final Member member, final int year, final int limit) {
+    private List<Long> findRecentGameIdsByYear(final Member member, final Integer year, final int limit) {
         QCheckIn qCheckIn = QCheckIn.checkIn;
         QGame qGame = QGame.game;
-
-        LocalDate start = LocalDate.of(year, 1, 1);
-        LocalDate end = LocalDate.of(year, 12, 31);
 
         return jpaQueryFactory
                 .select(qGame.id)
@@ -556,7 +586,7 @@ public class CustomCheckInRepositoryImpl implements CustomCheckInRepository {
                 .join(qCheckIn.game, qGame)
                 .where(
                         qCheckIn.member.eq(member),
-                        qGame.date.between(start, end),
+                        isBetweenYear(year),
                         qGame.gameState.eq(GameState.COMPLETED)
                 )
                 .orderBy(qCheckIn.id.desc())

--- a/backend/app/src/main/java/com/yagubogu/checkin/service/CheckInService.java
+++ b/backend/app/src/main/java/com/yagubogu/checkin/service/CheckInService.java
@@ -28,7 +28,6 @@ import com.yagubogu.sse.dto.GameWithFanRateParam;
 import com.yagubogu.sse.dto.event.CheckInCreatedEvent;
 import com.yagubogu.team.domain.Team;
 import java.time.LocalDate;
-import java.time.YearMonth;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -94,7 +93,7 @@ public class CheckInService {
 
     public CheckInHistoryResponse findCheckInHistory(
             final long memberId,
-            final int year,
+            final Integer year,
             final Integer month,
             final CheckInResultFilter resultFilter,
             final CheckInOrderFilter orderFilter
@@ -114,7 +113,7 @@ public class CheckInService {
     }
 
 
-    public StadiumCheckInCountsResponse findStadiumCheckInCounts(final long memberId, final int year) {
+    public StadiumCheckInCountsResponse findStadiumCheckInCounts(final long memberId, final Integer year) {
         Member member = getMember(memberId);
         List<StadiumCheckInCountParam> stadiumCheckInCounts = checkInRepository.findStadiumCheckInCounts(member,
                 year);

--- a/backend/app/src/main/java/com/yagubogu/stat/controller/v1/StatController.java
+++ b/backend/app/src/main/java/com/yagubogu/stat/controller/v1/StatController.java
@@ -25,7 +25,7 @@ public class StatController implements StatControllerInterface {
 
     public ResponseEntity<StatCountsResponse> findStatCounts(
             final MemberClaims memberClaims,
-            @RequestParam final int year
+            @RequestParam(required = false) final Integer year
     ) {
         StatCountsResponse response = statService.findStatCounts(memberClaims.id(), year);
 
@@ -34,7 +34,7 @@ public class StatController implements StatControllerInterface {
 
     public ResponseEntity<WinRateResponse> findWinRate(
             final MemberClaims memberClaims,
-            @RequestParam final int year
+            @RequestParam(required = false) final Integer year
     ) {
         WinRateResponse response = statService.findWinRate(memberClaims.id(), year);
 
@@ -43,7 +43,7 @@ public class StatController implements StatControllerInterface {
 
     public ResponseEntity<RecentGamesWinRateResponse> findRecentTenGamesWinRate(
             final MemberClaims memberClaims,
-            @RequestParam final int year
+            @RequestParam(required = false) final Integer year
     ) {
         RecentGamesWinRateResponse response = statService.findRecentTenGamesWinRate(memberClaims.id(), year);
 
@@ -52,7 +52,7 @@ public class StatController implements StatControllerInterface {
 
     public ResponseEntity<LuckyStadiumResponse> findLuckyStadiums(
             final MemberClaims memberClaims,
-            @RequestParam final int year
+            @RequestParam(required = false) final Integer year
     ) {
         LuckyStadiumResponse response = statService.findLuckyStadium(memberClaims.id(), year);
 
@@ -70,7 +70,7 @@ public class StatController implements StatControllerInterface {
 
     public ResponseEntity<OpponentWinRateResponse> findOpponentWinRate(
             final MemberClaims memberClaims,
-            @RequestParam final int year
+            @RequestParam(required = false) final Integer year
     ) {
         OpponentWinRateResponse response = statService.findOpponentWinRate(memberClaims.id(), year);
 

--- a/backend/app/src/main/java/com/yagubogu/stat/controller/v1/StatControllerInterface.java
+++ b/backend/app/src/main/java/com/yagubogu/stat/controller/v1/StatControllerInterface.java
@@ -32,7 +32,7 @@ public interface StatControllerInterface {
     @GetMapping("/counts")
     ResponseEntity<StatCountsResponse> findStatCounts(
             @Parameter(hidden = true) MemberClaims memberClaims,
-            @RequestParam int year
+            @RequestParam(required = false) Integer year
     );
 
     @Operation(summary = "내 팀 인증 승률 조회", description = "내 팀의 해당 연도 인증 승률을 조회합니다.")
@@ -44,7 +44,7 @@ public interface StatControllerInterface {
     @GetMapping("/win-rate")
     ResponseEntity<WinRateResponse> findWinRate(
             @Parameter(hidden = true) MemberClaims memberClaims,
-            @RequestParam int year
+            @RequestParam(required = false) Integer year
     );
 
     @Operation(summary = "내 팀 최근 10경기 인증 승률 조회", description = "내 팀의 최근 10경기 인증 승률을 조회합니다.")
@@ -56,7 +56,7 @@ public interface StatControllerInterface {
     @GetMapping("/win-rate/recent")
     ResponseEntity<RecentGamesWinRateResponse> findRecentTenGamesWinRate(
             @Parameter(hidden = true) MemberClaims memberClaims,
-            @RequestParam int year
+            @RequestParam(required = false) Integer year
     );
 
     @Operation(summary = "행운의 야구장 조회", description = "해당 연도에서 승률이 가장 높은 야구장을 조회합니다.")
@@ -68,7 +68,7 @@ public interface StatControllerInterface {
     @GetMapping("/lucky-stadiums")
     ResponseEntity<LuckyStadiumResponse> findLuckyStadiums(
             @Parameter(hidden = true) MemberClaims memberClaims,
-            @RequestParam int year
+            @RequestParam(required = false) Integer year
     );
 
     @Operation(summary = "평균 득, 실, 안타, 피안타, 실책 조회", description = "멤버의 전체 경기의 평균 통계 정보를 조회합니다.")
@@ -79,7 +79,7 @@ public interface StatControllerInterface {
     @GetMapping("/me")
     ResponseEntity<AverageStatisticResponse> findAverageStatistic(
             @Parameter(hidden = true) MemberClaims memberClaims,
-            @RequestParam final Integer year
+            @RequestParam(required = false) final Integer year
     );
 
     @Operation(summary = "상대 팀별 승률 조회", description = "상대 팀별 승률 정보 및 전적 정보를 조회합니다.")
@@ -90,7 +90,7 @@ public interface StatControllerInterface {
     @GetMapping("/win-rate/opponents")
     ResponseEntity<OpponentWinRateResponse> findOpponentWinRate(
             @Parameter(hidden = true) MemberClaims memberClaim,
-            @RequestParam final int year
+            @RequestParam(required = false) final Integer year
     );
 
     @Operation(summary = "승리 요정 랭킹 조회", description = "전체 유저 중 상위 승리 요정을 조회합니다.")

--- a/backend/app/src/main/java/com/yagubogu/stat/dto/StadiumStatsParam.java
+++ b/backend/app/src/main/java/com/yagubogu/stat/dto/StadiumStatsParam.java
@@ -2,7 +2,7 @@ package com.yagubogu.stat.dto;
 
 public record StadiumStatsParam(
         String stadiumName,
-        long winCounts,
-        long totalCountsWithoutDraw
+        int winCounts,
+        int totalCountsWithoutDraw
 ) {
 }

--- a/backend/app/src/main/java/com/yagubogu/stat/repository/VictoryFairyRankingRepository.java
+++ b/backend/app/src/main/java/com/yagubogu/stat/repository/VictoryFairyRankingRepository.java
@@ -78,7 +78,7 @@ public interface VictoryFairyRankingRepository extends JpaRepository<VictoryFair
                 JOIN
                     teams t ON t.team_id = m.team_id
                 WHERE
-                    vfr.game_year = :gameYear
+                    (:gameYear IS NULL OR vfr.game_year = :gameYear)
                     AND m.deleted_at IS NULL
                     AND m.team_id IS NOT NULL
                     AND (:#{#teamFilter.name()} = 'ALL' OR t.team_code = :#{#teamFilter.name()})
@@ -91,6 +91,6 @@ public interface VictoryFairyRankingRepository extends JpaRepository<VictoryFair
     List<VictoryFairyRankParam> findTopRankingByTeamFilterAndYear(
             @Param("teamFilter") TeamFilter teamFilter,
             @Param("limit") int limit,
-            @Param("gameYear") int gameYear
+            @Param("gameYear") Integer gameYear
     );
 }

--- a/backend/app/src/main/java/com/yagubogu/stat/repository/VictoryFairyRankingRepositoryCustom.java
+++ b/backend/app/src/main/java/com/yagubogu/stat/repository/VictoryFairyRankingRepositoryCustom.java
@@ -10,9 +10,10 @@ import java.util.Optional;
 
 public interface VictoryFairyRankingRepositoryCustom {
 
-    Optional<VictoryFairyRankParam> findByMemberAndTeamFilterAndYear(Member member, TeamFilter teamFilter, int year);
+    Optional<VictoryFairyRankParam> findByMemberAndTeamFilterAndYear(Member member, TeamFilter teamFilter,
+                                                                     Integer year);
 
-    Optional<Long> findRankWithinTeamByMemberAndYear(Member member, int year);
+    Optional<Long> findRankWithinTeamByMemberAndYear(Member member, Integer year);
 
     void batchUpdate(List<UpdateDto> updates, int batchSize);
 

--- a/backend/app/src/main/java/com/yagubogu/stat/repository/VictoryFairyRankingRepositoryImpl.java
+++ b/backend/app/src/main/java/com/yagubogu/stat/repository/VictoryFairyRankingRepositoryImpl.java
@@ -32,7 +32,7 @@ public class VictoryFairyRankingRepositoryImpl implements VictoryFairyRankingRep
     public Optional<VictoryFairyRankParam> findByMemberAndTeamFilterAndYear(
             final Member member,
             final TeamFilter teamFilter,
-            final int year
+            final Integer year
     ) {
         QVictoryFairyRanking V2 = new QVictoryFairyRanking("v2");
         QMember M2 = new QMember("m2");
@@ -63,7 +63,7 @@ public class VictoryFairyRankingRepositoryImpl implements VictoryFairyRankingRep
                 .join(VICTORY_FAIRY_RANKING.member, MEMBER)
                 .join(MEMBER.team, TEAM)
                 .where(
-                        VICTORY_FAIRY_RANKING.gameYear.eq(year),
+                        filterByYear(VICTORY_FAIRY_RANKING, year),
                         VICTORY_FAIRY_RANKING.member.eq(member),
                         filterByTeam(teamFilter, TEAM)
                 )
@@ -116,7 +116,7 @@ public class VictoryFairyRankingRepositoryImpl implements VictoryFairyRankingRep
     }
 
     @Override
-    public Optional<Long> findRankWithinTeamByMemberAndYear(final Member member, final int year) {
+    public Optional<Long> findRankWithinTeamByMemberAndYear(final Member member, final Integer year) {
         // 1. 멤버에게 응원팀이 없으면 랭킹 계산 불가
         if (member.getTeam() == null) {
             return Optional.empty();
@@ -128,7 +128,7 @@ public class VictoryFairyRankingRepositoryImpl implements VictoryFairyRankingRep
                 .from(VICTORY_FAIRY_RANKING)
                 .where(
                         VICTORY_FAIRY_RANKING.member.eq(member),
-                        VICTORY_FAIRY_RANKING.gameYear.eq(year)
+                        filterByYear(VICTORY_FAIRY_RANKING, year)
                 )
                 .fetchOne();
 
@@ -148,7 +148,7 @@ public class VictoryFairyRankingRepositoryImpl implements VictoryFairyRankingRep
                 .join(ranking.member, qMember)
                 .where(
                         qMember.team.eq(member.getTeam()),
-                        ranking.gameYear.eq(year),
+                        filterByYear(ranking, year),
                         ranking.score.gt(memberScore)
                 )
                 .fetchOne()).orElse(0L);
@@ -164,5 +164,12 @@ public class VictoryFairyRankingRepositoryImpl implements VictoryFairyRankingRep
         }
 
         return team.teamCode.eq(teamFilter.name());
+    }
+
+    private BooleanExpression filterByYear(final QVictoryFairyRanking victoryFairyRanking, final Integer year) {
+        if (year == null) {
+            return null;
+        }
+        return victoryFairyRanking.gameYear.eq(year);
     }
 }

--- a/backend/app/src/main/java/com/yagubogu/stat/service/StatService.java
+++ b/backend/app/src/main/java/com/yagubogu/stat/service/StatService.java
@@ -51,7 +51,7 @@ public class StatService {
     private final MemberRepository memberRepository;
     private final VictoryFairyRankingRepository victoryFairyRankingRepository;
 
-    public StatCountsResponse findStatCounts(final long memberId, final int year) {
+    public StatCountsResponse findStatCounts(final long memberId, final Integer year) {
         Member member = getMember(memberId);
         validateUser(member);
 
@@ -67,7 +67,7 @@ public class StatService {
         );
     }
 
-    public WinRateResponse findWinRate(final long memberId, final int year) {
+    public WinRateResponse findWinRate(final long memberId, final Integer year) {
         Member member = getMember(memberId);
         validateUser(member);
 
@@ -78,7 +78,7 @@ public class StatService {
         return new WinRateResponse(calculateWinRate(winCounts, favoriteCheckInCounts));
     }
 
-    public RecentGamesWinRateResponse findRecentTenGamesWinRate(final Long memberId, final int year) {
+    public RecentGamesWinRateResponse findRecentTenGamesWinRate(final Long memberId, final Integer year) {
         Member member = getMember(memberId);
         validateUser(member);
 
@@ -89,14 +89,13 @@ public class StatService {
         return new RecentGamesWinRateResponse(calculateWinRate(recentWinCounts, recentCounts));
     }
 
-    public LuckyStadiumResponse findLuckyStadium(final long memberId, final int year) {
+    public LuckyStadiumResponse findLuckyStadium(final long memberId, final Integer year) {
         Member member = getMember(memberId);
         validateUser(member);
 
         List<StadiumStatsParam> stadiumStats = checkInRepository.findWinAndNonDrawCountByStadium(
                 memberId,
-                LocalDate.of(year, 1, 1),
-                LocalDate.of(year, 12, 31)
+                year
         );
         String luckyStadiumName = getLuckyStadiumName(stadiumStats);
 
@@ -110,7 +109,7 @@ public class StatService {
         return AverageStatisticResponse.from(averageStatisticParam);
     }
 
-    public OpponentWinRateResponse findOpponentWinRate(final Long memberId, final int year) {
+    public OpponentWinRateResponse findOpponentWinRate(final Long memberId, final Integer year) {
         Member member = getMember(memberId);
         validateUser(member);
         Team team = member.getTeam();
@@ -162,9 +161,6 @@ public class StatService {
             final TeamFilter teamFilter,
             Integer year
     ) {
-        if (year == null) {
-            year = LocalDate.now().getYear();
-        }
         Member member = getMember(memberId);
         List<VictoryFairyRankingParam> topRankingResponses = findTopVictoryRanking(teamFilter, year);
 
@@ -182,7 +178,7 @@ public class StatService {
 
     private List<VictoryFairyRankingParam> findTopVictoryRanking(
             final TeamFilter teamFilter,
-            final int year
+            final Integer year
     ) {
         List<VictoryFairyRankParam> victoryFairyRankings = victoryFairyRankingRepository.findTopRankingByTeamFilterAndYear(
                 teamFilter,

--- a/backend/app/src/test/java/com/yagubogu/checkin/CheckInE2eTest.java
+++ b/backend/app/src/test/java/com/yagubogu/checkin/CheckInE2eTest.java
@@ -32,7 +32,6 @@ import io.restassured.http.ContentType;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import java.time.LocalDate;
-import java.time.YearMonth;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -590,5 +589,119 @@ public class CheckInE2eTest extends E2eTestBase {
             Member member = memberFactory.save(b -> b.team(team));
             checkInFactory.save(b -> b.member(member).team(team).game(game));
         }
+    }
+
+    @DisplayName("year가 주어지지 않으면 전체 기간의 구장별 방문 횟수를 조회한다")
+    @Test
+    void findStadiumCheckInCounts_withoutYear() {
+        // given
+        Member member = memberFactory.save(MemberBuilder::build);
+        String accessToken = authFactory.getAccessTokenByMemberId(member.getId(), Role.USER);
+
+        // 2024년: 잠실 1회
+        Game game2024 = gameFactory.save(builder -> builder
+                .date(LocalDate.of(2024, 7, 10))
+                .stadium(stadiumJamsil)
+                .homeTeam(samsung)
+                .awayTeam(doosan));
+        checkInFactory.save(builder -> builder.game(game2024).member(member).team(samsung));
+
+        // 2025년: 잠실 1회, 고척 1회
+        Game game2025Jamsil = gameFactory.save(builder -> builder
+                .date(LocalDate.of(2025, 7, 20))
+                .stadium(stadiumJamsil)
+                .homeTeam(samsung)
+                .awayTeam(doosan));
+        Game game2025Gocheok = gameFactory.save(builder -> builder
+                .date(LocalDate.of(2025, 7, 21))
+                .stadium(stadiumGocheok)
+                .homeTeam(kia)
+                .awayTeam(kt));
+        checkInFactory.save(builder -> builder.game(game2025Jamsil).member(member).team(samsung));
+        checkInFactory.save(builder -> builder.game(game2025Gocheok).member(member).team(kia));
+
+        StadiumCheckInCountsResponse expected = new StadiumCheckInCountsResponse(
+                List.of(
+                        new StadiumCheckInCountParam(1L, "광주", 0L),
+                        new StadiumCheckInCountParam(2L, "잠실", 2L), // 2024년 1회 + 2025년 1회
+                        new StadiumCheckInCountParam(3L, "고척", 1L), // 2025년 1회
+                        new StadiumCheckInCountParam(4L, "수원", 0L),
+                        new StadiumCheckInCountParam(5L, "대구", 0L),
+                        new StadiumCheckInCountParam(6L, "사직", 0L),
+                        new StadiumCheckInCountParam(7L, "문학", 0L),
+                        new StadiumCheckInCountParam(8L, "창원", 0L),
+                        new StadiumCheckInCountParam(9L, "대전", 0L)));
+
+        // when: year 파라미터 없이 요청
+        StadiumCheckInCountsResponse actual = RestAssured.given().log().all()
+                .contentType(ContentType.JSON)
+                .header(HttpHeaders.AUTHORIZATION, accessToken)
+                .when().get("/api/v1/check-ins/stadiums/counts")
+                .then().log().all()
+                .statusCode(200)
+                .extract()
+                .as(StadiumCheckInCountsResponse.class);
+
+        // then: 전체 기간 집계 확인
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @DisplayName("year가 주어지지 않으면 전체 기간의 직관 내역을 조회한다")
+    @Test
+    void findCheckInHistory_withoutYear() {
+        // given
+        Member fora = memberFactory.save(b -> b.team(kia));
+        String accessToken = authFactory.getAccessTokenByMemberId(fora.getId(), Role.USER);
+
+        // 2024년 경기
+        Game game2024_1 = gameFactory.save(builder -> builder.stadium(stadiumJamsil)
+                .date(LocalDate.of(2024, 6, 15))
+                .gameState(GameState.COMPLETED)
+                .homeTeam(kt).homeScore(10).homeScoreBoard(TestFixture.getHomeScoreBoard())
+                .awayTeam(kia).awayScore(1).awayScoreBoard(TestFixture.getAwayScoreBoard()));
+        Game game2024_2 = gameFactory.save(builder -> builder.stadium(stadiumJamsil)
+                .date(LocalDate.of(2024, 7, 25))
+                .gameState(GameState.COMPLETED)
+                .homeTeam(kt).homeScore(10).homeScoreBoard(TestFixture.getHomeScoreBoard())
+                .awayTeam(kia).awayScore(1).awayScoreBoard(TestFixture.getAwayScoreBoard()));
+
+        checkInFactory.save(b -> b.game(game2024_1).team(kia).member(fora));
+        checkInFactory.save(b -> b.game(game2024_2).team(kia).member(fora));
+
+        // 2025년 경기
+        Game game2025_1 = gameFactory.save(builder -> builder.stadium(stadiumJamsil)
+                .date(LocalDate.of(2025, 6, 10))
+                .gameState(GameState.COMPLETED)
+                .homeTeam(kt).homeScore(10).homeScoreBoard(TestFixture.getHomeScoreBoard())
+                .awayTeam(kia).awayScore(1).awayScoreBoard(TestFixture.getAwayScoreBoard()));
+        Game game2025_2 = gameFactory.save(builder -> builder.stadium(stadiumJamsil)
+                .date(LocalDate.of(2025, 7, 15))
+                .gameState(GameState.COMPLETED)
+                .homeTeam(kt).homeScore(10).homeScoreBoard(TestFixture.getHomeScoreBoard())
+                .awayTeam(kia).awayScore(1).awayScoreBoard(TestFixture.getAwayScoreBoard()));
+        Game game2025_3 = gameFactory.save(builder -> builder.stadium(stadiumJamsil)
+                .date(LocalDate.of(2025, 8, 5))
+                .gameState(GameState.COMPLETED)
+                .homeTeam(kt).homeScore(10).homeScoreBoard(TestFixture.getHomeScoreBoard())
+                .awayTeam(kia).awayScore(1).awayScoreBoard(TestFixture.getAwayScoreBoard()));
+
+        checkInFactory.save(b -> b.game(game2025_1).team(kia).member(fora));
+        checkInFactory.save(b -> b.game(game2025_2).team(kia).member(fora));
+        checkInFactory.save(b -> b.game(game2025_3).team(kia).member(fora));
+
+        // when: year 파라미터 없이 요청
+        ExtractableResponse<Response> response = RestAssured.given().log().all()
+                .contentType(ContentType.JSON)
+                .header(HttpHeaders.AUTHORIZATION, accessToken)
+                .queryParam("result", CheckInResultFilter.ALL)
+                .queryParam("order", CheckInOrderFilter.LATEST)
+                .when().get("/api/v1/check-ins/members")
+                .then().log().all()
+                .statusCode(200)
+                .extract();
+
+        // then: 전체 기간(5경기) 조회 확인
+        CheckInHistoryResponse result = response.as(CheckInHistoryResponse.class);
+        assertThat(result.checkInHistory()).hasSize(5);
     }
 }

--- a/backend/app/src/test/java/com/yagubogu/stat/StatE2eTest.java
+++ b/backend/app/src/test/java/com/yagubogu/stat/StatE2eTest.java
@@ -18,6 +18,7 @@ import com.yagubogu.stat.dto.OpponentWinRateTeamParam;
 import com.yagubogu.stat.dto.v1.AverageStatisticResponse;
 import com.yagubogu.stat.dto.v1.LuckyStadiumResponse;
 import com.yagubogu.stat.dto.v1.OpponentWinRateResponse;
+import com.yagubogu.stat.dto.v1.RecentGamesWinRateResponse;
 import com.yagubogu.stat.dto.v1.StatCountsResponse;
 import com.yagubogu.stat.dto.v1.WinRateResponse;
 import com.yagubogu.support.auth.AuthFactory;
@@ -756,5 +757,423 @@ public class StatE2eTest extends E2eTestBase {
             s.assertThat(ltRes.losses()).isEqualTo(1);
             s.assertThat(ltRes.winRate()).isEqualTo(50.0);
         });
+    }
+
+    @DisplayName("year가 주어지지 않으면 전체 기간의 승패무 횟수를 조회한다")
+    @Test
+    void findStatCounts_withoutYear() {
+        // given
+        Member member = memberFactory.save(b -> b.team(ht));
+        accessToken = authFactory.getAccessTokenByMemberId(member.getId(), Role.USER);
+
+        // 2024년 경기 (2승 1무)
+        Game g1 = gameFactory.save(b -> b.stadium(kia)
+                .homeTeam(ht).awayTeam(lt)
+                .date(LocalDate.of(2024, 5, 10))
+                .homeScore(5).awayScore(3)
+                .gameState(GameState.COMPLETED));
+        Game g2 = gameFactory.save(b -> b.stadium(kia)
+                .homeTeam(ht).awayTeam(ss)
+                .date(LocalDate.of(2024, 5, 11))
+                .homeScore(6).awayScore(2)
+                .gameState(GameState.COMPLETED));
+        Game g3 = gameFactory.save(b -> b.stadium(lot)
+                .homeTeam(lt).awayTeam(ht)
+                .date(LocalDate.of(2024, 5, 12))
+                .homeScore(3).awayScore(3)
+                .gameState(GameState.COMPLETED)); // 무
+
+        checkInFactory.save(b -> b.game(g1).member(member).team(ht));
+        checkInFactory.save(b -> b.game(g2).member(member).team(ht));
+        checkInFactory.save(b -> b.game(g3).member(member).team(ht));
+
+        // 2025년 경기 (2승 1패)
+        Game g4 = gameFactory.save(b -> b.stadium(kia)
+                .homeTeam(ht).awayTeam(lt)
+                .date(LocalDate.of(2025, 7, 10))
+                .homeScore(7).awayScore(4)
+                .gameState(GameState.COMPLETED));
+        Game g5 = gameFactory.save(b -> b.stadium(sam)
+                .homeTeam(ss).awayTeam(ht)
+                .date(LocalDate.of(2025, 7, 11))
+                .homeScore(2).awayScore(5)
+                .gameState(GameState.COMPLETED));
+        Game g6 = gameFactory.save(b -> b.stadium(lot)
+                .homeTeam(lt).awayTeam(ht)
+                .date(LocalDate.of(2025, 7, 12))
+                .homeScore(8).awayScore(3)
+                .gameState(GameState.COMPLETED)); // 패
+
+        checkInFactory.save(b -> b.game(g4).member(member).team(ht));
+        checkInFactory.save(b -> b.game(g5).member(member).team(ht));
+        checkInFactory.save(b -> b.game(g6).member(member).team(ht));
+
+        // when: year 파라미터 없이 요청
+        StatCountsResponse actual = RestAssured.given().log().all()
+                .contentType(ContentType.JSON)
+                .header(HttpHeaders.AUTHORIZATION, accessToken)
+                .when().get("/api/v1/stats/counts")
+                .then().log().all()
+                .statusCode(200)
+                .extract()
+                .as(StatCountsResponse.class);
+
+        // then: 2024년(2승 0패 1무) + 2025년(2승 1패 0무) = 4승 1패 1무, 총 6경기
+        assertThat(actual).isEqualTo(new StatCountsResponse(4, 1, 1, 6));
+    }
+
+    @DisplayName("year가 주어지지 않으면 전체 기간의 직관 승률을 조회한다")
+    @Test
+    void findWinRate_withoutYear() {
+        // given
+        Member member = memberFactory.save(b -> b.team(ht));
+        accessToken = authFactory.getAccessTokenByMemberId(member.getId(), Role.USER);
+
+        // 2024년 경기 (2승 1패)
+        Game g1 = gameFactory.save(b -> b.stadium(kia)
+                .homeTeam(ht).awayTeam(lt)
+                .date(LocalDate.of(2024, 6, 10))
+                .homeScore(5).awayScore(3)
+                .gameState(GameState.COMPLETED));
+        Game g2 = gameFactory.save(b -> b.stadium(kia)
+                .homeTeam(ht).awayTeam(ss)
+                .date(LocalDate.of(2024, 6, 11))
+                .homeScore(6).awayScore(2)
+                .gameState(GameState.COMPLETED));
+        Game g3 = gameFactory.save(b -> b.stadium(lot)
+                .homeTeam(lt).awayTeam(ht)
+                .date(LocalDate.of(2024, 6, 12))
+                .homeScore(7).awayScore(3)
+                .gameState(GameState.COMPLETED)); // 패
+
+        checkInFactory.save(b -> b.game(g1).member(member).team(ht));
+        checkInFactory.save(b -> b.game(g2).member(member).team(ht));
+        checkInFactory.save(b -> b.game(g3).member(member).team(ht));
+
+        // 2025년 경기 (3승)
+        Game g4 = gameFactory.save(b -> b.stadium(kia)
+                .homeTeam(ht).awayTeam(lt)
+                .date(LocalDate.of(2025, 7, 10))
+                .homeScore(8).awayScore(4)
+                .gameState(GameState.COMPLETED));
+        Game g5 = gameFactory.save(b -> b.stadium(sam)
+                .homeTeam(ss).awayTeam(ht)
+                .date(LocalDate.of(2025, 7, 11))
+                .homeScore(3).awayScore(6)
+                .gameState(GameState.COMPLETED));
+        Game g6 = gameFactory.save(b -> b.stadium(kia)
+                .homeTeam(ht).awayTeam(lt)
+                .date(LocalDate.of(2025, 7, 12))
+                .homeScore(7).awayScore(5)
+                .gameState(GameState.COMPLETED));
+
+        checkInFactory.save(b -> b.game(g4).member(member).team(ht));
+        checkInFactory.save(b -> b.game(g5).member(member).team(ht));
+        checkInFactory.save(b -> b.game(g6).member(member).team(ht));
+
+        // when: year 파라미터 없이 요청
+        WinRateResponse actual = RestAssured.given().log().all()
+                .contentType(ContentType.JSON)
+                .header(HttpHeaders.AUTHORIZATION, accessToken)
+                .when().get("/api/v1/stats/win-rate")
+                .then().log().all()
+                .statusCode(200)
+                .extract()
+                .as(WinRateResponse.class);
+
+        // then: 총 5승 1패 = 83.3%
+        assertThat(actual).isEqualTo(new WinRateResponse(83.3));
+    }
+
+    @DisplayName("year가 주어지지 않으면 전체 기간의 행운의 구장을 조회한다")
+    @Test
+    void findLuckyStadium_withoutYear() {
+        // given
+        Member member = memberFactory.save(b -> b.team(ht));
+        accessToken = authFactory.getAccessTokenByMemberId(member.getId(), Role.USER);
+
+        // 2024년: 챔피언스필드 2승
+        Game g1 = gameFactory.save(b -> b.stadium(kia)
+                .homeTeam(ht).awayTeam(lt)
+                .date(LocalDate.of(2024, 5, 15))
+                .homeScore(6).awayScore(3)
+                .gameState(GameState.COMPLETED));
+        checkInFactory.save(b -> b.game(g1).member(member).team(ht));
+        Game g2 = gameFactory.save(b -> b.stadium(kia)
+                .homeTeam(ht).awayTeam(lt)
+                .date(LocalDate.of(2024, 5, 16))
+                .homeScore(6).awayScore(3)
+                .gameState(GameState.COMPLETED));
+        checkInFactory.save(b -> b.game(g1).member(member).team(ht));
+
+        // 2025년: 챔피언스필드 1승, 사직구장 2승
+        Game g3 = gameFactory.save(b -> b.stadium(kia)
+                .homeTeam(ht).awayTeam(ss)
+                .date(LocalDate.of(2025, 7, 10))
+                .homeScore(5).awayScore(2)
+                .gameState(GameState.COMPLETED));
+        Game g4 = gameFactory.save(b -> b.stadium(lot)
+                .homeTeam(ht).awayTeam(lt)
+                .date(LocalDate.of(2025, 7, 11))
+                .homeScore(7).awayScore(4)
+                .gameState(GameState.COMPLETED));
+        Game g5 = gameFactory.save(b -> b.stadium(lot)
+                .homeTeam(lt).awayTeam(ht)
+                .date(LocalDate.of(2025, 7, 12))
+                .homeScore(3).awayScore(6)
+                .gameState(GameState.COMPLETED));
+
+        checkInFactory.save(b -> b.game(g2).member(member).team(ht));
+        checkInFactory.save(b -> b.game(g3).member(member).team(ht));
+        checkInFactory.save(b -> b.game(g4).member(member).team(ht));
+
+        // when: year 파라미터 없이 요청
+        LuckyStadiumResponse actual = RestAssured.given().log().all()
+                .contentType(ContentType.JSON)
+                .header(HttpHeaders.AUTHORIZATION, accessToken)
+                .when().get("/api/v1/stats/lucky-stadiums")
+                .then().log().all()
+                .statusCode(200)
+                .extract()
+                .as(LuckyStadiumResponse.class);
+
+        // then
+        assertThat(actual).isEqualTo(new LuckyStadiumResponse("챔피언스필드"));
+    }
+
+    @DisplayName("year가 주어지지 않으면 전체 기간의 평균 통계를 조회한다")
+    @Test
+    void findAverageStatistic_withoutYear() {
+        // given
+        Member member = memberFactory.save(b -> b.team(ht));
+        accessToken = authFactory.getAccessTokenByMemberId(member.getId(), Role.USER);
+
+        // 2024년 경기
+        Game g1 = gameFactory.save(b -> b.stadium(kia)
+                .homeTeam(ht).awayTeam(lt)
+                .date(LocalDate.of(2024, 5, 10))
+                .homeScore(6).awayScore(4)
+                .homeScoreBoard(new ScoreBoard(6, 10, 1, 0,
+                        List.of("0", "1", "2", "0", "0", "2", "0", "0", "0", "-", "-", "-")))
+                .awayScoreBoard(new ScoreBoard(4, 8, 0, 0,
+                        List.of("0", "1", "2", "0", "0", "2", "0", "0", "0", "-", "-", "-")))
+                .gameState(GameState.COMPLETED));
+        Game g2 = gameFactory.save(b -> b.stadium(kia)
+                .homeTeam(lt).awayTeam(ht)
+                .date(LocalDate.of(2024, 5, 11))
+                .homeScore(5).awayScore(8)
+                .homeScoreBoard(new ScoreBoard(5, 9, 0, 0,
+                        List.of("0", "1", "2", "0", "0", "2", "0", "0", "0", "-", "-", "-")))
+                .awayScoreBoard(new ScoreBoard(8, 12, 1, 0,
+                        List.of("1", "0", "0", "2", "0", "0", "0", "0", "0", "-", "-", "-")))
+                .gameState(GameState.COMPLETED));
+
+        checkInFactory.save(b -> b.game(g1).member(member).team(ht));
+        checkInFactory.save(b -> b.game(g2).member(member).team(ht));
+
+        // 2025년 경기
+        Game g3 = gameFactory.save(b -> b.stadium(kia)
+                .homeTeam(ht).awayTeam(ss)
+                .date(LocalDate.of(2025, 7, 10))
+                .homeScore(10).awayScore(6)
+                .homeScoreBoard(new ScoreBoard(10, 14, 0, 0,
+                        List.of("2", "1", "2", "0", "0", "2", "0", "0", "0", "-", "-", "-")))
+                .awayScoreBoard(new ScoreBoard(6, 10, 2, 0,
+                        List.of("0", "1", "2", "0", "0", "2", "0", "0", "0", "-", "-", "-")))
+                .gameState(GameState.COMPLETED));
+        Game g4 = gameFactory.save(b -> b.stadium(kia)
+                .homeTeam(ht).awayTeam(lt)
+                .date(LocalDate.of(2025, 7, 11))
+                .homeScore(4).awayScore(3)
+                .homeScoreBoard(new ScoreBoard(4, 8, 1, 0,
+                        List.of("0", "1", "2", "0", "0", "2", "0", "0", "0", "-", "-", "-")))
+                .awayScoreBoard(new ScoreBoard(3, 7, 0, 0,
+                        List.of("0", "1", "2", "0", "0", "2", "0", "0", "0", "-", "-", "-")))
+                .gameState(GameState.COMPLETED));
+
+        checkInFactory.save(b -> b.game(g3).member(member).team(ht));
+        checkInFactory.save(b -> b.game(g4).member(member).team(ht));
+
+        // when: year 파라미터 없이 요청
+        AverageStatisticResponse actual = RestAssured.given().log().all()
+                .contentType(ContentType.JSON)
+                .header(HttpHeaders.AUTHORIZATION, accessToken)
+                .when().get("/api/v1/stats/me")
+                .then().log().all()
+                .statusCode(200)
+                .extract().as(AverageStatisticResponse.class);
+
+        // then: 평균 득점 = (6+8+10+4)/4 = 7.0, 평균 실점 = (4+5+6+3)/4 = 4.5, 평균 실책 =
+        // (1+1+0+1)/4 = 0.75 → 0.8, 평균 안타 = (10+12+14+8)/4 = 11.0, 평균 피안타 =
+        // (8+9+10+7)/4 = 8.5
+        assertThat(actual).isEqualTo(new AverageStatisticResponse(7.0, 4.5, 0.8, 11.0, 8.5));
+    }
+
+    @DisplayName("year가 주어지지 않으면 전체 기간의 상대팀별 승률을 조회한다")
+    @Test
+    void findOpponentWinRate_withoutYear() {
+        // given
+        Member member = memberFactory.save(b -> b.team(ht));
+        accessToken = authFactory.getAccessTokenByMemberId(member.getId(), Role.USER);
+
+        // 2024년: SS와 2승
+        Game g1 = gameFactory.save(b -> b.stadium(kia)
+                .homeTeam(ht).awayTeam(ss)
+                .date(LocalDate.of(2024, 5, 10))
+                .homeScore(5).awayScore(3)
+                .gameState(GameState.COMPLETED));
+        Game g2 = gameFactory.save(b -> b.stadium(sam)
+                .homeTeam(ss).awayTeam(ht)
+                .date(LocalDate.of(2024, 5, 11))
+                .homeScore(2).awayScore(4)
+                .gameState(GameState.COMPLETED));
+
+        checkInFactory.save(b -> b.game(g1).member(member).team(ht));
+        checkInFactory.save(b -> b.game(g2).member(member).team(ht));
+
+        // 2025년: LT와 1승 1패
+        Game g3 = gameFactory.save(b -> b.stadium(kia)
+                .homeTeam(ht).awayTeam(lt)
+                .date(LocalDate.of(2025, 7, 10))
+                .homeScore(6).awayScore(2)
+                .gameState(GameState.COMPLETED));
+        Game g4 = gameFactory.save(b -> b.stadium(lot)
+                .homeTeam(lt).awayTeam(ht)
+                .date(LocalDate.of(2025, 7, 11))
+                .homeScore(7).awayScore(3)
+                .gameState(GameState.COMPLETED));
+
+        checkInFactory.save(b -> b.game(g3).member(member).team(ht));
+        checkInFactory.save(b -> b.game(g4).member(member).team(ht));
+
+        // when
+        OpponentWinRateResponse actual = RestAssured.given().log().all()
+                .contentType(ContentType.JSON)
+                .header(HttpHeaders.AUTHORIZATION, accessToken)
+                .when().get("/api/v1/stats/win-rate/opponents")
+                .then().log().all()
+                .statusCode(200)
+                .extract()
+                .as(OpponentWinRateResponse.class);
+
+        // then
+        assertSoftly(s -> {
+            s.assertThat(actual.opponents()).hasSize(9);
+
+            // SS: 2승 0패 = 100%
+            OpponentWinRateTeamParam ssRes = actual.opponents().stream()
+                    .filter(r -> r.teamCode().equals("SS"))
+                    .findFirst().orElseThrow();
+            s.assertThat(ssRes.wins()).isEqualTo(2);
+            s.assertThat(ssRes.losses()).isEqualTo(0);
+            s.assertThat(ssRes.winRate()).isEqualTo(100.0);
+
+            // LT: 1승 1패 = 50%
+            OpponentWinRateTeamParam ltRes = actual.opponents().stream()
+                    .filter(r -> r.teamCode().equals("LT"))
+                    .findFirst().orElseThrow();
+            s.assertThat(ltRes.wins()).isEqualTo(1);
+            s.assertThat(ltRes.losses()).isEqualTo(1);
+            s.assertThat(ltRes.winRate()).isEqualTo(50.0);
+        });
+    }
+
+    @DisplayName("year가 주어지지 않으면 전체 기간의 최근 10경기 승률을 조회한다")
+    @Test
+    void findRecentTenGamesWinRate_withoutYear() {
+        // given
+        Member member = memberFactory.save(b -> b.team(ht));
+        accessToken = authFactory.getAccessTokenByMemberId(member.getId(), Role.USER);
+
+        // 2024년 경기 (3승 2패)
+        Game g1 = gameFactory.save(b -> b.stadium(kia)
+                .homeTeam(ht).awayTeam(lt)
+                .date(LocalDate.of(2024, 5, 1))
+                .homeScore(5).awayScore(3)
+                .gameState(GameState.COMPLETED));
+        Game g2 = gameFactory.save(b -> b.stadium(kia)
+                .homeTeam(ht).awayTeam(ss)
+                .date(LocalDate.of(2024, 5, 2))
+                .homeScore(6).awayScore(2)
+                .gameState(GameState.COMPLETED));
+        Game g3 = gameFactory.save(b -> b.stadium(lot)
+                .homeTeam(lt).awayTeam(ht)
+                .date(LocalDate.of(2024, 5, 3))
+                .homeScore(7).awayScore(3)
+                .gameState(GameState.COMPLETED)); // 패
+        Game g4 = gameFactory.save(b -> b.stadium(kia)
+                .homeTeam(ht).awayTeam(lt)
+                .date(LocalDate.of(2024, 5, 4))
+                .homeScore(5).awayScore(4)
+                .gameState(GameState.COMPLETED));
+        Game g5 = gameFactory.save(b -> b.stadium(lot)
+                .homeTeam(lt).awayTeam(ht)
+                .date(LocalDate.of(2024, 5, 5))
+                .homeScore(6).awayScore(3)
+                .gameState(GameState.COMPLETED)); // 패
+
+        checkInFactory.save(b -> b.game(g1).member(member).team(ht));
+        checkInFactory.save(b -> b.game(g2).member(member).team(ht));
+        checkInFactory.save(b -> b.game(g3).member(member).team(ht));
+        checkInFactory.save(b -> b.game(g4).member(member).team(ht));
+        checkInFactory.save(b -> b.game(g5).member(member).team(ht));
+
+        // 2025년 경기 (4승 3패) - 최근 10경기에 포함
+        Game g6 = gameFactory.save(b -> b.stadium(kia)
+                .homeTeam(ht).awayTeam(lt)
+                .date(LocalDate.of(2025, 7, 1))
+                .homeScore(5).awayScore(3)
+                .gameState(GameState.COMPLETED));
+        Game g7 = gameFactory.save(b -> b.stadium(kia)
+                .homeTeam(ht).awayTeam(ss)
+                .date(LocalDate.of(2025, 7, 2))
+                .homeScore(6).awayScore(2)
+                .gameState(GameState.COMPLETED));
+        Game g8 = gameFactory.save(b -> b.stadium(lot)
+                .homeTeam(lt).awayTeam(ht)
+                .date(LocalDate.of(2025, 7, 3))
+                .homeScore(7).awayScore(3)
+                .gameState(GameState.COMPLETED)); // 패
+        Game g9 = gameFactory.save(b -> b.stadium(kia)
+                .homeTeam(ht).awayTeam(lt)
+                .date(LocalDate.of(2025, 7, 4))
+                .homeScore(5).awayScore(4)
+                .gameState(GameState.COMPLETED));
+        Game g10 = gameFactory.save(b -> b.stadium(lot)
+                .homeTeam(lt).awayTeam(ht)
+                .date(LocalDate.of(2025, 7, 5))
+                .homeScore(8).awayScore(3)
+                .gameState(GameState.COMPLETED)); // 패
+        Game g11 = gameFactory.save(b -> b.stadium(kia)
+                .homeTeam(ht).awayTeam(ss)
+                .date(LocalDate.of(2025, 7, 6))
+                .homeScore(6).awayScore(2)
+                .gameState(GameState.COMPLETED));
+        Game g12 = gameFactory.save(b -> b.stadium(lot)
+                .homeTeam(lt).awayTeam(ht)
+                .date(LocalDate.of(2025, 7, 7))
+                .homeScore(5).awayScore(3)
+                .gameState(GameState.COMPLETED)); // 패
+
+        checkInFactory.save(b -> b.game(g6).member(member).team(ht));
+        checkInFactory.save(b -> b.game(g7).member(member).team(ht));
+        checkInFactory.save(b -> b.game(g8).member(member).team(ht));
+        checkInFactory.save(b -> b.game(g9).member(member).team(ht));
+        checkInFactory.save(b -> b.game(g10).member(member).team(ht));
+        checkInFactory.save(b -> b.game(g11).member(member).team(ht));
+        checkInFactory.save(b -> b.game(g12).member(member).team(ht));
+
+        // when: year 파라미터 없이 요청
+        RecentGamesWinRateResponse actual = RestAssured.given().log().all()
+                .contentType(ContentType.JSON)
+                .header(HttpHeaders.AUTHORIZATION, accessToken)
+                .when().get("/api/v1/stats/win-rate/recent")
+                .then().log().all()
+                .statusCode(200)
+                .extract()
+                .as(RecentGamesWinRateResponse.class);
+
+        // then: 최근 10경기(g3-g12) 중 5승 5패 = 50.0%
+        assertThat(actual.winRate()).isEqualTo(50.0);
     }
 }

--- a/backend/app/src/test/java/com/yagubogu/stat/StatE2eTest.java
+++ b/backend/app/src/test/java/com/yagubogu/stat/StatE2eTest.java
@@ -904,7 +904,7 @@ public class StatE2eTest extends E2eTestBase {
                 .date(LocalDate.of(2024, 5, 16))
                 .homeScore(6).awayScore(3)
                 .gameState(GameState.COMPLETED));
-        checkInFactory.save(b -> b.game(g1).member(member).team(ht));
+        checkInFactory.save(b -> b.game(g2).member(member).team(ht));
 
         // 2025년: 챔피언스필드 1승, 사직구장 2승
         Game g3 = gameFactory.save(b -> b.stadium(kia)
@@ -923,9 +923,9 @@ public class StatE2eTest extends E2eTestBase {
                 .homeScore(3).awayScore(6)
                 .gameState(GameState.COMPLETED));
 
-        checkInFactory.save(b -> b.game(g2).member(member).team(ht));
         checkInFactory.save(b -> b.game(g3).member(member).team(ht));
         checkInFactory.save(b -> b.game(g4).member(member).team(ht));
+        checkInFactory.save(b -> b.game(g5).member(member).team(ht));
 
         // when: year 파라미터 없이 요청
         LuckyStadiumResponse actual = RestAssured.given().log().all()


### PR DESCRIPTION
## 📌 관련 이슈
- close #850 

## ✨ 변경 내용
- 아래 api들의 year을 required false로 수정하고, year을 입력하지 않는 경우 전체 기간을 조회하도록 수정함
/stats/counts
/stats/win-rate
/stats/win-rate/recent
/stats/lucky-stadiums
/stats/me
/stats/win-rate/opponents
/check-ins/members
/check-ins/stadiums/counts


## 🎸 기타 참고 사항
- 스크린샷, 참고 링크, 추가 설명 등 (없으면 생략 가능)