### PR TITLE
design: 통계 연도 선택 최신순 정렬

### DIFF
--- a/android/app/src/main/java/com/yagubogu/ui/home/component/StadiumFanRate.kt
+++ b/android/app/src/main/java/com/yagubogu/ui/home/component/StadiumFanRate.kt
@@ -179,7 +179,7 @@ private fun RefreshIcon(
                 .graphicsLayer {
                     rotationZ = animatedRotation
                 }.noRippleClickable {
-                    rotation = (rotation + 360f) % 720f
+                    rotation += 360f
                     onRefresh()
                     Firebase.analytics.logEvent("fan_rate_refresh", null)
                 },

--- a/android/app/src/main/java/com/yagubogu/ui/stats/StatsScreen.kt
+++ b/android/app/src/main/java/com/yagubogu/ui/stats/StatsScreen.kt
@@ -210,7 +210,7 @@ private fun StatsYearDropdown(
                     .crop(vertical = 8.dp)
                     .padding(vertical = 4.dp),
         ) {
-            StatsViewModel.YEAR_RANGE.forEach { year: Int ->
+            StatsViewModel.YEAR_RANGE.reversed().forEach { year: Int ->
                 DropdownMenuItem(
                     text = {
                         Text(


### PR DESCRIPTION
## 📌 관련 이슈
- close #872 

## ✨ 변경 내용
통계 연도 선택 드롭다운을 최신순 정렬로 변경했습니다.

<img width="146" height="255" alt="image" src="https://github.com/user-attachments/assets/91e8202d-7253-4fc4-aad3-c9cece1e23ba" />


## 🎸 기타 참고 사항
- 스크린샷, 참고 링크, 추가 설명 등 (없으면 생략 가능)