### PR TITLE
feat: 직관 내역 달력에 오늘 날짜 표시

### DIFF
--- a/mobile/composeApp/src/commonMain/kotlin/com/yagubogu/ui/attendance/AttendanceHistoryScreen.kt
+++ b/mobile/composeApp/src/commonMain/kotlin/com/yagubogu/ui/attendance/AttendanceHistoryScreen.kt
@@ -63,6 +63,7 @@ import kotlinx.datetime.LocalDate
 import kotlinx.datetime.YearMonth
 import kotlinx.datetime.number
 import kotlinx.datetime.onDay
+import kotlinx.datetime.yearMonth
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.viewmodel.koinViewModel
@@ -89,6 +90,7 @@ fun AttendanceHistoryScreen(
 
     val startMonth: YearMonth = AttendanceHistoryViewModel.START_MONTH
     val endMonth: YearMonth = AttendanceHistoryViewModel.END_MONTH
+    val today: LocalDate = LocalDate.now()
 
     var viewType: AttendanceHistoryViewType by rememberSaveable {
         mutableStateOf(AttendanceHistoryViewType.CALENDAR)
@@ -100,7 +102,11 @@ fun AttendanceHistoryScreen(
     }
 
     LaunchedEffect(selectedMonth) {
-        viewModel.updateSelectedDate(selectedMonth.onDay(1))
+        if (selectedMonth == today.yearMonth) {
+            viewModel.updateSelectedDate(today)
+        } else {
+            viewModel.updateSelectedDate(selectedMonth.onDay(1))
+        }
     }
 
     val checkInSuccessMessage: String =

--- a/mobile/composeApp/src/commonMain/kotlin/com/yagubogu/ui/attendance/component/AttendanceCalendar.kt
+++ b/mobile/composeApp/src/commonMain/kotlin/com/yagubogu/ui/attendance/component/AttendanceCalendar.kt
@@ -1,6 +1,7 @@
 package com.yagubogu.ui.attendance.component
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -20,7 +21,6 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import org.jetbrains.compose.resources.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -30,19 +30,24 @@ import com.kizitonwose.calendar.compose.rememberCalendarState
 import com.kizitonwose.calendar.core.CalendarDay
 import com.kizitonwose.calendar.core.DayPosition
 import com.kizitonwose.calendar.core.daysOfWeek
-import com.kizitonwose.calendar.core.now
+import com.kizitonwose.calendar.core.minusDays
 import com.yagubogu.ui.theme.Black
 import com.yagubogu.ui.theme.Gray400
 import com.yagubogu.ui.theme.PretendardRegular
+import com.yagubogu.ui.theme.PretendardRegular16
+import com.yagubogu.ui.theme.Primary050
 import com.yagubogu.ui.theme.Primary500
+import com.yagubogu.ui.theme.Primary700
 import com.yagubogu.ui.theme.White
 import com.yagubogu.ui.theme.dpToSp
 import com.yagubogu.ui.util.getDisplayNameResId
 import com.yagubogu.ui.util.minusMonths
 import com.yagubogu.ui.util.noRippleClickable
+import com.yagubogu.ui.util.now
 import kotlinx.datetime.DayOfWeek
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.YearMonth
+import org.jetbrains.compose.resources.stringResource
 
 @Composable
 fun AttendanceCalendar(
@@ -125,11 +130,29 @@ private fun Day(
     modifier: Modifier = Modifier,
 ) {
     val today: LocalDate = LocalDate.now()
+    val isToday: Boolean = day.date == today
 
     Column(
         modifier =
             modifier
                 .aspectRatio(0.8f)
+                .padding(horizontal = 4.dp)
+                .padding(bottom = 4.dp)
+                .background(
+                    color = when {
+                        isSelected -> Primary050
+                        else -> Color.Transparent
+                    },
+                    shape = RoundedCornerShape(4.dp)
+                )
+                .border(
+                    width = 1.dp,
+                    color = when {
+                        isSelected -> Primary500
+                        else -> Color.Transparent
+                    },
+                    shape = RoundedCornerShape(4.dp)
+                )
                 .noRippleClickable(
                     enabled = day.position == DayPosition.MonthDate && day.date <= today,
                     onClick = { onClick(day) },
@@ -138,10 +161,11 @@ private fun Day(
     ) {
         Text(
             text = day.date.day.toString(),
-            style = PretendardRegular.copy(fontSize = 16.dpToSp),
+            style = PretendardRegular16,
             color =
                 when {
-                    isSelected -> White
+                    isToday -> White
+                    isSelected -> Primary700
                     day.position != DayPosition.MonthDate -> Gray400
                     day.date > today -> Gray400
                     else -> Black
@@ -149,11 +173,16 @@ private fun Day(
             textAlign = TextAlign.Center,
             modifier =
                 Modifier
+                    .padding(top = 2.dp)
                     .size(30.dp)
                     .background(
-                        color = if (isSelected) Primary500 else Color.Transparent,
+                        color = when {
+                            isToday -> Primary500
+                            else -> Color.Transparent
+                        },
                         shape = CircleShape,
-                    ).padding(2.dp)
+                    )
+                    .padding(2.dp)
                     .wrapContentHeight(align = Alignment.CenterVertically),
         )
 
@@ -177,7 +206,7 @@ private fun AttendanceCalendarPreview() {
         endMonth = YearMonth.now(),
         selectedMonth = YearMonth.now(),
         onMonthChange = {},
-        selectedDate = LocalDate.now(),
+        selectedDate = LocalDate.now().minusDays(1),
         onDateChange = {},
         attendanceDates = ATTENDANCE_HISTORY_ITEMS.map { it.summary.attendanceDate }.toSet(),
     )

--- a/mobile/composeApp/src/commonMain/kotlin/com/yagubogu/ui/attendance/component/AttendanceCalendarContent.kt
+++ b/mobile/composeApp/src/commonMain/kotlin/com/yagubogu/ui/attendance/component/AttendanceCalendarContent.kt
@@ -35,6 +35,7 @@ import com.yagubogu.ui.attendance.model.PastGameUiState
 import com.yagubogu.ui.theme.PretendardBold16
 import com.yagubogu.ui.theme.Primary500
 import com.yagubogu.ui.theme.White
+import com.yagubogu.ui.util.minusDays
 import com.yagubogu.ui.util.minusMonths
 import com.yagubogu.ui.util.now
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -112,7 +113,7 @@ fun AttendanceCalendarContent(
                 currentItems.forEach { item: AttendanceHistoryItem ->
                     AttendanceItem(item = item, isExpanded = true)
                 }
-            } else {
+            } else if (selectedDate != LocalDate.now()) {
                 AttendanceAdditionButton(
                     onClick = {
                         onPastGamesRequest(selectedDate)
@@ -185,7 +186,7 @@ private fun AttendanceCalendarContentPreview() {
         endMonth = YearMonth.now(),
         selectedMonth = YearMonth.now(),
         onMonthChange = {},
-        selectedDate = LocalDate.now(),
+        selectedDate = LocalDate.now().minusDays(3),
         onDateChange = {},
         pastGameUiState = PastGameUiState.Loading,
         onPastGamesRequest = {},

--- a/mobile/composeApp/src/commonMain/kotlin/com/yagubogu/ui/attendance/component/AttendanceCalendarContent.kt
+++ b/mobile/composeApp/src/commonMain/kotlin/com/yagubogu/ui/attendance/component/AttendanceCalendarContent.kt
@@ -70,6 +70,7 @@ fun AttendanceCalendarContent(
     val currentItems: List<AttendanceHistoryItem>? = itemsByDate[selectedDate]
     val scrollState: ScrollState = rememberScrollState()
     var showBottomSheet: Boolean by rememberSaveable { mutableStateOf(false) }
+    val isToday: Boolean = selectedDate == LocalDate.now()
 
     LaunchedEffect(Unit) {
         scrollToTopEvent.collect {
@@ -113,7 +114,7 @@ fun AttendanceCalendarContent(
                 currentItems.forEach { item: AttendanceHistoryItem ->
                     AttendanceItem(item = item, isExpanded = true)
                 }
-            } else if (selectedDate != LocalDate.now()) {
+            } else if (!isToday) {
                 AttendanceAdditionButton(
                     onClick = {
                         onPastGamesRequest(selectedDate)
@@ -124,7 +125,7 @@ fun AttendanceCalendarContent(
             }
         }
 
-        if (currentItems != null) {
+        if (currentItems != null && !isToday) {
             SmallFloatingActionButton(
                 onClick = {
                     onPastGamesRequest(selectedDate)
@@ -194,11 +195,18 @@ private fun AttendanceCalendarContentPreview() {
     )
 }
 
-@Preview("빈 캘린더 화면", showBackground = true)
+@Preview("오늘 경기가 있는 캘린더 화면", showBackground = true)
 @Composable
-private fun AttendanceCalendarContentNoItemPreview() {
+private fun AttendanceCalendarContentTodayItemPreview() {
     AttendanceCalendarContent(
-        items = emptyList(),
+        items = listOf(
+            ATTENDANCE_HISTORY_ITEM_PLAYED.copy(
+                summary =
+                    ATTENDANCE_HISTORY_ITEM_PLAYED.summary.copy(
+                        id = 2L,
+                        attendanceDate = LocalDate.now(),
+                    ),
+            )),
         startMonth = YearMonth.now().minusMonths(1),
         endMonth = YearMonth.now(),
         selectedMonth = YearMonth.now(),

--- a/mobile/composeApp/src/commonMain/kotlin/com/yagubogu/ui/attendance/component/Fixture.kt
+++ b/mobile/composeApp/src/commonMain/kotlin/com/yagubogu/ui/attendance/component/Fixture.kt
@@ -16,7 +16,7 @@ val ATTENDANCE_HISTORY_ITEM_PLAYED =
         summary =
             AttendanceHistoryItem.Summary(
                 id = 0L,
-                attendanceDate = LocalDate.now(),
+                attendanceDate = LocalDate.now().minusDays(1),
                 stadiumName = "잠실 야구장",
                 awayTeam =
                     GameTeam(


### PR DESCRIPTION
## 📌 관련 이슈
- close #915 

## ✨ 변경 내용
- 오늘 날짜를 구분하여 표시합니다.
- 현재 달 선택 시 오늘 날짜를 자동으로 선택합니다.
- 오늘 날짜에는 직관 내역 추가가 불가능합니다.

## 🎸 기타 참고 사항
- 스크린샷, 참고 링크, 추가 설명 등 (없으면 생략 가능)


https://github.com/user-attachments/assets/ee8e4bb6-fd91-4ede-8335-932c956a02f4

