### PR TITLE
fix: 이미지를 선택하고 가이드 조정하지 않으면 홀쪽해지는 버그

### DIFF
--- a/mobile/gradle/libs.versions.toml
+++ b/mobile/gradle/libs.versions.toml
@@ -66,7 +66,7 @@ appUpdate = "2.1.0"
 
 # Image Loading
 coilCompose = "3.3.0"
-imagepickerkmp = "1.0.32"
+imagepickerkmp = "1.0.34"
 compressor = "3.0.1"
 
 # UI Components


### PR DESCRIPTION
## 📌 관련 이슈
- close #921 

## ✨ 변경 내용
- ImagePickerKMP 기여하고 버전업 시켜서 프사 홀쭉해지는 버그 정상화함

## 🎸 기타 참고 사항

https://github.com/user-attachments/assets/533e10a7-c99b-4f42-82d1-2fb1961e1540

