### PR TITLE
feat: 상세 통계 화면 shimmer 추가

### DIFF
--- a/mobile/composeApp/src/commonMain/kotlin/com/yagubogu/ui/stats/StatsScreen.kt
+++ b/mobile/composeApp/src/commonMain/kotlin/com/yagubogu/ui/stats/StatsScreen.kt
@@ -87,6 +87,7 @@ fun StatsScreen(
         HorizontalPager(
             state = pagerState,
             modifier = Modifier.fillMaxSize(),
+            beyondViewportPageCount = 1,
         ) { page: Int ->
             when (StatsTab.entries[page]) {
                 StatsTab.MY_STATS -> StatsMyScreen(year, scrollToTopEvent)

--- a/mobile/composeApp/src/commonMain/kotlin/com/yagubogu/ui/stats/StatsViewModel.kt
+++ b/mobile/composeApp/src/commonMain/kotlin/com/yagubogu/ui/stats/StatsViewModel.kt
@@ -65,6 +65,8 @@ class StatsViewModel(
 
     private var attendanceJob: Job? = null
     private var averageStatsJob: Job? = null
+    private var vsTeamStatsJob: Job? = null
+    private var stadiumVisitCountsJob: Job? = null
 
     fun fetchMyStats() {
         fetchMyAttendanceStats()
@@ -80,6 +82,8 @@ class StatsViewModel(
         if(_year.value == year) return
         _statsMyUiModel.value = null
         _averageStats.value = null
+        _vsTeamStatItems.value = emptyList()
+        _stadiumVisitCounts.value = emptyList()
         _year.value = year
     }
 
@@ -148,7 +152,8 @@ class StatsViewModel(
     }
 
     private fun fetchVsTeamStats() {
-        viewModelScope.launch {
+        vsTeamStatsJob?.cancel()
+        vsTeamStatsJob = viewModelScope.launch {
             val year: Int = year.value
             val vsTeamStatsResult: Result<List<VsTeamStatItem>> =
                 statsRepository
@@ -166,7 +171,8 @@ class StatsViewModel(
     }
 
     private fun fetchStadiumVisitCounts() {
-        viewModelScope.launch {
+        stadiumVisitCountsJob?.cancel()
+        stadiumVisitCountsJob = viewModelScope.launch {
             val year: Int = year.value
             val stadiumVisitCountsResult: Result<List<StadiumVisitCount>> =
                 checkInRepository.getStadiumCheckInCounts(year).mapList { it.toUiModel() }

--- a/mobile/composeApp/src/commonMain/kotlin/com/yagubogu/ui/stats/detail/component/StadiumVisitCounts.kt
+++ b/mobile/composeApp/src/commonMain/kotlin/com/yagubogu/ui/stats/detail/component/StadiumVisitCounts.kt
@@ -66,7 +66,7 @@ private fun StadiumVisitCountsShimmer(modifier: Modifier = Modifier) {
                 .fillMaxWidth()
                 .padding(vertical = 2.dp)
                 .height(24.dp)
-                .shimmerLoading(4.dp)
+                .shimmerLoading(8.dp)
         )
     }
 }
@@ -106,4 +106,10 @@ private fun List<StadiumVisitCount>.toBarChartItems(): List<BarChartItemValue> =
 @Composable
 private fun StadiumVisitCountsPreview() {
     StadiumVisitCounts(List(9) { i -> StadiumVisitCount(location = "잠실", visitCounts = 7 - i) })
+}
+
+@Preview
+@Composable
+private fun StadiumVisitCountsEmptyPreview() {
+    StadiumVisitCounts(emptyList())
 }

--- a/mobile/composeApp/src/commonMain/kotlin/com/yagubogu/ui/stats/detail/component/StadiumVisitCounts.kt
+++ b/mobile/composeApp/src/commonMain/kotlin/com/yagubogu/ui/stats/detail/component/StadiumVisitCounts.kt
@@ -2,16 +2,17 @@ package com.yagubogu.ui.stats.detail.component
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import org.jetbrains.compose.resources.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import yagubogu.composeapp.generated.resources.Res
 import com.yagubogu.ui.common.component.chart.AnimatedBarChart
 import com.yagubogu.ui.common.model.BarChartItemValue
 import com.yagubogu.ui.common.model.BarChartLabel.Companion.DefaultBarChartDataLabel
@@ -20,6 +21,9 @@ import com.yagubogu.ui.stats.detail.model.StadiumVisitCount
 import com.yagubogu.ui.theme.PretendardBold20
 import com.yagubogu.ui.theme.Primary500
 import com.yagubogu.ui.theme.White
+import com.yagubogu.ui.util.shimmerLoading
+import org.jetbrains.compose.resources.stringResource
+import yagubogu.composeapp.generated.resources.Res
 import yagubogu.composeapp.generated.resources.all_count
 import yagubogu.composeapp.generated.resources.stats_stadium_visit_count
 
@@ -31,6 +35,7 @@ fun StadiumVisitCounts(
     Column(
         modifier =
             modifier
+                .fillMaxWidth()
                 .background(White, RoundedCornerShape(12.dp))
                 .padding(20.dp),
         verticalArrangement = Arrangement.spacedBy(20.dp),
@@ -40,11 +45,28 @@ fun StadiumVisitCounts(
             style = PretendardBold20,
         )
 
-        AnimatedBarChart(
-            strokeVerticalGap = 16.dp,
-            durationMillis = 700,
-            strokeWidth = 20.dp,
-            items = stadiumVisitCounts.toBarChartItems(),
+        if (stadiumVisitCounts.isEmpty()) {
+            StadiumVisitCountsShimmer()
+        } else {
+            AnimatedBarChart(
+                strokeVerticalGap = 16.dp,
+                durationMillis = 700,
+                strokeWidth = 20.dp,
+                items = stadiumVisitCounts.toBarChartItems(),
+            )
+        }
+    }
+}
+
+@Composable
+private fun StadiumVisitCountsShimmer(modifier: Modifier = Modifier) {
+    repeat(9) {
+        Box(
+            modifier = modifier
+                .fillMaxWidth()
+                .padding(vertical = 2.dp)
+                .height(24.dp)
+                .shimmerLoading(4.dp)
         )
     }
 }

--- a/mobile/composeApp/src/commonMain/kotlin/com/yagubogu/ui/stats/detail/component/VsTeamWinRates.kt
+++ b/mobile/composeApp/src/commonMain/kotlin/com/yagubogu/ui/stats/detail/component/VsTeamWinRates.kt
@@ -140,7 +140,7 @@ private fun VsTeamStatItemShimmer(modifier: Modifier = Modifier) {
                 .fillMaxWidth()
                 .padding(vertical = 8.dp)
                 .height(40.dp)
-                .shimmerLoading(8.dp)
+                .shimmerLoading(12.dp)
         )
     }
 }
@@ -162,6 +162,16 @@ private fun VsTeamWinRatesPreview() {
                     winningPercentage = 77.7,
                 )
             },
+        isVsTeamStatsExpanded = false,
+    )
+}
+
+@Preview
+@Composable
+private fun VsTeamWinRatesEmptyPreview() {
+    VsTeamWinRates(
+        onShowMoreClick = { },
+        vsTeamStatItems = emptyList(),
         isVsTeamStatsExpanded = false,
     )
 }

--- a/mobile/composeApp/src/commonMain/kotlin/com/yagubogu/ui/stats/detail/component/VsTeamWinRates.kt
+++ b/mobile/composeApp/src/commonMain/kotlin/com/yagubogu/ui/stats/detail/component/VsTeamWinRates.kt
@@ -5,8 +5,11 @@ import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.spring
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -14,12 +17,10 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import org.jetbrains.compose.resources.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import yagubogu.composeapp.generated.resources.Res
 import com.yagubogu.domain.model.Team
 import com.yagubogu.ui.common.component.ShowMoreButton
 import com.yagubogu.ui.stats.detail.model.VsTeamStatItem
@@ -32,6 +33,9 @@ import com.yagubogu.ui.theme.PretendardSemiBold
 import com.yagubogu.ui.theme.White
 import com.yagubogu.ui.util.formatOneDecimal
 import com.yagubogu.ui.util.noRippleClickable
+import com.yagubogu.ui.util.shimmerLoading
+import org.jetbrains.compose.resources.stringResource
+import yagubogu.composeapp.generated.resources.Res
 import yagubogu.composeapp.generated.resources.all_win_rate
 import yagubogu.composeapp.generated.resources.stats_vs_team_stats
 import yagubogu.composeapp.generated.resources.stats_vs_team_winning_percentage
@@ -47,6 +51,7 @@ fun VsTeamWinRates(
         verticalArrangement = Arrangement.spacedBy(20.dp),
         modifier =
             modifier
+                .fillMaxWidth()
                 .animateContentSize(
                     animationSpec =
                         spring(
@@ -64,8 +69,12 @@ fun VsTeamWinRates(
             verticalArrangement = Arrangement.spacedBy(4.dp),
             modifier = Modifier.noRippleClickable(onClick = onShowMoreClick),
         ) {
-            vsTeamStatItems.forEach { vsTeamStatItem: VsTeamStatItem ->
-                VsTeamStatItem(vsTeamStatItem = vsTeamStatItem)
+            if (vsTeamStatItems.isEmpty()) {
+                VsTeamStatItemShimmer()
+            } else {
+                vsTeamStatItems.forEach { vsTeamStatItem: VsTeamStatItem ->
+                    VsTeamStatItem(vsTeamStatItem = vsTeamStatItem)
+                }
             }
         }
         ShowMoreButton(
@@ -114,7 +123,25 @@ private fun VsTeamStatItem(
                 color = Gray400,
             )
         }
-        Text(text = stringResource(Res.string.all_win_rate, vsTeamStatItem.winningPercentage.formatOneDecimal()))
+        Text(
+            text = stringResource(
+                Res.string.all_win_rate,
+                vsTeamStatItem.winningPercentage.formatOneDecimal()
+            )
+        )
+    }
+}
+
+@Composable
+private fun VsTeamStatItemShimmer(modifier: Modifier = Modifier) {
+    repeat(5) {
+        Box(
+            modifier = modifier
+                .fillMaxWidth()
+                .padding(vertical = 8.dp)
+                .height(40.dp)
+                .shimmerLoading(8.dp)
+        )
     }
 }
 


### PR DESCRIPTION
## 📌 관련 이슈
- close #923 


## ✨ 변경 내용
- `StatsViewModel`에서 연도 변경 시 상대 팀별 통계 및 구장 방문 횟수 데이터를 초기화하고, 관련 Coroutine Job 취소 로직 추가
- `VsTeamWinRates`, `StadiumVisitCounts` 컴포넌트에 데이터 로딩 중 표시할 Shimmer 효과(스켈레톤 UI) 추가
- `StatsScreen`의 `HorizontalPager`에 `beyondViewportPageCount = 1` **(페이지가 보이기 전에 미리 불러오는) 
설정을 추가하여 페이지 전환 성능 개선**
## 🎸 기타 참고 사항

### Before😱
<img width="321" height="642" alt="image" src="https://github.com/user-attachments/assets/a0d84aeb-bd9d-475b-b68a-0139bed764c1" />

### After😎

[Screen_recording_20260317_124222.webm](https://github.com/user-attachments/assets/4753f9e2-798d-49be-9fae-3026154f9e98)

### 추가) CornerRadius 수정
- 팀별 승률 12dp, 구장 방문 8dp

<img width="321" alt="image" src="https://github.com/user-attachments/assets/65573b67-0761-4790-94b5-8c8d15a2b924" />
