### PR TITLE
fix: 프로필 사진 업로드 화면의 2가지 버그 수정

### DIFF
--- a/mobile/composeApp/src/commonMain/kotlin/com/yagubogu/ui/setting/ProfileImagePicker.kt
+++ b/mobile/composeApp/src/commonMain/kotlin/com/yagubogu/ui/setting/ProfileImagePicker.kt
@@ -1,0 +1,61 @@
+package com.yagubogu.ui.setting
+
+import androidx.compose.runtime.Composable
+import co.touchlab.kermit.Logger
+import com.yagubogu.ui.util.UiText
+import io.github.ismoy.imagepickerkmp.domain.config.CameraCaptureConfig
+import io.github.ismoy.imagepickerkmp.domain.config.CropConfig
+import io.github.ismoy.imagepickerkmp.domain.models.CompressionLevel
+import io.github.ismoy.imagepickerkmp.domain.models.GalleryPhotoResult
+import io.github.ismoy.imagepickerkmp.domain.models.MimeType.Companion.ALL_SUPPORTED_TYPES
+import io.github.ismoy.imagepickerkmp.presentation.ui.components.GalleryPickerLauncher
+import yagubogu.composeapp.generated.resources.Res
+import yagubogu.composeapp.generated.resources.setting_edit_profile_image_selection_failed
+
+@Composable
+fun ProfileImagePicker(
+    onPhotosSelected: (String) -> Unit,
+    onError: (UiText) -> Unit,
+    onClosePicker: () -> Unit,
+) {
+    val logger: Logger = Logger.withTag("ProfileImagePicker")
+    logger.d { "ProfileImagePicker 열림" }
+    GalleryPickerLauncher(
+        allowMultiple = false,
+        mimeTypes = ALL_SUPPORTED_TYPES,
+        onPhotosSelected = { photos: List<GalleryPhotoResult> ->
+            logger.d { "onPhotosSelected, 사진 개수: ${photos.size}" }
+            onClosePicker()
+
+            val photo: GalleryPhotoResult? = photos.firstOrNull()
+            if (photo == null) {
+                logger.w { "선택된 사진이 없습니다" }
+                return@GalleryPickerLauncher
+            }
+            onPhotosSelected(photo.uri)
+            onClosePicker()
+        },
+        onError = { exception: Exception ->
+            logger.e(exception) { "GalleryPicker 에러 발생" }
+            onError(UiText.StringRes(Res.string.setting_edit_profile_image_selection_failed))
+            onClosePicker()
+        },
+        onDismiss = {
+            logger.d { "GalleryPicker 닫힘" }
+            onClosePicker()
+        },
+        enableCrop = true,
+        cameraCaptureConfig =
+            CameraCaptureConfig(
+                compressionLevel = CompressionLevel.HIGH,
+                cropConfig =
+                    CropConfig(
+                        enabled = true,
+                        aspectRatioLocked = true,
+                        circularCrop = true,
+                        squareCrop = false,
+                        freeformCrop = false,
+                    ),
+            ),
+    )
+}

--- a/mobile/composeApp/src/commonMain/kotlin/com/yagubogu/ui/setting/SettingMainScreen.kt
+++ b/mobile/composeApp/src/commonMain/kotlin/com/yagubogu/ui/setting/SettingMainScreen.kt
@@ -29,7 +29,6 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import co.touchlab.kermit.Logger
 import com.yagubogu.BuildKonfig
 import com.yagubogu.ui.common.component.profile.ProfileImage
 import com.yagubogu.ui.common.platform.PlatformType
@@ -48,15 +47,8 @@ import com.yagubogu.ui.theme.PretendardRegular12
 import com.yagubogu.ui.theme.PretendardSemiBold
 import com.yagubogu.ui.theme.White
 import com.yagubogu.ui.util.LocalSnackbarHostState
-import com.yagubogu.ui.util.UiText
 import com.yagubogu.ui.util.showSingleSnackbar
 import com.yagubogu.ui.util.yyyyMMddFormatter
-import io.github.ismoy.imagepickerkmp.domain.config.CameraCaptureConfig
-import io.github.ismoy.imagepickerkmp.domain.config.CropConfig
-import io.github.ismoy.imagepickerkmp.domain.models.CompressionLevel
-import io.github.ismoy.imagepickerkmp.domain.models.GalleryPhotoResult
-import io.github.ismoy.imagepickerkmp.domain.models.MimeType.Companion.ALL_SUPPORTED_TYPES
-import io.github.ismoy.imagepickerkmp.presentation.ui.components.GalleryPickerLauncher
 import kotlinx.datetime.format
 import org.jetbrains.compose.resources.getString
 import org.jetbrains.compose.resources.stringResource
@@ -66,7 +58,6 @@ import yagubogu.composeapp.generated.resources.setting_contact_us
 import yagubogu.composeapp.generated.resources.setting_edit_my_team
 import yagubogu.composeapp.generated.resources.setting_edit_nickname
 import yagubogu.composeapp.generated.resources.setting_edit_profile_image
-import yagubogu.composeapp.generated.resources.setting_edit_profile_image_selection_failed
 import yagubogu.composeapp.generated.resources.setting_edited_nickname_alert
 import yagubogu.composeapp.generated.resources.setting_main_sign_up_date
 import yagubogu.composeapp.generated.resources.setting_manage_account
@@ -145,54 +136,6 @@ fun SettingMainScreen(
             onCancel = { showNicknameEditDialog = false },
         )
     }
-}
-
-@Composable
-fun ProfileImagePicker(
-    onPhotosSelected: (String) -> Unit,
-    onError: (UiText) -> Unit,
-    onClosePicker: () -> Unit,
-) {
-    val logger: Logger = Logger.withTag("ProfileImagePicker")
-    logger.d { "ProfileImagePicker 열림" }
-    GalleryPickerLauncher(
-        allowMultiple = false,
-        mimeTypes = ALL_SUPPORTED_TYPES,
-        onPhotosSelected = { photos: List<GalleryPhotoResult> ->
-            logger.d { "onPhotosSelected, 사진 개수: ${photos.size}" }
-            onClosePicker()
-
-            val photo: GalleryPhotoResult? = photos.firstOrNull()
-            if (photo == null) {
-                logger.w { "선택된 사진이 없습니다" }
-                return@GalleryPickerLauncher
-            }
-            onPhotosSelected(photo.uri)
-            onClosePicker()
-        },
-        onError = { exception: Exception ->
-            logger.e(exception) { "GalleryPicker 에러 발생" }
-            onError(UiText.StringRes(Res.string.setting_edit_profile_image_selection_failed))
-            onClosePicker()
-        },
-        onDismiss = {
-            logger.d { "GalleryPicker 닫힘" }
-            onClosePicker()
-        },
-        enableCrop = true,
-        cameraCaptureConfig =
-            CameraCaptureConfig(
-                compressionLevel = CompressionLevel.HIGH,
-                cropConfig =
-                    CropConfig(
-                        enabled = true,
-                        aspectRatioLocked = true,
-                        circularCrop = true,
-                        squareCrop = false,
-                        freeformCrop = false,
-                    ),
-            ),
-    )
 }
 
 @Composable

--- a/mobile/composeApp/src/commonMain/kotlin/com/yagubogu/ui/setting/SettingMainScreen.kt
+++ b/mobile/composeApp/src/commonMain/kotlin/com/yagubogu/ui/setting/SettingMainScreen.kt
@@ -19,7 +19,6 @@ import androidx.compose.runtime.State
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -49,6 +48,7 @@ import com.yagubogu.ui.theme.PretendardRegular12
 import com.yagubogu.ui.theme.PretendardSemiBold
 import com.yagubogu.ui.theme.White
 import com.yagubogu.ui.util.LocalSnackbarHostState
+import com.yagubogu.ui.util.UiText
 import com.yagubogu.ui.util.showSingleSnackbar
 import com.yagubogu.ui.util.yyyyMMddFormatter
 import io.github.ismoy.imagepickerkmp.domain.config.CameraCaptureConfig
@@ -57,8 +57,6 @@ import io.github.ismoy.imagepickerkmp.domain.models.CompressionLevel
 import io.github.ismoy.imagepickerkmp.domain.models.GalleryPhotoResult
 import io.github.ismoy.imagepickerkmp.domain.models.MimeType.Companion.ALL_SUPPORTED_TYPES
 import io.github.ismoy.imagepickerkmp.presentation.ui.components.GalleryPickerLauncher
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.launch
 import kotlinx.datetime.format
 import org.jetbrains.compose.resources.getString
 import org.jetbrains.compose.resources.stringResource
@@ -68,9 +66,7 @@ import yagubogu.composeapp.generated.resources.setting_contact_us
 import yagubogu.composeapp.generated.resources.setting_edit_my_team
 import yagubogu.composeapp.generated.resources.setting_edit_nickname
 import yagubogu.composeapp.generated.resources.setting_edit_profile_image
-import yagubogu.composeapp.generated.resources.setting_edit_profile_image_processing_failed
 import yagubogu.composeapp.generated.resources.setting_edit_profile_image_selection_failed
-import yagubogu.composeapp.generated.resources.setting_edit_profile_image_upload_failed
 import yagubogu.composeapp.generated.resources.setting_edited_nickname_alert
 import yagubogu.composeapp.generated.resources.setting_main_sign_up_date
 import yagubogu.composeapp.generated.resources.setting_manage_account
@@ -82,23 +78,16 @@ fun SettingMainScreen(
     viewModel: SettingViewModel,
     onSettingAccountClick: () -> Unit,
     onFavoriteTeamEditClick: () -> Unit,
-    onFullScreenMode: (Boolean) -> Unit,
+    onProfileImagePickerOpen: () -> Unit,
     onOssLicenseClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val snackbarHostState = LocalSnackbarHostState.current
 
-    val scope: CoroutineScope = rememberCoroutineScope()
     val memberInfoItem: State<MemberInfoItem> =
         viewModel.myMemberInfoItem.collectAsStateWithLifecycle(MemberInfoItem())
 
     var showNicknameEditDialog: Boolean by rememberSaveable { mutableStateOf(false) }
-
-    var showGallery by rememberSaveable { mutableStateOf(false) }
-
-    LaunchedEffect(showGallery) {
-        onFullScreenMode(showGallery)
-    }
 
     LaunchedEffect(Unit) {
         viewModel.fetchMemberInfo()
@@ -136,22 +125,12 @@ fun SettingMainScreen(
         onClickSettingAccount = onSettingAccountClick,
         onFavoriteTeamEditClick = onFavoriteTeamEditClick,
         onNicknameEdit = { showNicknameEditDialog = true },
-        onProfileImageUpload = {
-            showGallery = true
-        },
+        onProfileImageUpload = onProfileImagePickerOpen,
         onOssLicenseClick = onOssLicenseClick,
         memberInfoItem = memberInfoItem.value,
         appVersion = getAppVersion(),
         modifier = modifier,
     )
-
-    if (showGallery) {
-        ProfileImagePicker(
-            scope,
-            viewModel::uploadProfileImage,
-            onClosePicker = { showGallery = false },
-        )
-    }
 
     if (showNicknameEditDialog) {
         NicknameEditDialog(
@@ -169,13 +148,13 @@ fun SettingMainScreen(
 }
 
 @Composable
-private fun ProfileImagePicker(
-    scope: CoroutineScope,
-    onUpload: suspend (String, String, Long) -> Result<Unit>,
+fun ProfileImagePicker(
+    onPhotosSelected: (String) -> Unit,
+    onError: (UiText) -> Unit,
     onClosePicker: () -> Unit,
 ) {
     val logger: Logger = Logger.withTag("ProfileImagePicker")
-    val snackbarHostState = LocalSnackbarHostState.current
+    logger.d { "ProfileImagePicker 열림" }
     GalleryPickerLauncher(
         allowMultiple = false,
         mimeTypes = ALL_SUPPORTED_TYPES,
@@ -188,39 +167,12 @@ private fun ProfileImagePicker(
                 logger.w { "선택된 사진이 없습니다" }
                 return@GalleryPickerLauncher
             }
-            scope.launch {
-                runCatching {
-                    handleImagePickerKMPCroppedImage(
-                        onUploadFailure = {
-                            snackbarHostState.showSingleSnackbar(
-                                scope = scope,
-                                stringResource = Res.string.setting_edit_profile_image_upload_failed,
-                            )
-                        },
-                        onProcessingFailure = {
-                            snackbarHostState.showSingleSnackbar(
-                                scope = scope,
-                                stringResource = Res.string.setting_edit_profile_image_processing_failed,
-                            )
-                        },
-                        sourceImageUri = photo.uri,
-                        onProfileImageUpload = onUpload,
-                    )
-                }.getOrElse { exception: Throwable ->
-                    logger.e(exception) { "이미지 처리 중 예외 발생" }
-                    snackbarHostState.showSingleSnackbar(
-                        scope = scope,
-                        stringResource = Res.string.setting_edit_profile_image_processing_failed,
-                    )
-                }
-            }
+            onPhotosSelected(photo.uri)
+            onClosePicker()
         },
         onError = { exception: Exception ->
             logger.e(exception) { "GalleryPicker 에러 발생" }
-            snackbarHostState.showSingleSnackbar(
-                scope = scope,
-                stringResource = Res.string.setting_edit_profile_image_selection_failed,
-            )
+            onError(UiText.StringRes(Res.string.setting_edit_profile_image_selection_failed))
             onClosePicker()
         },
         onDismiss = {

--- a/mobile/composeApp/src/commonMain/kotlin/com/yagubogu/ui/setting/SettingScreen.kt
+++ b/mobile/composeApp/src/commonMain/kotlin/com/yagubogu/ui/setting/SettingScreen.kt
@@ -1,13 +1,12 @@
 package com.yagubogu.ui.setting
 
-import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.expandVertically
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
-import androidx.compose.animation.shrinkVertically
+import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -15,6 +14,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.navigation3.runtime.NavEntry
 import androidx.navigation3.runtime.NavKey
 import androidx.navigation3.runtime.entryProvider
@@ -24,6 +24,7 @@ import com.yagubogu.ui.navigation.model.NavigationState
 import com.yagubogu.ui.navigation.model.SettingNavKey
 import com.yagubogu.ui.navigation.model.toEntries
 import com.yagubogu.ui.theme.Gray050
+import com.yagubogu.ui.theme.Gray900
 import com.yagubogu.ui.util.slidePopTransition
 import com.yagubogu.ui.util.slidePredictivePopTransition
 import com.yagubogu.ui.util.slidePushTransition
@@ -44,16 +45,12 @@ fun SettingScreen(
     modifier: Modifier = Modifier,
     viewModel: SettingViewModel = koinViewModel(),
 ) {
-    var isTopBarVisible: Boolean by remember { mutableStateOf(true) }
+    var isGalleryOpen by remember { mutableStateOf(false) }
 
-    Scaffold(
-        containerColor = Gray050,
-        topBar = {
-            AnimatedVisibility(
-                visible = isTopBarVisible,
-                enter = expandVertically() + fadeIn(),
-                exit = shrinkVertically() + fadeOut(),
-            ) {
+    Box(modifier = Modifier.fillMaxSize()) {
+        Scaffold(
+            containerColor = Gray050,
+            topBar = {
                 DefaultToolbar(
                     onBackClick = onBackClick,
                     title =
@@ -62,52 +59,70 @@ fun SettingScreen(
                                 ?: Res.string.setting_main_title,
                         ),
                 )
-            }
-        },
-        modifier = modifier,
-    ) { innerPadding: PaddingValues ->
-        val entryProvider: (NavKey) -> NavEntry<NavKey> =
-            entryProvider {
-                entry<SettingNavKey.SettingMain> {
-                    SettingMainScreen(
-                        viewModel = viewModel,
-                        onSettingAccountClick = { onSettingItemClick(SettingNavKey.SettingAccount) },
-                        onFavoriteTeamEditClick = { onFavoriteTeamEditClick() },
-                        onFullScreenMode = { isFull: Boolean -> isTopBarVisible = !isFull },
-                        onOssLicenseClick = { onSettingItemClick(SettingNavKey.OssLicense) },
-                    )
-                }
-                entry<SettingNavKey.SettingAccount> {
-                    SettingAccountScreen(
-                        viewModel = viewModel,
-                        onDeleteAccountClick = { onSettingItemClick(SettingNavKey.SettingDeleteAccount) },
-                        onLogout = onLogout,
-                    )
-                }
-                entry<SettingNavKey.SettingDeleteAccount> {
-                    SettingDeleteAccountScreen(
-                        viewModel = viewModel,
-                        onDeleteAccountCancel = onDeleteAccountCancel,
-                        onLogout = onDeleteAccount,
-                    )
-                }
-                entry<SettingNavKey.OssLicense> {
-                    OssLicenseScreen()
-                }
-            }
-
-        NavDisplay(
-            modifier =
-                Modifier
-                    .padding(innerPadding)
-                    .fillMaxSize(),
-            entries = navigationState.toEntries(entryProvider),
-            onBack = onBackClick,
-            transitionSpec = { slidePushTransition() },
-            popTransitionSpec = { slidePopTransition() },
-            predictivePopTransitionSpec = { edge ->
-                slidePredictivePopTransition(edge)
             },
-        )
+            modifier = modifier,
+        ) { innerPadding: PaddingValues ->
+            val entryProvider: (NavKey) -> NavEntry<NavKey> =
+                entryProvider {
+                    entry<SettingNavKey.SettingMain> {
+                        SettingMainScreen(
+                            viewModel = viewModel,
+                            onSettingAccountClick = { onSettingItemClick(SettingNavKey.SettingAccount) },
+                            onFavoriteTeamEditClick = { onFavoriteTeamEditClick() },
+                            onProfileImagePickerOpen = { isGalleryOpen = true },
+                            onOssLicenseClick = { onSettingItemClick(SettingNavKey.OssLicense) },
+                        )
+                    }
+                    entry<SettingNavKey.SettingAccount> {
+                        SettingAccountScreen(
+                            viewModel = viewModel,
+                            onDeleteAccountClick = { onSettingItemClick(SettingNavKey.SettingDeleteAccount) },
+                            onLogout = onLogout,
+                        )
+                    }
+                    entry<SettingNavKey.SettingDeleteAccount> {
+                        SettingDeleteAccountScreen(
+                            viewModel = viewModel,
+                            onDeleteAccountCancel = onDeleteAccountCancel,
+                            onLogout = onDeleteAccount,
+                        )
+                    }
+                    entry<SettingNavKey.OssLicense> {
+                        OssLicenseScreen()
+                    }
+                }
+
+            NavDisplay(
+                modifier =
+                    Modifier
+                        .padding(innerPadding)
+                        .fillMaxSize(),
+                entries = navigationState.toEntries(entryProvider),
+                onBack = onBackClick,
+                transitionSpec = { slidePushTransition() },
+                popTransitionSpec = { slidePopTransition() },
+                predictivePopTransitionSpec = { edge ->
+                    slidePredictivePopTransition(edge)
+                },
+            )
+        }
+        if (isGalleryOpen) {
+            Box(
+                modifier =
+                    Modifier
+                        .fillMaxSize()
+                        .background(Gray900.copy(alpha = 0.3f))
+                        .systemBarsPadding()
+                        .pointerInput(Unit) { detectTapGestures { } }, // 배경 터치 차단
+            ) {
+                ProfileImagePicker(
+                    onPhotosSelected = { uri: String ->
+                        viewModel.handleProfileImage(uri)
+                    },
+                    onError = { uiText -> viewModel.emitProfileError(uiText) },
+                    onClosePicker = { isGalleryOpen = false },
+                )
+            }
+        }
     }
 }

--- a/mobile/composeApp/src/commonMain/kotlin/com/yagubogu/ui/setting/SettingViewModel.kt
+++ b/mobile/composeApp/src/commonMain/kotlin/com/yagubogu/ui/setting/SettingViewModel.kt
@@ -32,6 +32,8 @@ import yagubogu.composeapp.generated.resources.setting_edit_nickname_no_permissi
 import yagubogu.composeapp.generated.resources.setting_edit_nickname_server_error
 import yagubogu.composeapp.generated.resources.setting_edit_nickname_too_long
 import yagubogu.composeapp.generated.resources.setting_edit_nickname_unknown_error
+import yagubogu.composeapp.generated.resources.setting_edit_profile_image_processing_failed
+import yagubogu.composeapp.generated.resources.setting_edit_profile_image_upload_failed
 import kotlin.time.Clock
 
 class SettingViewModel(
@@ -97,6 +99,36 @@ class SettingViewModel(
     fun cancelDeleteAccount() {
         viewModelScope.launch {
             _settingEvent.emit(SettingEvent.DeleteAccountCancel)
+        }
+    }
+
+    fun handleProfileImage(uri: String) {
+        viewModelScope.launch {
+            runCatching {
+                handleImagePickerKMPCroppedImage(
+                    sourceImageUri = uri,
+                    onUploadFailure = {
+                        emitProfileError(UiText.StringRes(Res.string.setting_edit_profile_image_upload_failed))
+                    },
+                    onProcessingFailure = {
+                        emitProfileError(UiText.StringRes(Res.string.setting_edit_profile_image_processing_failed))
+                    },
+                    onProfileImageUpload = ::uploadProfileImage,
+                )
+            }.onFailure { exception ->
+                logger.e(exception) { "이미지 처리 과정 중 예외 발생" }
+                emitProfileError(UiText.StringRes(Res.string.setting_edit_profile_image_processing_failed))
+            }
+        }
+    }
+
+    /**
+     * 프로필 관련 에러 이벤트를 SharedFlow로 방출합니다.
+     * 외부 라이브러리의 콜백에서도 안전하게 호출할 수 있도록 launch를 포함합니다.
+     */
+    fun emitProfileError(uiText: UiText) {
+        viewModelScope.launch {
+            _settingEvent.emit(SettingEvent.ProfileImageEditFailure(uiText))
         }
     }
 

--- a/mobile/composeApp/src/commonMain/kotlin/com/yagubogu/ui/setting/model/SettingEvent.kt
+++ b/mobile/composeApp/src/commonMain/kotlin/com/yagubogu/ui/setting/model/SettingEvent.kt
@@ -11,6 +11,12 @@ sealed interface SettingEvent {
         val uiText: UiText,
     ) : SettingEvent
 
+    data object ProfileImageEditSuccess : SettingEvent
+
+    data class ProfileImageEditFailure(
+        val uiText: UiText,
+    ) : SettingEvent
+
     data object Logout : SettingEvent
 
     data object DeleteAccount : SettingEvent


### PR DESCRIPTION
## 📌 관련 이슈
- close #913

## ✨ 변경 내용
- scaffold에서 탑바를 애니메이션으로 숨기는 동작 없이 설정 전체 영역에 이미지 피커가 뜨게 변경했습니다
- 설정에서 이미지피커 뒤에 반투명 오버레이로 터치를 막아 프로필 사진 변경중에는 다른 화면으로 이동을 봉쇄했습니다.

## 🎸 기타 참고 사항

https://github.com/user-attachments/assets/c6410908-fdb4-48bc-b59d-bd4327b128b4

