### PR TITLE
hotfix: 12글자 이상 닉네임 수정 버그 수정

### DIFF
--- a/mobile/composeApp/src/commonMain/kotlin/com/yagubogu/ui/setting/component/dialog/NicknameEditDialog.kt
+++ b/mobile/composeApp/src/commonMain/kotlin/com/yagubogu/ui/setting/component/dialog/NicknameEditDialog.kt
@@ -42,6 +42,8 @@ import yagubogu.composeapp.generated.resources.all_confirm
 import yagubogu.composeapp.generated.resources.setting_edit_nickname
 import yagubogu.composeapp.generated.resources.setting_edit_nickname_dialog_hint
 
+private const val NICKNAME_LENGTH_LIMIT = 15
+
 @Composable
 fun NicknameEditDialog(
     nickname: String,
@@ -74,8 +76,10 @@ fun NicknameEditDialog(
                 TextField(
                     value = nickname.value,
                     onValueChange = {
-                        if (it.length <= 12) {
+                        if (it.length <= NICKNAME_LENGTH_LIMIT) {
                             nickname.value = it
+                        } else {
+                            nickname.value = it.substring(0, NICKNAME_LENGTH_LIMIT)
                         }
                     },
                     placeholder = { Text(text = stringResource(Res.string.setting_edit_nickname_dialog_hint)) },


### PR DESCRIPTION
## 📌 관련 이슈
- close #943 

## ✨ 변경 내용
- 닉네임 최대 길이를 12자에서 15자로 상향 조정 및 `NICKNAME_LENGTH_LIMIT` 상수 도입
- 입력값이 제한 길이를 초과할 경우 자동으로 잘리도록 truncation 로직 추가 (substring 적용)

## 🎸 기타 참고 사항
- 스크린샷, 참고 링크, 추가 설명 등 (없으면 생략 가능)