### PR TITLE
fix: 현장톡 인셋 버그, 응원바 안나오는 버그 수정, 현장톡 목록 shimmer 추가

### DIFF
--- a/mobile/composeApp/src/commonMain/kotlin/com/yagubogu/ui/livetalk/LivetalkScreen.kt
+++ b/mobile/composeApp/src/commonMain/kotlin/com/yagubogu/ui/livetalk/LivetalkScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.rememberLazyListState
@@ -24,6 +25,7 @@ import androidx.compose.ui.unit.sp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.yagubogu.ui.livetalk.component.LIVETALK_STADIUM_ITEMS
 import com.yagubogu.ui.livetalk.component.LivetalkStadiumItem
+import com.yagubogu.ui.livetalk.component.ShimmerStadiumItem
 import com.yagubogu.ui.livetalk.model.LivetalkStadiumItem
 import com.yagubogu.ui.theme.Gray050
 import com.yagubogu.ui.theme.Gray400
@@ -46,7 +48,9 @@ fun LivetalkScreen(
     modifier: Modifier = Modifier,
     viewModel: LivetalkViewModel = koinViewModel(),
 ) {
-    val livetalkStadiumItems: List<LivetalkStadiumItem> by viewModel.stadiumItems.collectAsStateWithLifecycle()
+    val livetalkStadiumDelegatedItems: List<LivetalkStadiumItem>? by viewModel.stadiumItems.collectAsStateWithLifecycle()
+
+    val livetalkStadiumItems = livetalkStadiumDelegatedItems
 
     LaunchedEffect(Unit) {
         viewModel.fetchGames()
@@ -54,8 +58,19 @@ fun LivetalkScreen(
 
     BackPressHandler()
 
-    when (livetalkStadiumItems.isNotEmpty()) {
-        true ->
+    when {
+        // 로딩 중 (데이터가 아직 null인 경우 shimmer)
+        livetalkStadiumItems == null -> {
+            ShimmerLivetalkScreen(modifier = modifier)
+        }
+
+        // 데이터가 비어있는 경우
+        livetalkStadiumItems.isEmpty() -> {
+            EmptyLivetalkScreen(modifier = modifier)
+        }
+
+        // 데이터가 존재할 경우
+        else -> {
             LivetalkScreen(
                 items = livetalkStadiumItems,
                 onItemClick = { item: LivetalkStadiumItem ->
@@ -64,8 +79,23 @@ fun LivetalkScreen(
                 modifier = modifier,
                 scrollToTopEvent = scrollToTopEvent,
             )
+        }
+    }
+}
 
-        false -> EmptyLivetalkScreen(modifier = modifier)
+@Composable
+fun ShimmerLivetalkScreen(modifier: Modifier = Modifier) {
+    Column(
+        modifier =
+            modifier
+                .fillMaxSize()
+                .background(Gray050)
+                .padding(top = 8.dp, start = 20.dp, end = 20.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+        repeat(5) {
+            ShimmerStadiumItem()
+        }
     }
 }
 
@@ -151,4 +181,10 @@ private fun LivetalkScreenPreview() {
 @Composable
 private fun EmptyLivetalkScreenPreview() {
     EmptyLivetalkScreen()
+}
+
+@Preview("로딩중 현장톡 화면")
+@Composable
+private fun ShimmerLivetalkScreenPreview() {
+    ShimmerLivetalkScreen()
 }

--- a/mobile/composeApp/src/commonMain/kotlin/com/yagubogu/ui/livetalk/LivetalkScreen.kt
+++ b/mobile/composeApp/src/commonMain/kotlin/com/yagubogu/ui/livetalk/LivetalkScreen.kt
@@ -84,7 +84,7 @@ fun LivetalkScreen(
 }
 
 @Composable
-fun ShimmerLivetalkScreen(modifier: Modifier = Modifier) {
+private fun ShimmerLivetalkScreen(modifier: Modifier = Modifier) {
     Column(
         modifier =
             modifier

--- a/mobile/composeApp/src/commonMain/kotlin/com/yagubogu/ui/livetalk/LivetalkViewModel.kt
+++ b/mobile/composeApp/src/commonMain/kotlin/com/yagubogu/ui/livetalk/LivetalkViewModel.kt
@@ -21,8 +21,8 @@ class LivetalkViewModel(
 ) : ViewModel() {
     private val logger = Logger.withTag("LivetalkViewModel")
 
-    private val _stadiumItems = MutableStateFlow<List<LivetalkStadiumItem>>(emptyList())
-    val stadiumItems: StateFlow<List<LivetalkStadiumItem>> = _stadiumItems.asStateFlow()
+    private val _stadiumItems = MutableStateFlow<List<LivetalkStadiumItem>?>(null)
+    val stadiumItems: StateFlow<List<LivetalkStadiumItem>?> = _stadiumItems.asStateFlow()
 
     fun fetchGames(date: LocalDate = LocalDate.now(clock)) {
         viewModelScope.launch {

--- a/mobile/composeApp/src/commonMain/kotlin/com/yagubogu/ui/livetalk/chat/LivetalkChatScreen.kt
+++ b/mobile/composeApp/src/commonMain/kotlin/com/yagubogu/ui/livetalk/chat/LivetalkChatScreen.kt
@@ -473,7 +473,7 @@ fun LivetalkChatPreviewLoading() {
 }
 
 // 내 팀이 홈팀에 속하고 인증한 경우
-@Preview(showBackground = true, name = "채팅 없음 (비인증/제3자)")
+@Preview(showBackground = true, name = "채팅 없음 (비인증)")
 @Composable
 fun LivetalkChatPreviewVerifiedEmpty() {
     val neutralTeams =

--- a/mobile/composeApp/src/commonMain/kotlin/com/yagubogu/ui/livetalk/chat/LivetalkChatScreen.kt
+++ b/mobile/composeApp/src/commonMain/kotlin/com/yagubogu/ui/livetalk/chat/LivetalkChatScreen.kt
@@ -261,27 +261,36 @@ fun LivetalkChatScreenContent(
                         .fillMaxWidth(),
             ) {
                 // 채팅 버블
-                when (state.chatList.uiState) {
-                    is LivetalkChatUiState.Success -> {
-                        LivetalkChatBubbleList(
-                            chatItems = state.chatList.items,
-                            modifier = Modifier.weight(1f),
-                            onDeleteClick = actions.chatBubbleItems.onRequestDelete,
-                            onReportClick = actions.chatBubbleItems.onRequestReport,
-                            onProfileClick = { actions.chatBubbleItems.onFetchMemberProfile(it.memberId) },
-                            fetchBeforeTalks = { actions.chatBubbleItems.onFetchBeforeTalks() },
-                        )
-                    }
+                Box(
+                    modifier =
+                        Modifier
+                            .weight(1f)
+                            .fillMaxWidth(),
+                ) {
+                    when (state.chatList.uiState) {
+                        is LivetalkChatUiState.Success -> {
+                            LivetalkChatBubbleList(
+                                chatItems = state.chatList.items,
+                                modifier = Modifier.fillMaxSize(),
+                                onDeleteClick = actions.chatBubbleItems.onRequestDelete,
+                                onReportClick = actions.chatBubbleItems.onRequestReport,
+                                onProfileClick = { actions.chatBubbleItems.onFetchMemberProfile(it.memberId) },
+                                fetchBeforeTalks = { actions.chatBubbleItems.onFetchBeforeTalks() },
+                            )
+                        }
 
-                    is LivetalkChatUiState.Loading -> {
-                        LivetalkChatBubbleListShimmer()
-                    }
+                        is LivetalkChatUiState.Loading -> {
+                            LivetalkChatBubbleListShimmer()
+                        }
 
-                    is LivetalkChatUiState.Empty -> {
-                        EmptyLivetalkChat(isCheckIn = state.isVerified)
+                        is LivetalkChatUiState.Empty -> {
+                            EmptyLivetalkChat(
+                                isCheckIn = state.isVerified,
+                                modifier = Modifier.fillMaxSize(),
+                            )
+                        }
                     }
                 }
-
                 // 구분선
                 HorizontalDivider(thickness = max(0.4.dp, Dp.Hairline), color = Gray300)
 
@@ -463,6 +472,49 @@ fun LivetalkChatPreviewLoading() {
     }
 }
 
+// 내 팀이 홈팀에 속하고 인증한 경우
+@Preview(showBackground = true, name = "채팅 없음 (비인증/제3자)")
+@Composable
+fun LivetalkChatPreviewVerifiedEmpty() {
+    val neutralTeams =
+        LivetalkTeams(
+            stadiumName = "고척 스카이돔",
+            homeTeamCode = "KT", // 홈: KT
+            awayTeamCode = "NC", // 원정: NC
+            myTeamCode = "KT", // 내 팀: 삼성
+        )
+
+    val mockState =
+        LivetalkChatScreenStates(
+            toolbar =
+                LivetalkChatScreenStates.Toolbar(
+                    teams = neutralTeams,
+                ),
+            chatList =
+                LivetalkChatScreenStates.ChatList(
+                    uiState = LivetalkChatUiState.Empty,
+                ),
+            inputBar =
+                LivetalkChatScreenStates.InputBar(
+                    text = "",
+                    stadiumName = neutralTeams.stadiumName,
+                ),
+            cheering =
+                LivetalkChatScreenStates.Cheering(
+                    myTeam = neutralTeams.myTeam,
+                    showingCount = 0L,
+                ),
+            isVerified = true,
+        )
+
+    YaguBoguTheme {
+        LivetalkChatScreenContent(
+            state = mockState,
+            actions = LivetalkChatScreenActions(),
+        )
+    }
+}
+
 // 내 팀이 홈/원정 어디에도 속하지 않고 인증하지 않은 경우
 @Preview(showBackground = true, name = "채팅 없음 (비인증/제3자)")
 @Composable
@@ -489,6 +541,11 @@ fun LivetalkChatPreviewEmpty() {
                 LivetalkChatScreenStates.InputBar(
                     text = "",
                     stadiumName = neutralTeams.stadiumName,
+                ),
+            cheering =
+                LivetalkChatScreenStates.Cheering(
+                    myTeam = neutralTeams.myTeam,
+                    showingCount = 0L,
                 ),
             isVerified = false,
         )

--- a/mobile/composeApp/src/commonMain/kotlin/com/yagubogu/ui/livetalk/chat/LivetalkChatScreen.kt
+++ b/mobile/composeApp/src/commonMain/kotlin/com/yagubogu/ui/livetalk/chat/LivetalkChatScreen.kt
@@ -8,6 +8,8 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
@@ -236,6 +238,10 @@ fun LivetalkChatScreenContent(
                 isVerified = state.isVerified,
                 onTextChange = actions.chatInputBar.onMessageTextChange,
                 onSendMessage = actions.chatInputBar.onSendMessage,
+                modifier =
+                    Modifier
+                        .navigationBarsPadding() // 시스템 네비게이션 바 영역 확보
+                        .imePadding(),
             )
         },
         containerColor = Gray050,

--- a/mobile/composeApp/src/commonMain/kotlin/com/yagubogu/ui/livetalk/chat/component/EmptyLivetalkChat.kt
+++ b/mobile/composeApp/src/commonMain/kotlin/com/yagubogu/ui/livetalk/chat/component/EmptyLivetalkChat.kt
@@ -5,7 +5,6 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.material3.Text
@@ -35,7 +34,6 @@ fun EmptyLivetalkChat(
     Column(
         modifier =
             modifier
-                .fillMaxSize()
                 .background(Gray050),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.Center,

--- a/mobile/composeApp/src/commonMain/kotlin/com/yagubogu/ui/livetalk/component/LivetalkStadiumItem.kt
+++ b/mobile/composeApp/src/commonMain/kotlin/com/yagubogu/ui/livetalk/component/LivetalkStadiumItem.kt
@@ -3,6 +3,7 @@ package com.yagubogu.ui.livetalk.component
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -34,6 +35,7 @@ import com.yagubogu.ui.theme.dpToSp
 import com.yagubogu.ui.util.color
 import com.yagubogu.ui.util.emoji
 import com.yagubogu.ui.util.noRippleClickable
+import com.yagubogu.ui.util.shimmerLoading
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
 import yagubogu.composeapp.generated.resources.Res
@@ -119,6 +121,17 @@ fun LivetalkStadiumItem(
 }
 
 @Composable
+fun ShimmerStadiumItem(modifier: Modifier = Modifier) {
+    Box(
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .height(142.dp)
+                .shimmerLoading(12.dp),
+    )
+}
+
+@Composable
 private fun TeamItem(
     name: String,
     emoji: String,
@@ -157,4 +170,10 @@ private fun LivetalkStadiumItemUnVerifiedPreview() {
         item = LIVETALK_STADIUM_ITEM_UNVERIFIED,
         onClick = {},
     )
+}
+
+@Preview
+@Composable
+private fun LivetalkStadiumItemShimmerPreview() {
+    ShimmerStadiumItem()
 }

--- a/mobile/composeApp/src/commonMain/kotlin/com/yagubogu/ui/navigation/NavigationRoot.kt
+++ b/mobile/composeApp/src/commonMain/kotlin/com/yagubogu/ui/navigation/NavigationRoot.kt
@@ -138,7 +138,7 @@ fun NavigationRoot(
         Box(modifier = modifier.fillMaxSize()) {
             // 외부에서 온 modifier 설정을 소비
             NavDisplay(
-                modifier = Modifier.fillMaxSize(), // 단순치 전체 채우기만
+                modifier = Modifier.fillMaxSize(),
                 entries = rootNavigator.state.toEntries(entryProvider),
                 onBack = { rootNavigator.goBack() },
                 transitionSpec = { slidePushTransition() },

--- a/mobile/composeApp/src/commonMain/kotlin/com/yagubogu/ui/navigation/NavigationRoot.kt
+++ b/mobile/composeApp/src/commonMain/kotlin/com/yagubogu/ui/navigation/NavigationRoot.kt
@@ -136,8 +136,9 @@ fun NavigationRoot(
                 }
             }
         Box(modifier = modifier.fillMaxSize()) {
+            // 외부에서 온 modifier 설정을 소비
             NavDisplay(
-                modifier = modifier.fillMaxSize(),
+                modifier = Modifier.fillMaxSize(), // 단순치 전체 채우기만
                 entries = rootNavigator.state.toEntries(entryProvider),
                 onBack = { rootNavigator.goBack() },
                 transitionSpec = { slidePushTransition() },


### PR DESCRIPTION
## 📌 관련 이슈
- close #953
- close #909

## ✨ 변경 내용
- 네비게이션 바에 채팅 입력창이 가리는 버그 수정
<img width="421" height="106" alt="image" src="https://github.com/user-attachments/assets/2682f95d-56a2-492c-bf3a-f0e44e1704a0" />

- 채팅이 없으면 인증했더라도 응원바가 나오지 않던 버그 수정

- 현장톡 목록 shimmer 추가

## 🎸 기타 참고 사항
https://github.com/user-attachments/assets/be15b6e9-b2bc-4b0e-a03a-d125ec45f51d

