### PR TITLE
feat: 개막일 카운트다운 시간 조정

### DIFF
--- a/mobile/composeApp/src/commonMain/kotlin/com/yagubogu/domain/model/OpeningDate.kt
+++ b/mobile/composeApp/src/commonMain/kotlin/com/yagubogu/domain/model/OpeningDate.kt
@@ -1,14 +1,14 @@
 package com.yagubogu.domain.model
 
-import kotlinx.datetime.LocalDate
+import kotlinx.datetime.LocalDateTime
 
 enum class OpeningDate(
-    val date: LocalDate,
+    val dateTime: LocalDateTime,
 ) {
-    YEAR_2026(date = LocalDate(2026, 3, 28)),
+    YEAR_2026(dateTime = LocalDateTime(2026, 3, 28, 14, 0)),
     ;
 
     companion object {
-        fun fromYear(year: Int): OpeningDate? = entries.find { it.date.year == year }
+        fun fromYear(year: Int): OpeningDate? = entries.find { it.dateTime.year == year }
     }
 }

--- a/mobile/composeApp/src/commonMain/kotlin/com/yagubogu/ui/home/HomeScreen.kt
+++ b/mobile/composeApp/src/commonMain/kotlin/com/yagubogu/ui/home/HomeScreen.kt
@@ -78,6 +78,7 @@ fun HomeScreen(
     val isStadiumStatsExpanded: Boolean by viewModel.isStadiumStatsExpanded.collectAsStateWithLifecycle()
     val victoryFairyRanking: VictoryFairyRanking by viewModel.victoryFairyRanking.collectAsStateWithLifecycle()
     val leftSecondsUntilOpening: StateFlow<Long> = viewModel.leftSecondsUntilOpening
+    val openingHour: Int = viewModel.openingHour
 
     var permissionState: PermissionState by remember { mutableStateOf(PermissionState.IDLE) }
 
@@ -172,6 +173,7 @@ fun HomeScreen(
         victoryFairyRanking = victoryFairyRanking,
         onVictoryFairyRankingClick = viewModel::fetchMemberProfile,
         leftSecondsUntilOpening = leftSecondsUntilOpening,
+        openingHour = openingHour,
         modifier = modifier,
         scrollToTopEvent = scrollToTopEvent,
     )
@@ -202,6 +204,7 @@ private fun HomeScreen(
     victoryFairyRanking: VictoryFairyRanking,
     onVictoryFairyRankingClick: (Long) -> Unit,
     leftSecondsUntilOpening: StateFlow<Long>,
+    openingHour: Int,
     modifier: Modifier = Modifier,
     scrollToTopEvent: SharedFlow<Unit> = MutableSharedFlow(),
 ) {
@@ -239,7 +242,10 @@ private fun HomeScreen(
         MemberStats(uiModel = memberStatsUiModel)
 
         if (isCountdownVisible) {
-            OpeningCountdown(leftSecondsFlow = leftSecondsUntilOpening)
+            OpeningCountdown(
+                leftSecondsFlow = leftSecondsUntilOpening,
+                openingHour = openingHour,
+            )
         }
 
         if (stadiumStatsUiModel.stadiumFanRates.isNotEmpty()) {
@@ -296,5 +302,6 @@ private fun HomeScreenPreview() {
         victoryFairyRanking = VICTORY_FAIRY_RANKING,
         onVictoryFairyRankingClick = {},
         leftSecondsUntilOpening = MutableStateFlow(1_000_000L),
+        openingHour = 14,
     )
 }

--- a/mobile/composeApp/src/commonMain/kotlin/com/yagubogu/ui/home/HomeViewModel.kt
+++ b/mobile/composeApp/src/commonMain/kotlin/com/yagubogu/ui/home/HomeViewModel.kt
@@ -131,6 +131,8 @@ class HomeViewModel(
     private val _leftSecondsUntilOpening = MutableStateFlow(getLeftSecondsUntilOpening())
     val leftSecondsUntilOpening: StateFlow<Long> = _leftSecondsUntilOpening.asStateFlow()
 
+    val openingHour: Int = getOpeningDateHour()
+
     init {
         startOpeningCountdown()
     }
@@ -360,6 +362,8 @@ class HomeViewModel(
             }
         }
     }
+
+    private fun getOpeningDateHour(): Int = OpeningDate.fromYear(LocalDate.now(clock).year)?.dateTime?.hour ?: 0
 
     private fun getLeftSecondsUntilOpening(): Long {
         val currentYear: Int = LocalDate.now(clock).year

--- a/mobile/composeApp/src/commonMain/kotlin/com/yagubogu/ui/home/HomeViewModel.kt
+++ b/mobile/composeApp/src/commonMain/kotlin/com/yagubogu/ui/home/HomeViewModel.kt
@@ -28,7 +28,7 @@ import com.yagubogu.ui.mapper.toDomain
 import com.yagubogu.ui.mapper.toUiModel
 import com.yagubogu.ui.util.mapList
 import com.yagubogu.ui.util.now
-import com.yagubogu.ui.util.toInstant
+import com.yagubogu.ui.util.toInstantKST
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.async
@@ -212,7 +212,8 @@ class HomeViewModel(
     }
 
     fun refreshStadiumStats() {
-        _stadiumStatsUiModel.value = stadiumStatsUiModel.value.copy(refreshTime = LocalTime.now(clock))
+        _stadiumStatsUiModel.value =
+            stadiumStatsUiModel.value.copy(refreshTime = LocalTime.now(clock))
     }
 
     fun fetchMemberProfile(memberId: Long) {
@@ -362,9 +363,11 @@ class HomeViewModel(
 
     private fun getLeftSecondsUntilOpening(): Long {
         val currentYear: Int = LocalDate.now(clock).year
-        val openingDate: OpeningDate = OpeningDate.fromYear(currentYear) ?: return 0L
+        val openingDateTime: OpeningDate = OpeningDate.fromYear(currentYear) ?: return 0L
         val time =
-            clock.now().until(other = openingDate.date.toInstant(), unit = DateTimeUnit.SECOND)
+            clock
+                .now()
+                .until(other = openingDateTime.dateTime.toInstantKST(), unit = DateTimeUnit.SECOND)
         return if (time < 0L) 0L else time
     }
 

--- a/mobile/composeApp/src/commonMain/kotlin/com/yagubogu/ui/home/component/OpeningCountdown.kt
+++ b/mobile/composeApp/src/commonMain/kotlin/com/yagubogu/ui/home/component/OpeningCountdown.kt
@@ -46,14 +46,15 @@ import yagubogu.composeapp.generated.resources.home_opening_countdown_left_time
 private const val SECONDS_PER_MINUTE = 60L
 private const val SECONDS_PER_HOUR = 60L * 60L
 private const val SECONDS_PER_DAY = 24L * 60L * 60L
-private const val OPENING_HOUR_SECONDS = 14L * SECONDS_PER_HOUR
 
 @Composable
 fun OpeningCountdown(
     leftSecondsFlow: StateFlow<Long>,
+    openingHour: Int,
     modifier: Modifier = Modifier,
 ) {
     val leftSecondsUntilOpening: State<Long> = leftSecondsFlow.collectAsStateWithLifecycle()
+    val openingHourSeconds: Long = openingHour * SECONDS_PER_HOUR
 
     Column(
         modifier =
@@ -77,17 +78,26 @@ fun OpeningCountdown(
             )
         }
         Spacer(modifier = Modifier.height(24.dp))
-        DaysText(leftTimeState = leftSecondsUntilOpening)
+        DaysText(leftTimeState = leftSecondsUntilOpening, openingHourSeconds = openingHourSeconds)
         Spacer(modifier = Modifier.height(16.dp))
-        TimeCountdowns(leftTimeState = leftSecondsUntilOpening)
+        TimeCountdowns(
+            leftTimeState = leftSecondsUntilOpening,
+            openingHourSeconds = openingHourSeconds,
+        )
     }
 }
 
 @Composable
-private fun DaysText(leftTimeState: State<Long>) {
+private fun DaysText(
+    leftTimeState: State<Long>,
+    openingHourSeconds: Long,
+) {
     val days: Long by remember {
         derivedStateOf {
-            maxOf(0L, (leftTimeState.value - OPENING_HOUR_SECONDS + SECONDS_PER_DAY - 1) / SECONDS_PER_DAY)
+            maxOf(
+                0L,
+                (leftTimeState.value - openingHourSeconds + SECONDS_PER_DAY - 1) / SECONDS_PER_DAY,
+            )
         }
     }
 
@@ -105,15 +115,16 @@ private fun DaysText(leftTimeState: State<Long>) {
 @Composable
 private fun TimeCountdowns(
     leftTimeState: State<Long>,
+    openingHourSeconds: Long,
     modifier: Modifier = Modifier,
 ) {
     val leftTime: Long by leftTimeState
 
     val timeForDisplay: Long =
-        if (leftTime <= OPENING_HOUR_SECONDS) {
+        if (leftTime <= openingHourSeconds) {
             leftTime
         } else {
-            (leftTime - OPENING_HOUR_SECONDS) % SECONDS_PER_DAY
+            (leftTime - openingHourSeconds) % SECONDS_PER_DAY
         }
 
     val hours: Long = timeForDisplay / SECONDS_PER_HOUR
@@ -209,7 +220,7 @@ private fun ColonDivider(modifier: Modifier = Modifier) {
 @Preview
 @Composable
 private fun OpeningCountdownPreview() {
-    OpeningCountdown(leftSecondsFlow = MutableStateFlow(1_000_000L))
+    OpeningCountdown(leftSecondsFlow = MutableStateFlow(1_000_000L), openingHour = 14)
 }
 
 @Preview(showBackground = true)

--- a/mobile/composeApp/src/commonMain/kotlin/com/yagubogu/ui/home/component/OpeningCountdown.kt
+++ b/mobile/composeApp/src/commonMain/kotlin/com/yagubogu/ui/home/component/OpeningCountdown.kt
@@ -46,6 +46,7 @@ import yagubogu.composeapp.generated.resources.home_opening_countdown_left_time
 private const val SECONDS_PER_MINUTE = 60L
 private const val SECONDS_PER_HOUR = 60L * 60L
 private const val SECONDS_PER_DAY = 24L * 60L * 60L
+private const val OPENING_HOUR_SECONDS = 14L * SECONDS_PER_HOUR
 
 @Composable
 fun OpeningCountdown(
@@ -84,7 +85,11 @@ fun OpeningCountdown(
 
 @Composable
 private fun DaysText(leftTimeState: State<Long>) {
-    val days: Long by remember { derivedStateOf { leftTimeState.value / SECONDS_PER_DAY } }
+    val days: Long by remember {
+        derivedStateOf {
+            maxOf(0L, (leftTimeState.value - OPENING_HOUR_SECONDS + SECONDS_PER_DAY - 1) / SECONDS_PER_DAY)
+        }
+    }
 
     Text(
         text = stringResource(Res.string.d_day_with_days, days),
@@ -104,9 +109,16 @@ private fun TimeCountdowns(
 ) {
     val leftTime: Long by leftTimeState
 
-    val hours: Long = (leftTime % SECONDS_PER_DAY) / SECONDS_PER_HOUR
-    val minutes: Long = (leftTime % SECONDS_PER_HOUR) / SECONDS_PER_MINUTE
-    val seconds: Long = leftTime % SECONDS_PER_MINUTE
+    val timeForDisplay: Long =
+        if (leftTime <= OPENING_HOUR_SECONDS) {
+            leftTime
+        } else {
+            (leftTime - OPENING_HOUR_SECONDS) % SECONDS_PER_DAY
+        }
+
+    val hours: Long = timeForDisplay / SECONDS_PER_HOUR
+    val minutes: Long = (timeForDisplay % SECONDS_PER_HOUR) / SECONDS_PER_MINUTE
+    val seconds: Long = timeForDisplay % SECONDS_PER_MINUTE
 
     Row(modifier = modifier) {
         TimeCountdown(

--- a/mobile/composeApp/src/commonMain/kotlin/com/yagubogu/ui/util/TimeExt.kt
+++ b/mobile/composeApp/src/commonMain/kotlin/com/yagubogu/ui/util/TimeExt.kt
@@ -10,6 +10,7 @@ import kotlinx.datetime.YearMonth
 import kotlinx.datetime.atStartOfDayIn
 import kotlinx.datetime.minus
 import kotlinx.datetime.plus
+import kotlinx.datetime.toInstant
 import kotlinx.datetime.toLocalDateTime
 import kotlinx.datetime.todayIn
 import kotlinx.datetime.yearMonth
@@ -46,6 +47,8 @@ fun YearMonth.Companion.now(
     clock: Clock = Clock.System,
     timeZone: TimeZone = KST,
 ): YearMonth = clock.todayIn(timeZone).yearMonth
+
+fun LocalDateTime.toInstantKST() = this.toInstant(KST)
 
 fun LocalDate.toInstant(): Instant = this.atStartOfDayIn(KST)
 

--- a/mobile/composeApp/src/commonMain/kotlin/com/yagubogu/ui/util/TimeExt.kt
+++ b/mobile/composeApp/src/commonMain/kotlin/com/yagubogu/ui/util/TimeExt.kt
@@ -48,9 +48,9 @@ fun YearMonth.Companion.now(
     timeZone: TimeZone = KST,
 ): YearMonth = clock.todayIn(timeZone).yearMonth
 
-fun LocalDateTime.toInstantKST() = this.toInstant(KST)
+fun LocalDateTime.toInstantKST(): Instant = this.toInstant(KST)
 
-fun LocalDate.toInstant(): Instant = this.atStartOfDayIn(KST)
+fun LocalDate.toInstantKST(): Instant = this.atStartOfDayIn(KST)
 
 fun LocalDate.minusDays(value: Int): LocalDate = minus(value, DateTimeUnit.DAY)
 


### PR DESCRIPTION
## 📌 관련 이슈
- close #956 

## ✨ 변경 내용
- `OpeningDate` enum의 속성을 `dateTime`으로 변경하고 구체적인 개막 시각(14:00) 반영
- `LocalDateTime`을 KST 기준 `Instant`로 변환하는 `toInstantKST` 확장 함수 추가

**개막일 (28일 14시 기준)**

**27일 23시**
<img width="40%" alt="image" src="https://github.com/user-attachments/assets/5fa6cf83-935a-4845-833b-22d87d2dd586" />

**28일 13시**
<img width="40%" alt="image" src="https://github.com/user-attachments/assets/2f403768-436c-490c-8364-9695dedad15b" />

**27일 23시 59분 -> 28일 0시 0분**

[Screen_recording_20260320_012445.webm](https://github.com/user-attachments/assets/4e2eaa1b-83c5-4c6c-9911-25340a8e7930)



## 🎸 기타 참고 사항
- 스크린샷, 참고 링크, 추가 설명 등 (없으면 생략 가능)