### PR TITLE
fix: 승리요정 랭킹 점수 갱신 시 전체 평균 보정값이 누락되는 버그 수정 (#961)

### DIFF
--- a/backend/app/src/main/java/com/yagubogu/checkin/repository/CheckInRepository.java
+++ b/backend/app/src/main/java/com/yagubogu/checkin/repository/CheckInRepository.java
@@ -57,11 +57,12 @@ public interface CheckInRepository extends JpaRepository<CheckIn, Long>, CustomC
             SELECT DISTINCT c.member.id
             FROM CheckIn c
             JOIN c.game g
-            WHERE g.date = :date
+            WHERE YEAR(g.date) = :year
+            AND c.checkInType = 'LOCATION_CHECK_IN'
             ORDER BY c.member.id
             """)
-    Slice<Long> findDistinctMemberIdsByDate(
-            @Param("date") LocalDate date,
+    Slice<Long> findDistinctMemberIdsByYear(
+            @Param("year") int year,
             Pageable pageable
     );
 

--- a/backend/app/src/main/java/com/yagubogu/stat/service/StatSyncService.java
+++ b/backend/app/src/main/java/com/yagubogu/stat/service/StatSyncService.java
@@ -36,7 +36,7 @@ public class StatSyncService {
             Slice<Long> slice;
             do {
                 Pageable pageable = PageRequest.of(page, CHUNK_SIZE);
-                slice = checkInRepository.findDistinctMemberIdsByDate(date, pageable);
+                slice = checkInRepository.findDistinctMemberIdsByYear(currentYear, pageable);
 
                 if (slice.hasContent()) {
                     List<Long> memberIds = slice.getContent();

--- a/backend/app/src/test/java/com/yagubogu/stat/service/StatSyncServiceUsingMysqlTest.java
+++ b/backend/app/src/test/java/com/yagubogu/stat/service/StatSyncServiceUsingMysqlTest.java
@@ -99,7 +99,7 @@ class StatSyncServiceUsingMysqlTest extends ServiceUsingMysqlTestBase {
         });
     }
 
-    @DisplayName("기존 연도 데이터가 있을 때, 같은 날짜로 갱신 시 누적 값으로 업데이트된다")
+    @DisplayName("기존 연도 데이터가 있을 때, 배치가 돌면 전체 평균 변동에 따라 직관을 안 간 회원의 점수도 재계산된다") // DisplayName 변경
     @Test
     void updateRankings_updateExisting() {
         // given
@@ -128,7 +128,7 @@ class StatSyncServiceUsingMysqlTest extends ServiceUsingMysqlTestBase {
                 .gameState(GameState.COMPLETED));
         checkInFactory.save(b -> b.game(g2).member(m1).team(HT));
 
-        // when
+        // when (8월 1일자로 배치 실행 -> 2025년도 전체 업데이트)
         statSyncService.updateRankings(later);
 
         // then
@@ -141,12 +141,15 @@ class StatSyncServiceUsingMysqlTest extends ServiceUsingMysqlTestBase {
                 .orElseThrow();
 
         assertSoftly(softAssertions -> {
+            // m1 검증
             softAssertions.assertThat(r1.getWinCount()).isEqualTo(1);
             softAssertions.assertThat(r1.getCheckInCount()).isEqualTo(2);
             softAssertions.assertThat(r1.getScore()).isEqualTo(57.14);
+
+            // m2 검증 (주석 해제 및 올바른 보정 점수 기입)
             softAssertions.assertThat(r2.getWinCount()).isEqualTo(1);
             softAssertions.assertThat(r2.getCheckInCount()).isEqualTo(1);
-            softAssertions.assertThat(r2.getScore()).isEqualTo(100.0);
+            softAssertions.assertThat(r2.getScore()).isEqualTo(80.0); // 100점에서 전체 평균 하락으로 인해 80점으로 보정됨
         });
     }
 
@@ -242,5 +245,50 @@ class StatSyncServiceUsingMysqlTest extends ServiceUsingMysqlTestBase {
             softAssertions.assertThat(results.get(0).getMember().getId()).isEqualTo(normalMember.getId());
         });
     }
-}
 
+    @DisplayName("다른 연도의 직관 기록은 당해 연도 랭킹 업데이트에 영향을 주지 않는다")
+    @Test
+    void updateRankings_separatesYears() {
+        // given
+        Member m1 = memberFactory.save(b -> b.team(HT));
+
+        // 2024년 직관 (HT 승)
+        LocalDate date2024 = LocalDate.of(2024, 5, 5);
+        Game g2024 = gameFactory.save(b -> b.stadium(kia)
+                .homeTeam(HT).awayTeam(LT).date(date2024)
+                .homeScore(5).awayScore(3).gameState(GameState.COMPLETED));
+        checkInFactory.save(b -> b.game(g2024).member(m1).team(HT));
+        statSyncService.updateRankings(date2024); // 2024년 배치 1회 실행
+
+        // 2025년 직관 (HT 승, 다른 멤버)
+        Member m2 = memberFactory.save(b -> b.team(HT));
+        LocalDate date2025 = LocalDate.of(2025, 5, 5);
+        Game g2025 = gameFactory.save(b -> b.stadium(kia)
+                .homeTeam(HT).awayTeam(LT).date(date2025)
+                .homeScore(5).awayScore(3).gameState(GameState.COMPLETED));
+        checkInFactory.save(b -> b.game(g2025).member(m2).team(HT));
+
+        // when (2025년 기준으로 배치 실행)
+        statSyncService.updateRankings(date2025);
+
+        // then
+        // 1. 2025년 랭킹에는 2025년에 직관한 m2만 등록되어야 함
+        List<VictoryFairyRanking> results2025 = victoryFairyRankingRepository
+                .findByMemberIdsAndYear(List.of(m1.getId(), m2.getId()), 2025);
+
+        // 2. 2024년 랭킹의 m1 점수는 2025년 데이터에 영향을 받지 않고 그대로 있어야 함
+        List<VictoryFairyRanking> results2024 = victoryFairyRankingRepository
+                .findByMemberIdsAndYear(List.of(m1.getId()), 2024);
+
+        assertSoftly(softAssertions -> {
+            // 2025년 검증
+            softAssertions.assertThat(results2025).hasSize(1);
+            softAssertions.assertThat(results2025.get(0).getMember().getId()).isEqualTo(m2.getId());
+            softAssertions.assertThat(results2025.get(0).getScore()).isEqualTo(100.0);
+
+            // 2024년 검증
+            softAssertions.assertThat(results2024).hasSize(1);
+            softAssertions.assertThat(results2024.get(0).getScore()).isEqualTo(100.0);
+        });
+    }
+}


### PR DESCRIPTION
- 베이즈 평활화(Bayesian Smoothing) 적용 시, 전체 평균 데이터(평균 승률, 평균 직관수)가 변동됨에도 당일 직관자만 랭킹이 업데이트되어 기존 랭커들의 점수가 방치되는(Staleness) 문제 해결
- 랭킹 업데이트(StatSyncService) 대상을 '특정 날짜 직관자'에서 '당해 연도 위치 인증 직관자 전체'로 변경
- CheckInRepository의 대상자 조회 쿼리 조건을 date 기준에서 year 기준으로 수정 (findDistinctMemberIdsByYear)
- 승리요정 랭킹 갱신 및 과거 기록/연도 격리 관련 테스트 코드 보완

## 📌 관련 이슈
- close #959 

## ✨ 변경 내용
- 어떤 기능/수정이 포함되었는지 간단 요약

## 🎸 기타 참고 사항
- 스크린샷, 참고 링크, 추가 설명 등 (없으면 생략 가능)