### PR TITLE
feat: 월별 경기 날짜 조회 API 추가

### DIFF
--- a/backend/app/src/main/java/com/yagubogu/game/controller/v1/GameController.java
+++ b/backend/app/src/main/java/com/yagubogu/game/controller/v1/GameController.java
@@ -2,10 +2,13 @@ package com.yagubogu.game.controller.v1;
 
 import com.yagubogu.auth.annotation.RequireRole;
 import com.yagubogu.auth.dto.MemberClaims;
+import com.yagubogu.game.dto.v1.GameDatesResponse;
 import com.yagubogu.game.dto.v1.GameResponse;
 import com.yagubogu.game.service.GameService;
 import java.time.LocalDate;
+import java.time.YearMonth;
 import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -22,6 +25,16 @@ public class GameController implements GameControllerInterface {
             @RequestParam final LocalDate date
     ) {
         GameResponse response = gameService.findGamesByDate(date, memberClaims.id());
+
+        return ResponseEntity.ok(response);
+    }
+
+    @RequireRole
+    public ResponseEntity<GameDatesResponse> findGameDatesByYearMonth(
+            final MemberClaims memberClaims,
+            @RequestParam @DateTimeFormat(pattern = "yyyy-MM") final YearMonth yearMonth
+    ) {
+        GameDatesResponse response = gameService.findGameDatesByYearMonth(yearMonth);
 
         return ResponseEntity.ok(response);
     }

--- a/backend/app/src/main/java/com/yagubogu/game/controller/v1/GameControllerInterface.java
+++ b/backend/app/src/main/java/com/yagubogu/game/controller/v1/GameControllerInterface.java
@@ -1,6 +1,7 @@
 package com.yagubogu.game.controller.v1;
 
 import com.yagubogu.auth.dto.MemberClaims;
+import com.yagubogu.game.dto.v1.GameDatesResponse;
 import com.yagubogu.game.dto.v1.GameResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -8,6 +9,8 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.time.LocalDate;
+import java.time.YearMonth;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -27,5 +30,16 @@ public interface GameControllerInterface {
     ResponseEntity<GameResponse> findGamesByDate(
             @Parameter(hidden = true) MemberClaims memberClaims,
             @RequestParam LocalDate date
+    );
+
+    @Operation(summary = "월별 경기 있는 날짜 목록 조회", description = "해당 월에 경기가 있는 날짜만 반환합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "날짜 목록 조회 성공"),
+            @ApiResponse(responseCode = "404", description = "회원을 찾을 수 없음")
+    })
+    @GetMapping("/dates")
+    ResponseEntity<GameDatesResponse> findGameDatesByYearMonth(
+            @Parameter(hidden = true) MemberClaims memberClaims,
+            @RequestParam @DateTimeFormat(pattern = "yyyy-MM") YearMonth yearMonth
     );
 }

--- a/backend/app/src/main/java/com/yagubogu/game/dto/v1/GameDatesResponse.java
+++ b/backend/app/src/main/java/com/yagubogu/game/dto/v1/GameDatesResponse.java
@@ -1,0 +1,9 @@
+package com.yagubogu.game.dto.v1;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public record GameDatesResponse(
+        List<LocalDate> dates
+) {
+}

--- a/backend/app/src/main/java/com/yagubogu/game/repository/GameRepository.java
+++ b/backend/app/src/main/java/com/yagubogu/game/repository/GameRepository.java
@@ -6,14 +6,15 @@ import com.yagubogu.game.dto.GameWithCheckInParam;
 import com.yagubogu.member.domain.Member;
 import com.yagubogu.stadium.domain.Stadium;
 import com.yagubogu.team.domain.Team;
-import java.time.LocalDate;
-import java.time.LocalTime;
-import java.util.List;
-import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface GameRepository extends JpaRepository<Game, Long> {
@@ -65,4 +66,14 @@ public interface GameRepository extends JpaRepository<Game, Long> {
     List<Game> findAllByDate(LocalDate date);
 
     boolean existsByDateAndGameStateIn(LocalDate date, List<GameState> states);
+
+    @Query("""
+            SELECT DISTINCT g.date 
+            FROM Game g 
+            WHERE g.date >= :start 
+                AND g.date < :end 
+                AND g.gameState <> com.yagubogu.game.domain.GameState.CANCELED 
+            ORDER BY g.date
+            """)
+    List<LocalDate> findDistinctGameDatesByMonth(@Param("start") LocalDate start, @Param("end") LocalDate end);
 }

--- a/backend/app/src/main/java/com/yagubogu/game/service/GameService.java
+++ b/backend/app/src/main/java/com/yagubogu/game/service/GameService.java
@@ -3,6 +3,7 @@ package com.yagubogu.game.service;
 import com.yagubogu.game.domain.Game;
 import com.yagubogu.game.dto.GameResultParam;
 import com.yagubogu.game.dto.GameWithCheckInParam;
+import com.yagubogu.game.dto.v1.GameDatesResponse;
 import com.yagubogu.game.dto.v1.GameResponse;
 import com.yagubogu.game.repository.GameRepository;
 import com.yagubogu.global.exception.NotFoundException;
@@ -10,6 +11,7 @@ import com.yagubogu.global.exception.UnprocessableEntityException;
 import com.yagubogu.member.domain.Member;
 import com.yagubogu.member.repository.MemberRepository;
 import java.time.LocalDate;
+import java.time.YearMonth;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -57,6 +59,13 @@ public class GameService {
     private Game getGame(final Long gameId) {
         return gameRepository.findById(gameId)
                 .orElseThrow(() -> new NotFoundException("Game not found"));
+    }
+
+    public GameDatesResponse findGameDatesByYearMonth(final YearMonth yearMonth) {
+        LocalDate start = yearMonth.atDay(1);
+        LocalDate end = yearMonth.atEndOfMonth().plusDays(1);
+        List<LocalDate> dates = gameRepository.findDistinctGameDatesByMonth(start, end);
+        return new GameDatesResponse(dates);
     }
 
     private void validateIsNotFuture(final LocalDate date) {

--- a/backend/app/src/test/java/com/yagubogu/game/GameE2eTest.java
+++ b/backend/app/src/test/java/com/yagubogu/game/GameE2eTest.java
@@ -1,13 +1,13 @@
 package com.yagubogu.game;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import com.yagubogu.auth.config.AuthTestConfig;
 import com.yagubogu.checkin.domain.CheckIn;
 import com.yagubogu.game.domain.Game;
+import com.yagubogu.game.domain.GameState;
 import com.yagubogu.game.dto.GameWithCheckInParam;
 import com.yagubogu.game.dto.StadiumByGameParam;
 import com.yagubogu.game.dto.TeamByGameParam;
+import com.yagubogu.game.dto.v1.GameDatesResponse;
 import com.yagubogu.game.dto.v1.GameResponse;
 import com.yagubogu.global.config.JpaAuditingConfig;
 import com.yagubogu.member.domain.Member;
@@ -24,9 +24,6 @@ import com.yagubogu.team.domain.Team;
 import com.yagubogu.team.repository.TeamRepository;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
-import java.time.LocalDate;
-import java.util.List;
-import java.util.stream.IntStream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -34,6 +31,12 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpHeaders;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @Import({AuthTestConfig.class, JpaAuditingConfig.class})
 public class GameE2eTest extends E2eTestBase {
@@ -128,6 +131,61 @@ public class GameE2eTest extends E2eTestBase {
                 .statusCode(422);
     }
 
+    @DisplayName("월별 경기 있는 날짜 목록을 반환한다")
+    @Test
+    void findGameDatesByYearMonth() {
+        // given
+        LocalDate date1 = LocalDate.of(2025, 5, 3);
+        LocalDate date2 = LocalDate.of(2025, 5, 10);
+        makeGame(date1, "HT", "LT", "잠실구장");
+        makeGame(date2, "WO", "HH", "고척돔");
+
+        Member member = makeMember(getTeamByCode("SS"));
+        String accessToken = authFactory.getAccessTokenByMemberId(member.getId(), Role.USER);
+
+        // when
+        GameDatesResponse actual = RestAssured.given().log().all()
+                .contentType(ContentType.JSON)
+                .header(HttpHeaders.AUTHORIZATION, accessToken)
+                .queryParam("yearMonth", "2025-05")
+                .when().get("/api/v1/games/dates")
+                .then().log().all()
+                .statusCode(200)
+                .extract()
+                .as(GameDatesResponse.class);
+
+        // then
+        assertThat(actual.dates()).containsExactlyInAnyOrder(date1, date2);
+    }
+
+    @DisplayName("취소된 경기만 있는 날짜는 결과에서 제외된다")
+    @Test
+    void findGameDatesByYearMonth_excludesCanceled() {
+        // given
+        LocalDate canceledDate = LocalDate.of(2025, 5, 3);
+        LocalDate scheduledDate = LocalDate.of(2025, 5, 10);
+        makeGameWithState(canceledDate, "HT", "LT", "잠실구장", GameState.CANCELED);
+        makeGame(scheduledDate, "WO", "HH", "고척돔");
+
+        Member member = makeMember(getTeamByCode("SS"));
+        String accessToken = authFactory.getAccessTokenByMemberId(member.getId(), Role.USER);
+
+        // when
+        GameDatesResponse actual = RestAssured.given().log().all()
+                .contentType(ContentType.JSON)
+                .header(HttpHeaders.AUTHORIZATION, accessToken)
+                .queryParam("yearMonth", "2025-05")
+                .when().get("/api/v1/games/dates")
+                .then().log().all()
+                .statusCode(200)
+                .extract()
+                .as(GameDatesResponse.class);
+
+        // then
+        assertThat(actual.dates()).containsExactly(scheduledDate);
+        assertThat(actual.dates()).doesNotContain(canceledDate);
+    }
+
     private Game makeGame(LocalDate date, String homeCode, String awayCode, String stadiumShortName) {
         Team homeTeam = getTeamByCode(homeCode);
         Team awayTeam = getTeamByCode(awayCode);
@@ -138,6 +196,26 @@ public class GameE2eTest extends E2eTestBase {
                 .awayTeam(awayTeam)
                 .stadium(stadium)
                 .date(date)
+        );
+    }
+
+    private Game makeGameWithState(
+            LocalDate date,
+            String homeCode,
+            String awayCode,
+            String stadiumShortName,
+            GameState gameState
+    ) {
+        Team homeTeam = getTeamByCode(homeCode);
+        Team awayTeam = getTeamByCode(awayCode);
+        Stadium stadium = stadiumRepository.findByShortName(stadiumShortName).orElseThrow();
+
+        return gameFactory.save(builder -> builder
+                .homeTeam(homeTeam)
+                .awayTeam(awayTeam)
+                .stadium(stadium)
+                .date(date)
+                .gameState(gameState)
         );
     }
 

--- a/backend/app/src/test/java/com/yagubogu/game/service/GameServiceTest.java
+++ b/backend/app/src/test/java/com/yagubogu/game/service/GameServiceTest.java
@@ -1,17 +1,16 @@
 package com.yagubogu.game.service;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-
 import com.yagubogu.auth.config.AuthTestConfig;
 import com.yagubogu.checkin.domain.CheckIn;
 import com.yagubogu.game.domain.Game;
+import com.yagubogu.game.domain.GameState;
 import com.yagubogu.game.domain.ScoreBoard;
 import com.yagubogu.game.dto.GameResultParam;
 import com.yagubogu.game.dto.GameResultParam.ScoreBoardParam;
 import com.yagubogu.game.dto.GameWithCheckInParam;
 import com.yagubogu.game.dto.StadiumByGameParam;
 import com.yagubogu.game.dto.TeamByGameParam;
+import com.yagubogu.game.dto.v1.GameDatesResponse;
 import com.yagubogu.game.dto.v1.GameResponse;
 import com.yagubogu.game.repository.GameRepository;
 import com.yagubogu.global.config.JpaAuditingConfig;
@@ -28,15 +27,20 @@ import com.yagubogu.support.member.MemberBuilder;
 import com.yagubogu.support.member.MemberFactory;
 import com.yagubogu.team.domain.Team;
 import com.yagubogu.team.repository.TeamRepository;
-import java.time.LocalDate;
-import java.util.List;
-import java.util.stream.IntStream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
+
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.util.List;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @Import({AuthTestConfig.class, JpaAuditingConfig.class})
 @DataJpaTest
@@ -156,6 +160,111 @@ class GameServiceTest {
         assertThat(scoreBoard).isEqualTo(expected);
     }
 
+    @DisplayName("해당 월에 경기가 있는 날짜 목록을 반환한다")
+    @Test
+    void findGameDatesByYearMonth() {
+        // given
+        YearMonth yearMonth = YearMonth.of(2025, 5);
+        LocalDate date1 = LocalDate.of(2025, 5, 3);
+        LocalDate date2 = LocalDate.of(2025, 5, 10);
+        LocalDate date3 = LocalDate.of(2025, 5, 17);
+
+        makeGame(date1, "HT", "LT", "잠실구장");
+        makeGame(date2, "WO", "HH", "고척돔");
+        makeGame(date3, "SK", "SS", "랜더스필드");
+
+        // when
+        GameDatesResponse response = gameService.findGameDatesByYearMonth(yearMonth);
+
+        // then
+        assertThat(response.dates()).containsExactlyInAnyOrder(date1, date2, date3);
+    }
+
+    @DisplayName("같은 날 여러 경기가 있어도 날짜는 중복 없이 반환한다")
+    @Test
+    void findGameDatesByYearMonth_noDuplicateDates() {
+        // given
+        YearMonth yearMonth = YearMonth.of(2025, 5);
+        LocalDate date = LocalDate.of(2025, 5, 3);
+
+        makeGame(date, "HT", "LT", "잠실구장");
+        makeGame(date, "WO", "HH", "고척돔");
+
+        // when
+        GameDatesResponse response = gameService.findGameDatesByYearMonth(yearMonth);
+
+        // then
+        assertThat(response.dates()).containsExactly(date);
+    }
+
+    @DisplayName("취소된 경기만 있는 날짜는 결과에 포함하지 않는다")
+    @Test
+    void findGameDatesByYearMonth_excludesCanceledGames() {
+        // given
+        YearMonth yearMonth = YearMonth.of(2025, 5);
+        LocalDate canceledDate = LocalDate.of(2025, 5, 3);
+        LocalDate scheduledDate = LocalDate.of(2025, 5, 10);
+
+        makeGameWithState(canceledDate, "HT", "LT", "잠실구장", GameState.CANCELED);
+        makeGame(scheduledDate, "WO", "HH", "고척돔");
+
+        // when
+        GameDatesResponse response = gameService.findGameDatesByYearMonth(yearMonth);
+
+        // then
+        assertThat(response.dates()).containsExactly(scheduledDate);
+        assertThat(response.dates()).doesNotContain(canceledDate);
+    }
+
+    @DisplayName("같은 날 일부 경기만 취소되면 해당 날짜는 결과에 포함된다")
+    @Test
+    void findGameDatesByYearMonth_includesDateWhenOnlySomeGamesCanceled() {
+        // given
+        YearMonth yearMonth = YearMonth.of(2025, 5);
+        LocalDate date = LocalDate.of(2025, 5, 3);
+
+        makeGame(date, "HT", "LT", "잠실구장");          // SCHEDULED
+        makeGame(date, "WO", "HH", "고척돔");            // SCHEDULED
+        makeGameWithState(date, "SK", "SS", "랜더스필드", GameState.CANCELED);  // CANCELED
+
+        // when
+        GameDatesResponse response = gameService.findGameDatesByYearMonth(yearMonth);
+
+        // then
+        assertThat(response.dates()).containsExactly(date);
+    }
+
+    @DisplayName("다른 월의 경기는 결과에 포함하지 않는다")
+    @Test
+    void findGameDatesByYearMonth_excludesOtherMonths() {
+        // given
+        YearMonth yearMonth = YearMonth.of(2025, 5);
+        LocalDate targetDate = LocalDate.of(2025, 5, 3);
+        LocalDate otherMonthDate = LocalDate.of(2025, 6, 1);
+
+        makeGame(targetDate, "HT", "LT", "잠실구장");
+        makeGame(otherMonthDate, "WO", "HH", "고척돔");
+
+        // when
+        GameDatesResponse response = gameService.findGameDatesByYearMonth(yearMonth);
+
+        // then
+        assertThat(response.dates()).containsExactly(targetDate);
+    }
+
+    @DisplayName("경기가 없는 월은 빈 리스트를 반환한다")
+    @Test
+    void findGameDatesByYearMonth_emptyWhenNoGames() {
+        // given
+        YearMonth yearMonth = YearMonth.of(2025, 5);
+
+        // when
+        GameDatesResponse response = gameService.findGameDatesByYearMonth(yearMonth);
+
+        // then
+        assertThat(response.dates()).isEmpty();
+    }
+
     private Game makeGame(LocalDate date, String homeCode, String awayCode, String stadiumShortName) {
         Team homeTeam = getTeamByCode(homeCode);
         Team awayTeam = getTeamByCode(awayCode);
@@ -166,6 +275,26 @@ class GameServiceTest {
                 .awayTeam(awayTeam)
                 .stadium(stadium)
                 .date(date)
+        );
+    }
+
+    private Game makeGameWithState(
+            LocalDate date,
+            String homeCode,
+            String awayCode,
+            String stadiumShortName,
+            GameState gameState
+    ) {
+        Team homeTeam = getTeamByCode(homeCode);
+        Team awayTeam = getTeamByCode(awayCode);
+        Stadium stadium = stadiumRepository.findByShortName(stadiumShortName).orElseThrow();
+
+        return gameFactory.save(builder -> builder
+                .homeTeam(homeTeam)
+                .awayTeam(awayTeam)
+                .stadium(stadium)
+                .date(date)
+                .gameState(gameState)
         );
     }
 


### PR DESCRIPTION
## 📌 관련 이슈
- close #이슈번호

## ✨ 변경 내용
# 월별 경기 날짜 조회

| 항목 | 내용 |
|------|------|
| Method | GET |
| URL | /api/v1/games/dates |
| 인증 | 필요 (Bearer Token) |

---

## Request

### Query Parameter

| 파라미터 | 타입 | 설명 | 예시 |
|----------|------|------|------|
| yearMonth | String | 조회할 연월 (yyyy-MM 형식) | 2026-03 |

### Request Example

```http
GET /api/v1/games/dates?yearMonth=2026-03
Authorization: Bearer {accessToken}
```
## Response

### 200 OK

| 필드 | 타입 | 설명 |
|------|------|------|
| dates | List\<String\> | 경기가 있는 날짜 목록 (yyyy-MM-dd 형식, 오름차순) |

```json
{
  "dates": [
    "2026-03-25",
    "2026-03-28",
    "2026-03-29",
    "2026-03-31"
  ]
}
```

## 🎸 기타 참고 사항
- 스크린샷, 참고 링크, 추가 설명 등 (없으면 생략 가능)