### PR TITLE
fix: 멤버 프로필 조회 시 승률은 현재 연도 기준, 최신 직관 날짜는 전체 연도 기준으로 반환

### DIFF
--- a/backend/app/src/main/java/com/yagubogu/member/dto/v1/MemberCheckInResponse.java
+++ b/backend/app/src/main/java/com/yagubogu/member/dto/v1/MemberCheckInResponse.java
@@ -13,8 +13,12 @@ public record MemberCheckInResponse(
 ) {
 
     public static MemberCheckInResponse from(final CheckInSummaryParam summary) {
-        if (summary == null || summary.totalCount() == 0) {
+        if (summary == null) {
             return empty();
+        }
+
+        if (summary.totalCount() == 0) {
+            return new MemberCheckInResponse(null, 0.0, null, null, null, summary.recentCheckInDate());
         }
 
         return new MemberCheckInResponse(

--- a/backend/app/src/main/java/com/yagubogu/member/service/MemberService.java
+++ b/backend/app/src/main/java/com/yagubogu/member/service/MemberService.java
@@ -179,7 +179,7 @@ public class MemberService {
         int year = LocalDate.now().getYear();
         MemberProfileBadgeResponse badgeResponse = createBadgeResponse(profileOwnerMember);
         VictoryFairyProfileResponse victoryFairyResponse = createVictoryFairyResponse(profileOwnerId, year);
-        MemberCheckInResponse checkInResponse = createCheckInResponse(profileOwnerId, null);
+        MemberCheckInResponse checkInResponse = createCheckInResponse(profileOwnerId, year);
 
         return MemberProfileResponse.from(
                 profileOwnerMember,

--- a/backend/app/src/test/java/com/yagubogu/member/MemberE2eTest.java
+++ b/backend/app/src/test/java/com/yagubogu/member/MemberE2eTest.java
@@ -314,7 +314,7 @@ public class MemberE2eTest extends E2eTestBase {
                 .statusCode(404);
     }
 
-    @DisplayName("사용자의 프로필 정보를 조회할 때, 연도와 상관없이 전체 직관 통계를 합산하여 보여준다")
+    @DisplayName("사용자의 프로필 정보를 조회할 때, 직관 통계는 현재 연도 기준으로, 최신 직관 날짜는 전체 연도 기준으로 보여준다")
     @Test
     void findProfileInformationWithAllYears() {
         // 1. Given: 기본 환경 설정 (팀, 경기장, 멤버)
@@ -364,18 +364,18 @@ public class MemberE2eTest extends E2eTestBase {
                 .statusCode(200)
                 .extract().as(MemberProfileResponse.class);
 
-        // 4. Then: 데이터 검증 (2024년 + 2026년 통계가 합산되었는지 확인)
+        // 4. Then: 데이터 검증 (현재 연도(2026년) 기준 통계, 최신 직관 날짜는 전체 연도 기준)
         assertSoftly(softly -> {
             softly.assertThat(response.nickname()).isEqualTo("가짜우가");
-            // 전체 직관 횟수: 3 (2024년 1건 + 2026년 2건)
-            softly.assertThat(response.checkIn().counts()).isEqualTo(3);
-            // 전체 승리 횟수: 2 (2024년 1승 + 2026년 1승)
-            softly.assertThat(response.checkIn().winCounts()).isEqualTo(2);
+            // 현재 연도(2026년) 직관 횟수: 2
+            softly.assertThat(response.checkIn().counts()).isEqualTo(2);
+            // 현재 연도(2026년) 승리 횟수: 1
+            softly.assertThat(response.checkIn().winCounts()).isEqualTo(1);
             softly.assertThat(response.checkIn().loseCounts()).isEqualTo(1);
-            // 최근 직관 날짜: 2026-02-15
+            // 최근 직관 날짜: 전체 연도 기준 2026-02-15
             softly.assertThat(response.checkIn().recentCheckInDate()).isEqualTo(LocalDate.of(2026, 2, 15));
-            // 승률 계산: (2승 / 3경기) * 100 = 66.7 (소수점 첫째자리 반올림 가정)
-            softly.assertThat(response.checkIn().winRate()).isEqualTo(66.7);
+            // 승률 계산: (1승 / 2경기) * 100 = 50.0 (현재 연도 기준)
+            softly.assertThat(response.checkIn().winRate()).isEqualTo(50.0);
         });
     }
 

--- a/backend/app/src/test/java/com/yagubogu/member/service/MemberServiceTest.java
+++ b/backend/app/src/test/java/com/yagubogu/member/service/MemberServiceTest.java
@@ -25,7 +25,15 @@ import com.yagubogu.member.repository.MemberRepository;
 import com.yagubogu.stat.dto.CheckInSummaryParam;
 import com.yagubogu.stat.dto.VictoryFairySummaryParam;
 import com.yagubogu.stat.service.StatService;
+import com.yagubogu.checkin.repository.CheckInRepository;
+import com.yagubogu.game.domain.GameState;
+import com.yagubogu.game.domain.Game;
+import com.yagubogu.stadium.domain.Stadium;
+import com.yagubogu.stadium.repository.StadiumRepository;
+import com.yagubogu.stat.repository.VictoryFairyRankingRepository;
 import com.yagubogu.support.badge.MemberBadgeFactory;
+import com.yagubogu.support.checkin.CheckInFactory;
+import com.yagubogu.support.game.GameFactory;
 import com.yagubogu.support.member.MemberBuilder;
 import com.yagubogu.support.member.MemberFactory;
 import com.yagubogu.team.domain.Team;
@@ -49,9 +57,10 @@ import org.springframework.context.annotation.Import;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -87,6 +96,21 @@ public class MemberServiceTest {
 
     @Autowired
     private EntityManager entityManager;
+
+    @Autowired
+    private CheckInRepository checkInRepository;
+
+    @Autowired
+    private CheckInFactory checkInFactory;
+
+    @Autowired
+    private GameFactory gameFactory;
+
+    @Autowired
+    private StadiumRepository stadiumRepository;
+
+    @Autowired
+    private VictoryFairyRankingRepository victoryFairyRankingRepository;
 
     @BeforeEach
     void setUp() {
@@ -475,7 +499,8 @@ public class MemberServiceTest {
                 .build()
         );
         CheckInSummaryParam fakeSummary = new CheckInSummaryParam(14, 75.0, 9, 0, 4, LocalDate.of(2025, 7, 24));
-        when(statService.findCheckInSummary(anyLong(), any())).thenReturn(fakeSummary);
+        int currentYear = LocalDate.now().getYear();
+        when(statService.findCheckInSummary(anyLong(), eq(currentYear))).thenReturn(fakeSummary);
         VictoryFairySummaryParam fakeVictorySummary = new VictoryFairySummaryParam(5L, 1L, 90.0);
         when(statService.findVictoryFairySummary(anyLong(), anyInt())).thenReturn(fakeVictorySummary);
         MemberProfileBadgeResponse expectedBadgeResponse = MemberProfileBadgeResponse.from(
@@ -508,6 +533,49 @@ public class MemberServiceTest {
             softAssertions.assertThat(actual.checkIn().loseCounts()).isEqualTo(expectedCheckInResponse.loseCounts());
             softAssertions.assertThat(actual.checkIn().recentCheckInDate())
                     .isEqualTo(expectedCheckInResponse.recentCheckInDate());
+        });
+        verify(statService).findCheckInSummary(profileOwneredMember.getId(), currentYear);
+    }
+
+    @DisplayName("이전 연도(2025)에만 직관한 멤버의 프로필 조회 시, 최신 직관 날짜는 2025년도로, 현재 연도(2026) 승률은 0%로 반환된다")
+    @Test
+    void findMemberProfile_onlyPreviousYearCheckIn_winRateIsZeroAndRecentDateIsPreviousYear() {
+        // given
+        Team HT = teamRepository.findByTeamCode("HT").orElseThrow();
+        Team LT = teamRepository.findByTeamCode("LT").orElseThrow();
+        Badge badge = badgeRepository.findByPolicy(Policy.SIGN_UP).getFirst();
+
+        Member member = memberFactory.save(builder -> builder.nickname("우가")
+                .team(HT)
+                .representativeBadge(badge)
+                .build()
+        );
+
+        Stadium kia = stadiumRepository.findByShortName("챔피언스필드").orElseThrow();
+        LocalDate checkInDate2025 = LocalDate.of(2025, 7, 24);
+
+        // 2025년에 직관한 경기 (HT 홈 승) — 현재 연도는 2026이므로 승률 집계 대상 아님
+        Game game2025 = gameFactory.save(b -> b.stadium(kia)
+                .homeTeam(HT).awayTeam(LT)
+                .date(checkInDate2025)
+                .homeScore(5).awayScore(1)
+                .gameState(GameState.COMPLETED));
+        checkInFactory.save(b -> b.member(member).team(HT).game(game2025));
+
+        // 실제 StatService 사용
+        StatService realStatService = new StatService(checkInRepository, memberRepository, victoryFairyRankingRepository);
+        MemberService realMemberService = new MemberService(memberRepository, teamRepository, badgeRepository,
+                memberBadgeRepository, publisher, realStatService);
+
+        // when — findMemberProfile 내부에서 LocalDate.now().getYear() = 2026 사용
+        MemberProfileResponse actual = realMemberService.findMemberProfile(member.getId());
+
+        // then
+        assertSoftly(softAssertions -> {
+            // 2026년 직관 없음 → 승률 0%
+            softAssertions.assertThat(actual.checkIn().winRate()).isEqualTo(0.0);
+            // 전체 연도 기준 최신 직관 날짜 → 2025-07-24
+            softAssertions.assertThat(actual.checkIn().recentCheckInDate()).isEqualTo(checkInDate2025);
         });
     }
 


### PR DESCRIPTION
## 📌 관련 이슈
- close #971 

## ✨ 변경 내용
- 어떤 기능/수정이 포함되었는지 간단 요약

## 🎸 기타 참고 사항
- 스크린샷, 참고 링크, 추가 설명 등 (없으면 생략 가능)