### PR TITLE
feat: 직관 인증 시 메모, 사진 추가

### DIFF
--- a/backend/app/src/main/java/com/yagubogu/checkin/controller/v1/CheckInController.java
+++ b/backend/app/src/main/java/com/yagubogu/checkin/controller/v1/CheckInController.java
@@ -4,13 +4,21 @@ import com.yagubogu.auth.annotation.RequireRole;
 import com.yagubogu.auth.dto.MemberClaims;
 import com.yagubogu.checkin.domain.CheckInOrderFilter;
 import com.yagubogu.checkin.domain.CheckInResultFilter;
+import com.yagubogu.checkin.dto.v1.AddCheckInImageRequest;
 import com.yagubogu.checkin.dto.v1.CheckInCountsResponse;
 import com.yagubogu.checkin.dto.v1.CheckInHistoryResponse;
+import com.yagubogu.checkin.dto.v1.CheckInImageParam;
+import com.yagubogu.checkin.dto.v1.CheckInImagesResponse;
+import com.yagubogu.checkin.dto.v1.CheckInMemoResponse;
 import com.yagubogu.checkin.dto.v1.CheckInStatusResponse;
 import com.yagubogu.checkin.dto.v1.CreateCheckInRequest;
 import com.yagubogu.checkin.dto.v1.FanRateResponse;
 import com.yagubogu.checkin.dto.v1.StadiumCheckInCountsResponse;
+import com.yagubogu.checkin.dto.v1.UpdateCheckInMemoRequest;
+import com.yagubogu.checkin.service.CheckInImageService;
 import com.yagubogu.checkin.service.CheckInService;
+import com.yagubogu.member.dto.v1.PreSignedUrlStartRequest;
+import com.yagubogu.member.dto.v1.PresignedUrlStartResponse;
 import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -26,6 +34,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class CheckInController implements CheckInControllerInterface {
 
     private final CheckInService checkInService;
+    private final CheckInImageService checkInImageService;
 
     public ResponseEntity<Void> createCheckIn(
             final MemberClaims memberClaims,
@@ -64,11 +73,7 @@ public class CheckInController implements CheckInControllerInterface {
             @RequestParam(name = "order", defaultValue = "LATEST") final CheckInOrderFilter orderFilter
     ) {
         CheckInHistoryResponse response = checkInService.findCheckInHistory(
-                memberClaims.id(),
-                year,
-                month,
-                resultFilter,
-                orderFilter
+                memberClaims.id(), year, month, resultFilter, orderFilter
         );
 
         return ResponseEntity.ok(response);
@@ -99,5 +104,75 @@ public class CheckInController implements CheckInControllerInterface {
         StadiumCheckInCountsResponse response = checkInService.findStadiumCheckInCounts(memberClaims.id(), year);
 
         return ResponseEntity.ok(response);
+    }
+
+    // ── 메모 CRUD ──────────────────────────────────────────────────────────────
+
+    public ResponseEntity<CheckInMemoResponse> getMemo(
+            final MemberClaims memberClaims,
+            @PathVariable final Long checkInId
+    ) {
+        CheckInMemoResponse response = checkInService.getMemo(memberClaims.id(), checkInId);
+
+        return ResponseEntity.ok(response);
+    }
+
+    public ResponseEntity<Void> updateMemo(
+            final MemberClaims memberClaims,
+            @PathVariable final Long checkInId,
+            @RequestBody final UpdateCheckInMemoRequest request
+    ) {
+        checkInService.updateMemo(memberClaims.id(), checkInId, request.memo());
+
+        return ResponseEntity.ok().build();
+    }
+
+    public ResponseEntity<Void> deleteMemo(
+            final MemberClaims memberClaims,
+            @PathVariable final Long checkInId
+    ) {
+        checkInService.deleteMemo(memberClaims.id(), checkInId);
+
+        return ResponseEntity.noContent().build();
+    }
+
+    // ── 이미지 CRUD ────────────────────────────────────────────────────────────
+
+    public ResponseEntity<PresignedUrlStartResponse> issueImagePresignedUrl(
+            final MemberClaims memberClaims,
+            @RequestBody final PreSignedUrlStartRequest request
+    ) {
+        PresignedUrlStartResponse response = checkInImageService.issuePresignedUrl(request);
+
+        return ResponseEntity.ok(response);
+    }
+
+    public ResponseEntity<CheckInImagesResponse> getImages(
+            final MemberClaims memberClaims,
+            @PathVariable final Long checkInId
+    ) {
+        CheckInImagesResponse response = checkInService.getImages(memberClaims.id(), checkInId);
+
+        return ResponseEntity.ok(response);
+    }
+
+    public ResponseEntity<CheckInImageParam> addImage(
+            final MemberClaims memberClaims,
+            @PathVariable final Long checkInId,
+            @RequestBody final AddCheckInImageRequest request
+    ) {
+        CheckInImageParam response = checkInService.addImage(memberClaims.id(), checkInId, request.imageKey());
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    public ResponseEntity<Void> deleteImage(
+            final MemberClaims memberClaims,
+            @PathVariable final Long checkInId,
+            @PathVariable final Long imageId
+    ) {
+        checkInService.deleteImage(memberClaims.id(), checkInId, imageId);
+
+        return ResponseEntity.noContent().build();
     }
 }

--- a/backend/app/src/main/java/com/yagubogu/checkin/controller/v1/CheckInControllerInterface.java
+++ b/backend/app/src/main/java/com/yagubogu/checkin/controller/v1/CheckInControllerInterface.java
@@ -20,6 +20,7 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import jakarta.validation.Valid;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -36,7 +37,7 @@ public interface CheckInControllerInterface {
     @PostMapping
     ResponseEntity<Void> createCheckIn(
             @Parameter(hidden = true) MemberClaims memberClaims,
-            @RequestBody CreateCheckInRequest request
+            @Valid @RequestBody CreateCheckInRequest request
     );
 
     @Operation(summary = "경기 인증 삭제", description = "지정한 경기 인증을 삭제합니다. 본인의 인증만 삭제할 수 있습니다.")

--- a/backend/app/src/main/java/com/yagubogu/checkin/controller/v1/CheckInControllerInterface.java
+++ b/backend/app/src/main/java/com/yagubogu/checkin/controller/v1/CheckInControllerInterface.java
@@ -3,24 +3,32 @@ package com.yagubogu.checkin.controller.v1;
 import com.yagubogu.auth.dto.MemberClaims;
 import com.yagubogu.checkin.domain.CheckInOrderFilter;
 import com.yagubogu.checkin.domain.CheckInResultFilter;
+import com.yagubogu.checkin.dto.v1.AddCheckInImageRequest;
 import com.yagubogu.checkin.dto.v1.CheckInCountsResponse;
 import com.yagubogu.checkin.dto.v1.CheckInHistoryResponse;
+import com.yagubogu.checkin.dto.v1.CheckInImageParam;
+import com.yagubogu.checkin.dto.v1.CheckInImagesResponse;
+import com.yagubogu.checkin.dto.v1.CheckInMemoResponse;
 import com.yagubogu.checkin.dto.v1.CheckInStatusResponse;
 import com.yagubogu.checkin.dto.v1.CreateCheckInRequest;
 import com.yagubogu.checkin.dto.v1.FanRateResponse;
 import com.yagubogu.checkin.dto.v1.StadiumCheckInCountsResponse;
+import com.yagubogu.checkin.dto.v1.UpdateCheckInMemoRequest;
+import com.yagubogu.member.dto.v1.PreSignedUrlStartRequest;
+import com.yagubogu.member.dto.v1.PresignedUrlStartResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import java.time.LocalDate;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
-import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -71,8 +79,8 @@ public interface CheckInControllerInterface {
     @GetMapping("/members")
     ResponseEntity<CheckInHistoryResponse> findCheckInHistory(
             @Parameter(hidden = true) MemberClaims memberClaims,
-            @RequestParam(required = false) final Integer year,
-            @RequestParam(required = false) final Integer month,
+            @RequestParam(required = false) Integer year,
+            @RequestParam(required = false) Integer month,
             @RequestParam(name = "result", defaultValue = "ALL") CheckInResultFilter resultFilter,
             @RequestParam(name = "order", defaultValue = "LATEST") CheckInOrderFilter orderFilter
     );
@@ -108,5 +116,88 @@ public interface CheckInControllerInterface {
     ResponseEntity<StadiumCheckInCountsResponse> findStadiumCheckInCount(
             @Parameter(hidden = true) MemberClaims memberClaims,
             @RequestParam(required = false) Integer year
+    );
+
+    // ── 메모 CRUD ──────────────────────────────────────────────────────────────
+
+    @Operation(summary = "직관 기록 메모 조회", description = "직관 기록의 메모를 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "메모 조회 성공"),
+            @ApiResponse(responseCode = "404", description = "직관 기록 또는 회원을 찾을 수 없음")
+    })
+    @GetMapping("/{checkInId}/memo")
+    ResponseEntity<CheckInMemoResponse> getMemo(
+            @Parameter(hidden = true) MemberClaims memberClaims,
+            @PathVariable Long checkInId
+    );
+
+    @Operation(summary = "직관 기록 메모 수정", description = "직관 기록의 메모를 추가하거나 수정합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "메모 수정 성공"),
+            @ApiResponse(responseCode = "404", description = "직관 기록 또는 회원을 찾을 수 없음")
+    })
+    @PutMapping("/{checkInId}/memo")
+    ResponseEntity<Void> updateMemo(
+            @Parameter(hidden = true) MemberClaims memberClaims,
+            @PathVariable Long checkInId,
+            @Valid @RequestBody UpdateCheckInMemoRequest request
+    );
+
+    @Operation(summary = "직관 기록 메모 삭제", description = "직관 기록의 메모를 삭제합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "메모 삭제 성공"),
+            @ApiResponse(responseCode = "404", description = "직관 기록 또는 회원을 찾을 수 없음")
+    })
+    @DeleteMapping("/{checkInId}/memo")
+    ResponseEntity<Void> deleteMemo(
+            @Parameter(hidden = true) MemberClaims memberClaims,
+            @PathVariable Long checkInId
+    );
+
+    // ── 이미지 CRUD ────────────────────────────────────────────────────────────
+
+    @Operation(summary = "직관 기록 이미지 업로드용 Presigned URL 발급", description = "직관 기록 이미지 업로드를 위한 S3 Presigned URL을 발급합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Presigned URL 발급 성공")
+    })
+    @PostMapping("/image/presigned-url")
+    ResponseEntity<PresignedUrlStartResponse> issueImagePresignedUrl(
+            @Parameter(hidden = true) MemberClaims memberClaims,
+            @Valid @RequestBody PreSignedUrlStartRequest request
+    );
+
+    @Operation(summary = "직관 기록 이미지 목록 조회", description = "직관 기록에 첨부된 이미지 목록을 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "이미지 목록 조회 성공"),
+            @ApiResponse(responseCode = "404", description = "직관 기록 또는 회원을 찾을 수 없음")
+    })
+    @GetMapping("/{checkInId}/images")
+    ResponseEntity<CheckInImagesResponse> getImages(
+            @Parameter(hidden = true) MemberClaims memberClaims,
+            @PathVariable Long checkInId
+    );
+
+    @Operation(summary = "직관 기록 이미지 추가", description = "직관 기록에 이미지를 추가합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "이미지 추가 성공"),
+            @ApiResponse(responseCode = "404", description = "직관 기록, 회원 또는 이미지를 찾을 수 없음")
+    })
+    @PostMapping("/{checkInId}/images")
+    ResponseEntity<CheckInImageParam> addImage(
+            @Parameter(hidden = true) MemberClaims memberClaims,
+            @PathVariable Long checkInId,
+            @Valid @RequestBody AddCheckInImageRequest request
+    );
+
+    @Operation(summary = "직관 기록 이미지 삭제", description = "직관 기록의 특정 이미지를 삭제합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "이미지 삭제 성공"),
+            @ApiResponse(responseCode = "404", description = "직관 기록, 회원 또는 이미지를 찾을 수 없음")
+    })
+    @DeleteMapping("/{checkInId}/images/{imageId}")
+    ResponseEntity<Void> deleteImage(
+            @Parameter(hidden = true) MemberClaims memberClaims,
+            @PathVariable Long checkInId,
+            @PathVariable Long imageId
     );
 }

--- a/backend/app/src/main/java/com/yagubogu/checkin/domain/CheckIn.java
+++ b/backend/app/src/main/java/com/yagubogu/checkin/domain/CheckIn.java
@@ -43,15 +43,15 @@ public class CheckIn extends BaseEntity {
     @Column(name = "memo", columnDefinition = "TEXT")
     private String memo;
 
-    @Column(name = "image_url", length = 500)
-    private String imageUrl;
-
     public CheckIn(final Game game, final Member member, final Team team, final CheckInType checkInType, final String memo, final String imageUrl) {
         this.game = game;
         this.member = member;
         this.team = team;
         this.checkInType = checkInType;
         this.memo = memo;
-        this.imageUrl = imageUrl;
+    }
+
+    public void updateMemo(final String memo) {
+        this.memo = memo;
     }
 }

--- a/backend/app/src/main/java/com/yagubogu/checkin/domain/CheckIn.java
+++ b/backend/app/src/main/java/com/yagubogu/checkin/domain/CheckIn.java
@@ -4,18 +4,7 @@ import com.yagubogu.game.domain.Game;
 import com.yagubogu.global.domain.BaseEntity;
 import com.yagubogu.member.domain.Member;
 import com.yagubogu.team.domain.Team;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
-import jakarta.persistence.UniqueConstraint;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -51,10 +40,18 @@ public class CheckIn extends BaseEntity {
     @Column(name = "check_in_type", nullable = false)
     private CheckInType checkInType;
 
-    public CheckIn(final Game game, final Member member, final Team team, final CheckInType checkInType) {
+    @Column(name = "memo", columnDefinition = "TEXT")
+    private String memo;
+
+    @Column(name = "image_url", length = 500)
+    private String imageUrl;
+
+    public CheckIn(final Game game, final Member member, final Team team, final CheckInType checkInType, final String memo, final String imageUrl) {
         this.game = game;
         this.member = member;
         this.team = team;
         this.checkInType = checkInType;
+        this.memo = memo;
+        this.imageUrl = imageUrl;
     }
 }

--- a/backend/app/src/main/java/com/yagubogu/checkin/domain/CheckInImage.java
+++ b/backend/app/src/main/java/com/yagubogu/checkin/domain/CheckInImage.java
@@ -1,0 +1,39 @@
+package com.yagubogu.checkin.domain;
+
+import com.yagubogu.global.domain.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Table(name = "check_in_images")
+@Entity
+public class CheckInImage extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "check_in_images_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "check_in_id", nullable = false)
+    private CheckIn checkIn;
+
+    @Column(name = "image_url", nullable = false, length = 500)
+    private String imageUrl;
+
+    public CheckInImage(final CheckIn checkIn, final String imageUrl) {
+        this.checkIn = checkIn;
+        this.imageUrl = imageUrl;
+    }
+}

--- a/backend/app/src/main/java/com/yagubogu/checkin/dto/CheckInGameParam.java
+++ b/backend/app/src/main/java/com/yagubogu/checkin/dto/CheckInGameParam.java
@@ -2,6 +2,7 @@ package com.yagubogu.checkin.dto;
 
 import com.yagubogu.game.domain.ScoreBoard;
 import java.time.LocalDate;
+import java.util.List;
 
 public record CheckInGameParam(
         Long checkInId,
@@ -10,7 +11,21 @@ public record CheckInGameParam(
         CheckInGameTeamParam awayTeam,
         LocalDate attendanceDate,
         ScoreBoard homeScoreBoard,
-        ScoreBoard awayScoreBoard
+        ScoreBoard awayScoreBoard,
+        String memo,
+        List<String> imageUrls
 ) {
+    public CheckInGameParam(
+            Long checkInId,
+            String stadiumFullName,
+            CheckInGameTeamParam homeTeam,
+            CheckInGameTeamParam awayTeam,
+            LocalDate attendanceDate,
+            ScoreBoard homeScoreBoard,
+            ScoreBoard awayScoreBoard,
+            String memo
+    ) {
+        this(checkInId, stadiumFullName, homeTeam, awayTeam, attendanceDate, homeScoreBoard, awayScoreBoard, memo, List.of());
+    }
 }
 

--- a/backend/app/src/main/java/com/yagubogu/checkin/dto/v1/AddCheckInImageRequest.java
+++ b/backend/app/src/main/java/com/yagubogu/checkin/dto/v1/AddCheckInImageRequest.java
@@ -1,0 +1,8 @@
+package com.yagubogu.checkin.dto.v1;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record AddCheckInImageRequest(
+        @NotBlank String imageKey
+) {
+}

--- a/backend/app/src/main/java/com/yagubogu/checkin/dto/v1/CheckInImageParam.java
+++ b/backend/app/src/main/java/com/yagubogu/checkin/dto/v1/CheckInImageParam.java
@@ -1,0 +1,7 @@
+package com.yagubogu.checkin.dto.v1;
+
+public record CheckInImageParam(
+        Long imageId,
+        String imageUrl
+) {
+}

--- a/backend/app/src/main/java/com/yagubogu/checkin/dto/v1/CheckInImagesResponse.java
+++ b/backend/app/src/main/java/com/yagubogu/checkin/dto/v1/CheckInImagesResponse.java
@@ -1,0 +1,8 @@
+package com.yagubogu.checkin.dto.v1;
+
+import java.util.List;
+
+public record CheckInImagesResponse(
+        List<CheckInImageParam> images
+) {
+}

--- a/backend/app/src/main/java/com/yagubogu/checkin/dto/v1/CheckInMemoResponse.java
+++ b/backend/app/src/main/java/com/yagubogu/checkin/dto/v1/CheckInMemoResponse.java
@@ -1,0 +1,6 @@
+package com.yagubogu.checkin.dto.v1;
+
+public record CheckInMemoResponse(
+        String memo
+) {
+}

--- a/backend/app/src/main/java/com/yagubogu/checkin/dto/v1/CreateCheckInRequest.java
+++ b/backend/app/src/main/java/com/yagubogu/checkin/dto/v1/CreateCheckInRequest.java
@@ -1,10 +1,6 @@
 package com.yagubogu.checkin.dto.v1;
 
-import jakarta.validation.constraints.Size;
-
 public record CreateCheckInRequest(
-        long gameId,
-        @Size(max = 500) String memo,
-        String imageKey
+        long gameId
 ) {
 }

--- a/backend/app/src/main/java/com/yagubogu/checkin/dto/v1/CreateCheckInRequest.java
+++ b/backend/app/src/main/java/com/yagubogu/checkin/dto/v1/CreateCheckInRequest.java
@@ -1,6 +1,10 @@
 package com.yagubogu.checkin.dto.v1;
 
+import jakarta.validation.constraints.Size;
+
 public record CreateCheckInRequest(
-        long gameId
+        long gameId,
+        @Size(max = 500) String memo,
+        String imageKey
 ) {
 }

--- a/backend/app/src/main/java/com/yagubogu/checkin/dto/v1/UpdateCheckInMemoRequest.java
+++ b/backend/app/src/main/java/com/yagubogu/checkin/dto/v1/UpdateCheckInMemoRequest.java
@@ -1,0 +1,8 @@
+package com.yagubogu.checkin.dto.v1;
+
+import jakarta.validation.constraints.Size;
+
+public record UpdateCheckInMemoRequest(
+        @Size(max = 500) String memo
+) {
+}

--- a/backend/app/src/main/java/com/yagubogu/checkin/repository/CheckInImageRepository.java
+++ b/backend/app/src/main/java/com/yagubogu/checkin/repository/CheckInImageRepository.java
@@ -1,0 +1,14 @@
+package com.yagubogu.checkin.repository;
+
+import com.yagubogu.checkin.domain.CheckInImage;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CheckInImageRepository extends JpaRepository<CheckInImage, Long> {
+
+    List<CheckInImage> findByCheckInId(Long checkInId);
+
+    List<CheckInImage> findByCheckInIdIn(List<Long> checkInIds);
+}

--- a/backend/app/src/main/java/com/yagubogu/checkin/repository/CustomCheckInRepositoryImpl.java
+++ b/backend/app/src/main/java/com/yagubogu/checkin/repository/CustomCheckInRepositoryImpl.java
@@ -259,7 +259,8 @@ public class CustomCheckInRepositoryImpl implements CustomCheckInRepository {
                         awayTeamResp(GAME, away, team),
                         GAME.date,
                         GAME.homeScoreBoard,
-                        GAME.awayScoreBoard
+                        GAME.awayScoreBoard,
+                        CHECK_IN.memo
                 )).from(CHECK_IN)
                 .join(CHECK_IN.game, GAME)
                 .join(GAME.stadium, STADIUM)

--- a/backend/app/src/main/java/com/yagubogu/checkin/service/CheckInImageService.java
+++ b/backend/app/src/main/java/com/yagubogu/checkin/service/CheckInImageService.java
@@ -1,0 +1,50 @@
+package com.yagubogu.checkin.service;
+
+import com.yagubogu.global.config.S3Properties;
+import com.yagubogu.global.exception.PayloadTooLargeException;
+import com.yagubogu.global.exception.UnsupportedMediaTypeException;
+import com.yagubogu.member.dto.v1.PreSignedUrlStartRequest;
+import com.yagubogu.member.dto.v1.PresignedUrlStartResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
+
+import java.util.Set;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class CheckInImageService {
+
+    private static final long MAX_FILE_SIZE = 5 * 1024 * 1024;
+    private static final String PATH_PREFIX = "images/check-ins/";
+    private static final Set<String> ALLOWED_CONTENT_TYPES = Set.of("image/jpeg", "image/jpg", "image/png");
+    private final S3Properties s3Properties;
+    private final S3Presigner s3Presigner;
+
+    public PresignedUrlStartResponse issuePresignedUrl(PreSignedUrlStartRequest request) {
+        if (request.contentLength() > MAX_FILE_SIZE) {
+            throw new PayloadTooLargeException("Check-in image is too large");
+        }
+        if (!ALLOWED_CONTENT_TYPES.contains(request.contentType())) {
+            throw new UnsupportedMediaTypeException("Check-in image content type not supported");
+        }
+
+        String key = PATH_PREFIX + UUID.randomUUID();
+
+        PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+                .bucket(s3Properties.bucket())
+                .key(key)
+                .contentType(request.contentType())
+                .contentLength(request.contentLength())
+                .build();
+
+        PresignedPutObjectRequest presignedPutObjectRequest = s3Presigner.presignPutObject(b -> b
+                .signatureDuration(s3Properties.presignExpiration())
+                .putObjectRequest(putObjectRequest));
+
+        return new PresignedUrlStartResponse(key, presignedPutObjectRequest.url().toString());
+    }
+}

--- a/backend/app/src/main/java/com/yagubogu/checkin/service/CheckInService.java
+++ b/backend/app/src/main/java/com/yagubogu/checkin/service/CheckInService.java
@@ -4,22 +4,14 @@ import com.yagubogu.checkin.domain.CheckIn;
 import com.yagubogu.checkin.domain.CheckInOrderFilter;
 import com.yagubogu.checkin.domain.CheckInResultFilter;
 import com.yagubogu.checkin.domain.CheckInType;
-import com.yagubogu.checkin.dto.CheckInGameParam;
-import com.yagubogu.checkin.dto.FanRateByGameParam;
-import com.yagubogu.checkin.dto.FanRateGameParam;
-import com.yagubogu.checkin.dto.GameWithFanCountsParam;
-import com.yagubogu.checkin.dto.StadiumCheckInCountParam;
+import com.yagubogu.checkin.dto.*;
 import com.yagubogu.checkin.dto.event.CheckInEvent;
 import com.yagubogu.checkin.dto.event.StadiumVisitEvent;
-import com.yagubogu.checkin.dto.v1.CheckInCountsResponse;
-import com.yagubogu.checkin.dto.v1.CheckInHistoryResponse;
-import com.yagubogu.checkin.dto.v1.CheckInStatusResponse;
-import com.yagubogu.checkin.dto.v1.CreateCheckInRequest;
-import com.yagubogu.checkin.dto.v1.FanRateResponse;
-import com.yagubogu.checkin.dto.v1.StadiumCheckInCountsResponse;
+import com.yagubogu.checkin.dto.v1.*;
 import com.yagubogu.checkin.repository.CheckInRepository;
 import com.yagubogu.game.domain.Game;
 import com.yagubogu.game.repository.GameRepository;
+import com.yagubogu.global.config.S3Properties;
 import com.yagubogu.global.exception.ConflictException;
 import com.yagubogu.global.exception.ForbiddenException;
 import com.yagubogu.global.exception.NotFoundException;
@@ -28,14 +20,17 @@ import com.yagubogu.member.repository.MemberRepository;
 import com.yagubogu.sse.dto.GameWithFanRateParam;
 import com.yagubogu.sse.dto.event.CheckInCreatedEvent;
 import com.yagubogu.team.domain.Team;
-import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
 
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -48,6 +43,8 @@ public class CheckInService {
     private final MemberRepository memberRepository;
     private final GameRepository gameRepository;
     private final ApplicationEventPublisher applicationEventPublisher;
+    private final S3Client s3Client;
+    private final S3Properties s3Properties;
 
     @Transactional
     public void createCheckIn(final Long memberId, final CreateCheckInRequest request) {
@@ -56,7 +53,8 @@ public class CheckInService {
         Team team = member.getTeam();
 
         validateNotExistGameAndMember(game, member);
-        saveCheckInSafely(game, member, team);
+        String imageUrl = resolveImageUrl(request.imageKey());
+        saveCheckInSafely(game, member, team, request.memo(), imageUrl);
 
         applicationEventPublisher.publishEvent(new CheckInEvent(member));
         applicationEventPublisher.publishEvent(new StadiumVisitEvent(member, game.getStadium().getId()));
@@ -167,8 +165,8 @@ public class CheckInService {
         return result;
     }
 
-    private void saveCheckInSafely(final Game game, final Member member, final Team team) {
-        CheckIn checkIn = new CheckIn(game, member, team, CheckInType.LOCATION_CHECK_IN);
+    private void saveCheckInSafely(final Game game, final Member member, final Team team, final String memo, final String imageUrl) {
+        CheckIn checkIn = new CheckIn(game, member, team, CheckInType.LOCATION_CHECK_IN, memo, imageUrl);
         try {
             checkInRepository.save(checkIn);
         } catch (DataIntegrityViolationException e) {
@@ -206,5 +204,21 @@ public class CheckInService {
         }
 
         return Math.round(((double) checkInCounts / total) * 1000) / ROUND_FACTOR;
+    }
+
+    private String resolveImageUrl(final String imageKey) {
+        if (imageKey == null) {
+            return null;
+        }
+        assertObjectExists(imageKey);
+        return s3Properties.endpoint() + "/" + s3Properties.bucket() + "/" + imageKey;
+    }
+
+    private void assertObjectExists(final String key) {
+        try {
+            s3Client.headObject(r -> r.bucket(s3Properties.bucket()).key(key));
+        } catch (NoSuchKeyException e) {
+            throw new NotFoundException("File does not exist in S3: " + key);
+        }
     }
 }

--- a/backend/app/src/main/java/com/yagubogu/checkin/service/CheckInService.java
+++ b/backend/app/src/main/java/com/yagubogu/checkin/service/CheckInService.java
@@ -1,6 +1,7 @@
 package com.yagubogu.checkin.service;
 
 import com.yagubogu.checkin.domain.CheckIn;
+import com.yagubogu.checkin.domain.CheckInImage;
 import com.yagubogu.checkin.domain.CheckInOrderFilter;
 import com.yagubogu.checkin.domain.CheckInResultFilter;
 import com.yagubogu.checkin.domain.CheckInType;
@@ -8,6 +9,7 @@ import com.yagubogu.checkin.dto.*;
 import com.yagubogu.checkin.dto.event.CheckInEvent;
 import com.yagubogu.checkin.dto.event.StadiumVisitEvent;
 import com.yagubogu.checkin.dto.v1.*;
+import com.yagubogu.checkin.repository.CheckInImageRepository;
 import com.yagubogu.checkin.repository.CheckInRepository;
 import com.yagubogu.game.domain.Game;
 import com.yagubogu.game.repository.GameRepository;
@@ -31,6 +33,8 @@ import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -40,6 +44,7 @@ public class CheckInService {
     private static final double ROUND_FACTOR = 10.0;
 
     private final CheckInRepository checkInRepository;
+    private final CheckInImageRepository checkInImageRepository;
     private final MemberRepository memberRepository;
     private final GameRepository gameRepository;
     private final ApplicationEventPublisher applicationEventPublisher;
@@ -53,8 +58,7 @@ public class CheckInService {
         Team team = member.getTeam();
 
         validateNotExistGameAndMember(game, member);
-        String imageUrl = resolveImageUrl(request.imageKey());
-        saveCheckInSafely(game, member, team, request.memo(), imageUrl);
+        saveCheckInSafely(game, member, team);
 
         applicationEventPublisher.publishEvent(new CheckInEvent(member));
         applicationEventPublisher.publishEvent(new StadiumVisitEvent(member, game.getStadium().getId()));
@@ -75,6 +79,54 @@ public class CheckInService {
         if (!checkIn.getMember().getId().equals(memberId)) {
             throw new ForbiddenException("Only your own check-in can be deleted");
         }
+    }
+
+    @Transactional
+    public void updateMemo(final Long memberId, final Long checkInId, final String memo) {
+        Member member = getMember(memberId);
+        CheckIn checkIn = getCheckInByIdAndMember(checkInId, member);
+        checkIn.updateMemo(memo);
+    }
+
+    @Transactional
+    public void deleteMemo(final Long memberId, final Long checkInId) {
+        Member member = getMember(memberId);
+        CheckIn checkIn = getCheckInByIdAndMember(checkInId, member);
+        checkIn.updateMemo(null);
+    }
+
+    public CheckInMemoResponse getMemo(final Long memberId, final Long checkInId) {
+        Member member = getMember(memberId);
+        CheckIn checkIn = getCheckInByIdAndMember(checkInId, member);
+        return new CheckInMemoResponse(checkIn.getMemo());
+    }
+
+    @Transactional
+    public CheckInImageParam addImage(final Long memberId, final Long checkInId, final String imageKey) {
+        Member member = getMember(memberId);
+        CheckIn checkIn = getCheckInByIdAndMember(checkInId, member);
+        String imageUrl = resolveImageUrl(imageKey);
+        CheckInImage image = checkInImageRepository.save(new CheckInImage(checkIn, imageUrl));
+        return new CheckInImageParam(image.getId(), image.getImageUrl());
+    }
+
+    @Transactional
+    public void deleteImage(final Long memberId, final Long checkInId, final Long imageId) {
+        Member member = getMember(memberId);
+        getCheckInByIdAndMember(checkInId, member);
+        CheckInImage image = checkInImageRepository.findById(imageId)
+                .filter(img -> img.getCheckIn().getId().equals(checkInId))
+                .orElseThrow(() -> new NotFoundException("CheckInImage is not found"));
+        checkInImageRepository.delete(image);
+    }
+
+    public CheckInImagesResponse getImages(final Long memberId, final Long checkInId) {
+        Member member = getMember(memberId);
+        getCheckInByIdAndMember(checkInId, member);
+        List<CheckInImageParam> images = checkInImageRepository.findByCheckInId(checkInId).stream()
+                .map(img -> new CheckInImageParam(img.getId(), img.getImageUrl()))
+                .toList();
+        return new CheckInImagesResponse(images);
     }
 
     public FanRateResponse findFanRatesByGames(final long memberId, final LocalDate date) {
@@ -116,22 +168,31 @@ public class CheckInService {
         Member member = getMember(memberId);
         Team team = member.getTeam();
         List<CheckInGameParam> checkIns = checkInRepository.findCheckInHistory(
-                member,
-                team,
-                year,
-                month,
-                resultFilter,
-                orderFilter
+                member, team, year, month, resultFilter, orderFilter
         );
 
-        return new CheckInHistoryResponse(checkIns);
-    }
+        List<Long> checkInIds = checkIns.stream().map(CheckInGameParam::checkInId).toList();
+        Map<Long, List<String>> imageUrlsByCheckInId = checkInImageRepository.findByCheckInIdIn(checkInIds)
+                .stream()
+                .collect(Collectors.groupingBy(
+                        img -> img.getCheckIn().getId(),
+                        Collectors.mapping(CheckInImage::getImageUrl, Collectors.toList())
+                ));
 
+        List<CheckInGameParam> enriched = checkIns.stream()
+                .map(p -> new CheckInGameParam(
+                        p.checkInId(), p.stadiumFullName(), p.homeTeam(), p.awayTeam(),
+                        p.attendanceDate(), p.homeScoreBoard(), p.awayScoreBoard(),
+                        p.memo(), imageUrlsByCheckInId.getOrDefault(p.checkInId(), List.of())
+                ))
+                .toList();
+
+        return new CheckInHistoryResponse(enriched);
+    }
 
     public StadiumCheckInCountsResponse findStadiumCheckInCounts(final long memberId, final Integer year) {
         Member member = getMember(memberId);
-        List<StadiumCheckInCountParam> stadiumCheckInCounts = checkInRepository.findStadiumCheckInCounts(member,
-                year);
+        List<StadiumCheckInCountParam> stadiumCheckInCounts = checkInRepository.findStadiumCheckInCounts(member, year);
 
         return new StadiumCheckInCountsResponse(stadiumCheckInCounts);
     }
@@ -139,9 +200,7 @@ public class CheckInService {
     public CheckInStatusResponse findLocationCheckInStatus(final long memberId, final LocalDate date) {
         Member member = getMember(memberId);
         boolean isCheckIn = checkInRepository.existsByMemberAndGameDateAndCheckInType(
-                member,
-                date,
-                CheckInType.LOCATION_CHECK_IN
+                member, date, CheckInType.LOCATION_CHECK_IN
         );
 
         return new CheckInStatusResponse(isCheckIn);
@@ -165,8 +224,8 @@ public class CheckInService {
         return result;
     }
 
-    private void saveCheckInSafely(final Game game, final Member member, final Team team, final String memo, final String imageUrl) {
-        CheckIn checkIn = new CheckIn(game, member, team, CheckInType.LOCATION_CHECK_IN, memo, imageUrl);
+    private void saveCheckInSafely(final Game game, final Member member, final Team team) {
+        CheckIn checkIn = new CheckIn(game, member, team, CheckInType.LOCATION_CHECK_IN, null, null);
         try {
             checkInRepository.save(checkIn);
         } catch (DataIntegrityViolationException e) {
@@ -178,6 +237,15 @@ public class CheckInService {
         if (checkInRepository.existsByGameAndMember(game, member)) {
             throw new ConflictException("CheckIn is already exists");
         }
+    }
+
+    private CheckIn getCheckInByIdAndMember(final Long checkInId, final Member member) {
+        CheckIn checkIn = checkInRepository.findById(checkInId)
+                .orElseThrow(() -> new NotFoundException("CheckIn is not found"));
+        if (!checkIn.getMember().equals(member)) {
+            throw new NotFoundException("CheckIn is not found");
+        }
+        return checkIn;
     }
 
     private Game getGameById(final long gameId) {
@@ -207,9 +275,6 @@ public class CheckInService {
     }
 
     private String resolveImageUrl(final String imageKey) {
-        if (imageKey == null) {
-            return null;
-        }
         assertObjectExists(imageKey);
         return s3Properties.endpoint() + "/" + s3Properties.bucket() + "/" + imageKey;
     }

--- a/backend/app/src/main/java/com/yagubogu/checkin/service/PastCheckInService.java
+++ b/backend/app/src/main/java/com/yagubogu/checkin/service/PastCheckInService.java
@@ -32,7 +32,7 @@ public class PastCheckInService {
 
         validateCheckInNotExists(member, game);
 
-        CheckIn pastCheckIn = new CheckIn(game, member, team, CheckInType.NON_LOCATION_CHECK_IN);
+        CheckIn pastCheckIn = new CheckIn(game, member, team, CheckInType.NON_LOCATION_CHECK_IN, null, null);
         checkInRepository.save(pastCheckIn);
     }
 

--- a/backend/app/src/main/resources/db/migration/mysql/V12__add_memo_image_to_check_ins.sql
+++ b/backend/app/src/main/resources/db/migration/mysql/V12__add_memo_image_to_check_ins.sql
@@ -1,3 +1,13 @@
 -- V12__add_memo_image_to_check_ins.sql
 ALTER TABLE check_ins ADD COLUMN memo TEXT NULL;
-ALTER TABLE check_ins ADD COLUMN image_url VARCHAR(500) NULL;
+
+CREATE TABLE check_in_images
+(
+    check_in_images_id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    check_in_id        BIGINT       NOT NULL,
+    image_url          VARCHAR(500) NOT NULL,
+    created_at         DATETIME(6)  NULL,
+    updated_at         DATETIME(6)  NULL,
+    deleted_at         DATETIME(6)  NULL,
+    CONSTRAINT fk_check_in_images_check_in FOREIGN KEY (check_in_id) REFERENCES check_ins (check_ins_id)
+);

--- a/backend/app/src/main/resources/db/migration/mysql/V12__add_memo_image_to_check_ins.sql
+++ b/backend/app/src/main/resources/db/migration/mysql/V12__add_memo_image_to_check_ins.sql
@@ -1,0 +1,3 @@
+-- V12__add_memo_image_to_check_ins.sql
+ALTER TABLE check_ins ADD COLUMN memo TEXT NULL;
+ALTER TABLE check_ins ADD COLUMN image_url VARCHAR(500) NULL;

--- a/backend/app/src/main/resources/db/migration/mysql/V13__add_memo_image_to_check_ins.sql
+++ b/backend/app/src/main/resources/db/migration/mysql/V13__add_memo_image_to_check_ins.sql
@@ -1,4 +1,4 @@
--- V12__add_memo_image_to_check_ins.sql
+-- V13__add_memo_image_to_check_ins.sql
 ALTER TABLE check_ins ADD COLUMN memo TEXT NULL;
 
 CREATE TABLE check_in_images

--- a/backend/app/src/test/java/com/yagubogu/checkin/CheckInE2eTest.java
+++ b/backend/app/src/test/java/com/yagubogu/checkin/CheckInE2eTest.java
@@ -102,7 +102,7 @@ public class CheckInE2eTest extends E2eTestBase {
         RestAssured.given().log().all()
                 .contentType(ContentType.JSON)
                 .header(HttpHeaders.AUTHORIZATION, accessToken)
-                .body(new CreateCheckInRequest(game.getId()))
+                .body(new CreateCheckInRequest(game.getId(), null, null))
                 .when().post("/api/v1/check-ins")
                 .then().log().all()
                 .statusCode(201);
@@ -121,7 +121,7 @@ public class CheckInE2eTest extends E2eTestBase {
         RestAssured.given().log().all()
                 .contentType(ContentType.JSON)
                 .header(HttpHeaders.AUTHORIZATION, accessToken)
-                .body(new CreateCheckInRequest(invalidGameId))
+                .body(new CreateCheckInRequest(invalidGameId, null, null))
                 .when().post("/api/v1/check-ins")
                 .then().log().all()
                 .statusCode(404);
@@ -144,7 +144,7 @@ public class CheckInE2eTest extends E2eTestBase {
         RestAssured.given().log().all()
                 .contentType(ContentType.JSON)
                 .header(HttpHeaders.AUTHORIZATION, accessToken)
-                .body(new CreateCheckInRequest(game.getId()))
+                .body(new CreateCheckInRequest(game.getId(), null, null))
                 .when().post("/api/v1/check-ins")
                 .then().log().all()
                 .statusCode(201);
@@ -153,10 +153,84 @@ public class CheckInE2eTest extends E2eTestBase {
         RestAssured.given().log().all()
                 .contentType(ContentType.JSON)
                 .header(HttpHeaders.AUTHORIZATION, accessToken)
-                .body(new CreateCheckInRequest(game.getId()))
+                .body(new CreateCheckInRequest(game.getId(), null, null))
                 .when().post("/api/v1/check-ins")
                 .then().log().all()
                 .statusCode(409);
+    }
+
+    @DisplayName("메모와 함께 인증을 저장한다")
+    @Test
+    void createCheckIn_withMemo() {
+        // given
+        Member fora = memberFactory.save(b -> b.team(kia));
+        String accessToken = authFactory.getAccessTokenByMemberId(fora.getId(), Role.USER);
+
+        LocalDate date = LocalDate.of(2025, 7, 28);
+        Game game = gameFactory.save(builder ->
+                builder.stadium(stadiumJamsil)
+                        .date(date)
+                        .homeTeam(kt).homeScore(10).homeScoreBoard(TestFixture.getHomeScoreBoard())
+                        .awayTeam(kia).awayScore(1).awayScoreBoard(TestFixture.getAwayScoreBoard()));
+
+        // when & then
+        RestAssured.given().log().all()
+                .contentType(ContentType.JSON)
+                .header(HttpHeaders.AUTHORIZATION, accessToken)
+                .body(new CreateCheckInRequest(game.getId(), "오늘 직관 너무 좋았다!", null))
+                .when().post("/api/v1/check-ins")
+                .then().log().all()
+                .statusCode(201);
+    }
+
+    @DisplayName("메모 없이 인증을 저장한다")
+    @Test
+    void createCheckIn_withoutMemo() {
+        // given
+        Member fora = memberFactory.save(b -> b.team(kia));
+        String accessToken = authFactory.getAccessTokenByMemberId(fora.getId(), Role.USER);
+
+        LocalDate date = LocalDate.of(2025, 7, 29);
+        Game game = gameFactory.save(builder ->
+                builder.stadium(stadiumJamsil)
+                        .date(date)
+                        .homeTeam(kt).homeScore(10).homeScoreBoard(TestFixture.getHomeScoreBoard())
+                        .awayTeam(kia).awayScore(1).awayScoreBoard(TestFixture.getAwayScoreBoard()));
+
+        // when & then
+        RestAssured.given().log().all()
+                .contentType(ContentType.JSON)
+                .header(HttpHeaders.AUTHORIZATION, accessToken)
+                .body(new CreateCheckInRequest(game.getId(), null, null))
+                .when().post("/api/v1/check-ins")
+                .then().log().all()
+                .statusCode(201);
+    }
+
+    @DisplayName("예외: 메모가 500자를 초과하면 예외가 발생한다")
+    @Test
+    void createCheckIn_memoTooLong() {
+        // given
+        Member fora = memberFactory.save(b -> b.team(kia));
+        String accessToken = authFactory.getAccessTokenByMemberId(fora.getId(), Role.USER);
+
+        LocalDate date = LocalDate.of(2025, 7, 30);
+        Game game = gameFactory.save(builder ->
+                builder.stadium(stadiumJamsil)
+                        .date(date)
+                        .homeTeam(kt).homeScore(10).homeScoreBoard(TestFixture.getHomeScoreBoard())
+                        .awayTeam(kia).awayScore(1).awayScoreBoard(TestFixture.getAwayScoreBoard()));
+
+        String longMemo = "a".repeat(501);
+
+        // when & then
+        RestAssured.given().log().all()
+                .contentType(ContentType.JSON)
+                .header(HttpHeaders.AUTHORIZATION, accessToken)
+                .body(new CreateCheckInRequest(game.getId(), longMemo, null))
+                .when().post("/api/v1/check-ins")
+                .then().log().all()
+                .statusCode(400);
     }
 
     @DisplayName("회원의 총 인증 횟수를 조회한다")

--- a/backend/app/src/test/java/com/yagubogu/checkin/CheckInE2eTest.java
+++ b/backend/app/src/test/java/com/yagubogu/checkin/CheckInE2eTest.java
@@ -8,6 +8,8 @@ import com.yagubogu.checkin.domain.CheckInResultFilter;
 import com.yagubogu.checkin.dto.StadiumCheckInCountParam;
 import com.yagubogu.checkin.dto.v1.CheckInCountsResponse;
 import com.yagubogu.checkin.dto.v1.CheckInHistoryResponse;
+import com.yagubogu.checkin.dto.v1.CheckInImagesResponse;
+import com.yagubogu.checkin.dto.v1.CheckInMemoResponse;
 import com.yagubogu.checkin.dto.v1.CheckInStatusResponse;
 import com.yagubogu.checkin.dto.v1.CreateCheckInRequest;
 import com.yagubogu.checkin.dto.v1.StadiumCheckInCountsResponse;
@@ -102,7 +104,7 @@ public class CheckInE2eTest extends E2eTestBase {
         RestAssured.given().log().all()
                 .contentType(ContentType.JSON)
                 .header(HttpHeaders.AUTHORIZATION, accessToken)
-                .body(new CreateCheckInRequest(game.getId(), null, null))
+                .body(new CreateCheckInRequest(game.getId()))
                 .when().post("/api/v1/check-ins")
                 .then().log().all()
                 .statusCode(201);
@@ -121,7 +123,7 @@ public class CheckInE2eTest extends E2eTestBase {
         RestAssured.given().log().all()
                 .contentType(ContentType.JSON)
                 .header(HttpHeaders.AUTHORIZATION, accessToken)
-                .body(new CreateCheckInRequest(invalidGameId, null, null))
+                .body(new CreateCheckInRequest(invalidGameId))
                 .when().post("/api/v1/check-ins")
                 .then().log().all()
                 .statusCode(404);
@@ -144,7 +146,7 @@ public class CheckInE2eTest extends E2eTestBase {
         RestAssured.given().log().all()
                 .contentType(ContentType.JSON)
                 .header(HttpHeaders.AUTHORIZATION, accessToken)
-                .body(new CreateCheckInRequest(game.getId(), null, null))
+                .body(new CreateCheckInRequest(game.getId()))
                 .when().post("/api/v1/check-ins")
                 .then().log().all()
                 .statusCode(201);
@@ -153,15 +155,15 @@ public class CheckInE2eTest extends E2eTestBase {
         RestAssured.given().log().all()
                 .contentType(ContentType.JSON)
                 .header(HttpHeaders.AUTHORIZATION, accessToken)
-                .body(new CreateCheckInRequest(game.getId(), null, null))
+                .body(new CreateCheckInRequest(game.getId()))
                 .when().post("/api/v1/check-ins")
                 .then().log().all()
                 .statusCode(409);
     }
 
-    @DisplayName("메모와 함께 인증을 저장한다")
+    @DisplayName("직관 기록에 메모를 추가/수정한다")
     @Test
-    void createCheckIn_withMemo() {
+    void updateMemo() {
         // given
         Member fora = memberFactory.save(b -> b.team(kia));
         String accessToken = authFactory.getAccessTokenByMemberId(fora.getId(), Role.USER);
@@ -172,20 +174,21 @@ public class CheckInE2eTest extends E2eTestBase {
                         .date(date)
                         .homeTeam(kt).homeScore(10).homeScoreBoard(TestFixture.getHomeScoreBoard())
                         .awayTeam(kia).awayScore(1).awayScoreBoard(TestFixture.getAwayScoreBoard()));
+        com.yagubogu.checkin.domain.CheckIn checkIn = checkInFactory.save(b -> b.game(game).team(kia).member(fora));
 
         // when & then
         RestAssured.given().log().all()
                 .contentType(ContentType.JSON)
                 .header(HttpHeaders.AUTHORIZATION, accessToken)
-                .body(new CreateCheckInRequest(game.getId(), "오늘 직관 너무 좋았다!", null))
-                .when().post("/api/v1/check-ins")
+                .body(new com.yagubogu.checkin.dto.v1.UpdateCheckInMemoRequest("오늘 직관 너무 좋았다!"))
+                .when().put("/api/v1/check-ins/" + checkIn.getId() + "/memo")
                 .then().log().all()
-                .statusCode(201);
+                .statusCode(200);
     }
 
-    @DisplayName("메모 없이 인증을 저장한다")
+    @DisplayName("예외: 메모가 500자를 초과하면 예외가 발생한다")
     @Test
-    void createCheckIn_withoutMemo() {
+    void updateMemo_tooLong() {
         // given
         Member fora = memberFactory.save(b -> b.team(kia));
         String accessToken = authFactory.getAccessTokenByMemberId(fora.getId(), Role.USER);
@@ -196,20 +199,21 @@ public class CheckInE2eTest extends E2eTestBase {
                         .date(date)
                         .homeTeam(kt).homeScore(10).homeScoreBoard(TestFixture.getHomeScoreBoard())
                         .awayTeam(kia).awayScore(1).awayScoreBoard(TestFixture.getAwayScoreBoard()));
+        com.yagubogu.checkin.domain.CheckIn checkIn = checkInFactory.save(b -> b.game(game).team(kia).member(fora));
 
         // when & then
         RestAssured.given().log().all()
                 .contentType(ContentType.JSON)
                 .header(HttpHeaders.AUTHORIZATION, accessToken)
-                .body(new CreateCheckInRequest(game.getId(), null, null))
-                .when().post("/api/v1/check-ins")
+                .body(new com.yagubogu.checkin.dto.v1.UpdateCheckInMemoRequest("a".repeat(501)))
+                .when().put("/api/v1/check-ins/" + checkIn.getId() + "/memo")
                 .then().log().all()
-                .statusCode(201);
+                .statusCode(400);
     }
 
-    @DisplayName("예외: 메모가 500자를 초과하면 예외가 발생한다")
+    @DisplayName("직관 기록의 메모를 삭제한다")
     @Test
-    void createCheckIn_memoTooLong() {
+    void deleteMemo() {
         // given
         Member fora = memberFactory.save(b -> b.team(kia));
         String accessToken = authFactory.getAccessTokenByMemberId(fora.getId(), Role.USER);
@@ -220,17 +224,66 @@ public class CheckInE2eTest extends E2eTestBase {
                         .date(date)
                         .homeTeam(kt).homeScore(10).homeScoreBoard(TestFixture.getHomeScoreBoard())
                         .awayTeam(kia).awayScore(1).awayScoreBoard(TestFixture.getAwayScoreBoard()));
-
-        String longMemo = "a".repeat(501);
+        com.yagubogu.checkin.domain.CheckIn checkIn = checkInFactory.save(b -> b.game(game).team(kia).member(fora));
 
         // when & then
         RestAssured.given().log().all()
                 .contentType(ContentType.JSON)
                 .header(HttpHeaders.AUTHORIZATION, accessToken)
-                .body(new CreateCheckInRequest(game.getId(), longMemo, null))
-                .when().post("/api/v1/check-ins")
+                .when().delete("/api/v1/check-ins/" + checkIn.getId() + "/memo")
                 .then().log().all()
-                .statusCode(400);
+                .statusCode(204);
+    }
+
+    @DisplayName("예외: 다른 회원의 직관 기록 메모는 수정할 수 없다")
+    @Test
+    void updateMemo_otherMember() {
+        // given
+        Member fora = memberFactory.save(b -> b.team(kia));
+        Member other = memberFactory.save(b -> b.team(kt));
+        String accessToken = authFactory.getAccessTokenByMemberId(other.getId(), Role.USER);
+
+        LocalDate date = LocalDate.of(2025, 7, 31);
+        Game game = gameFactory.save(builder ->
+                builder.stadium(stadiumJamsil)
+                        .date(date)
+                        .homeTeam(kt).homeScore(10).homeScoreBoard(TestFixture.getHomeScoreBoard())
+                        .awayTeam(kia).awayScore(1).awayScoreBoard(TestFixture.getAwayScoreBoard()));
+        com.yagubogu.checkin.domain.CheckIn checkIn = checkInFactory.save(b -> b.game(game).team(kia).member(fora));
+
+        // when & then
+        RestAssured.given().log().all()
+                .contentType(ContentType.JSON)
+                .header(HttpHeaders.AUTHORIZATION, accessToken)
+                .body(new com.yagubogu.checkin.dto.v1.UpdateCheckInMemoRequest("내 메모가 아닌데?"))
+                .when().put("/api/v1/check-ins/" + checkIn.getId() + "/memo")
+                .then().log().all()
+                .statusCode(404);
+    }
+
+    @DisplayName("예외: 다른 회원의 직관 기록 이미지는 삭제할 수 없다")
+    @Test
+    void deleteImage_otherMember() {
+        // given
+        Member fora = memberFactory.save(b -> b.team(kia));
+        Member other = memberFactory.save(b -> b.team(kt));
+        String accessToken = authFactory.getAccessTokenByMemberId(other.getId(), Role.USER);
+
+        LocalDate date = LocalDate.of(2025, 8, 1);
+        Game game = gameFactory.save(builder ->
+                builder.stadium(stadiumJamsil)
+                        .date(date)
+                        .homeTeam(kt).homeScore(10).homeScoreBoard(TestFixture.getHomeScoreBoard())
+                        .awayTeam(kia).awayScore(1).awayScoreBoard(TestFixture.getAwayScoreBoard()));
+        com.yagubogu.checkin.domain.CheckIn checkIn = checkInFactory.save(b -> b.game(game).team(kia).member(fora));
+
+        // when & then
+        RestAssured.given().log().all()
+                .contentType(ContentType.JSON)
+                .header(HttpHeaders.AUTHORIZATION, accessToken)
+                .when().delete("/api/v1/check-ins/" + checkIn.getId() + "/image")
+                .then().log().all()
+                .statusCode(404);
     }
 
     @DisplayName("회원의 총 인증 횟수를 조회한다")
@@ -777,5 +830,162 @@ public class CheckInE2eTest extends E2eTestBase {
         // then: 전체 기간(5경기) 조회 확인
         CheckInHistoryResponse result = response.as(CheckInHistoryResponse.class);
         assertThat(result.checkInHistory()).hasSize(5);
+    }
+
+    // ── 메모 CRUD ──────────────────────────────────────────────────────────────
+
+    @DisplayName("메모를 조회한다 - 메모 없는 경우 null 반환")
+    @Test
+    void getMemo_returnsNull_whenNoMemo() {
+        // given
+        Member fora = memberFactory.save(b -> b.team(kia));
+        String accessToken = authFactory.getAccessTokenByMemberId(fora.getId(), Role.USER);
+
+        Game game = gameFactory.save(b -> b.stadium(stadiumJamsil).date(LocalDate.of(2025, 9, 1))
+                .homeTeam(kt).awayTeam(kia));
+        com.yagubogu.checkin.domain.CheckIn checkIn = checkInFactory.save(b -> b.game(game).team(kia).member(fora));
+
+        // when
+        CheckInMemoResponse actual = RestAssured.given().log().all()
+                .contentType(ContentType.JSON)
+                .header(HttpHeaders.AUTHORIZATION, accessToken)
+                .when().get("/api/v1/check-ins/" + checkIn.getId() + "/memo")
+                .then().log().all()
+                .statusCode(200)
+                .extract().as(CheckInMemoResponse.class);
+
+        // then
+        assertThat(actual.memo()).isNull();
+    }
+
+    @DisplayName("메모를 수정 후 조회한다")
+    @Test
+    void getMemo_afterUpdate() {
+        // given
+        Member fora = memberFactory.save(b -> b.team(kia));
+        String accessToken = authFactory.getAccessTokenByMemberId(fora.getId(), Role.USER);
+
+        Game game = gameFactory.save(b -> b.stadium(stadiumJamsil).date(LocalDate.of(2025, 9, 2))
+                .homeTeam(kt).awayTeam(kia));
+        com.yagubogu.checkin.domain.CheckIn checkIn = checkInFactory.save(b -> b.game(game).team(kia).member(fora));
+
+        RestAssured.given()
+                .contentType(ContentType.JSON)
+                .header(HttpHeaders.AUTHORIZATION, accessToken)
+                .body(new com.yagubogu.checkin.dto.v1.UpdateCheckInMemoRequest("수정된 메모"))
+                .when().put("/api/v1/check-ins/" + checkIn.getId() + "/memo");
+
+        // when
+        CheckInMemoResponse actual = RestAssured.given().log().all()
+                .contentType(ContentType.JSON)
+                .header(HttpHeaders.AUTHORIZATION, accessToken)
+                .when().get("/api/v1/check-ins/" + checkIn.getId() + "/memo")
+                .then().log().all()
+                .statusCode(200)
+                .extract().as(CheckInMemoResponse.class);
+
+        // then
+        assertThat(actual.memo()).isEqualTo("수정된 메모");
+    }
+
+    @DisplayName("예외: 존재하지 않는 직관 기록의 메모를 조회하면 404가 발생한다")
+    @Test
+    void getMemo_notFound() {
+        // given
+        Member fora = memberFactory.save(b -> b.team(kia));
+        String accessToken = authFactory.getAccessTokenByMemberId(fora.getId(), Role.USER);
+        long invalidCheckInId = 999999L;
+
+        // when & then
+        RestAssured.given().log().all()
+                .contentType(ContentType.JSON)
+                .header(HttpHeaders.AUTHORIZATION, accessToken)
+                .when().get("/api/v1/check-ins/" + invalidCheckInId + "/memo")
+                .then().log().all()
+                .statusCode(404);
+    }
+
+    // ── 이미지 CRUD ────────────────────────────────────────────────────────────
+
+    @DisplayName("이미지 목록을 조회한다 - 이미지 없는 경우 빈 리스트 반환")
+    @Test
+    void getImages_returnsEmptyList() {
+        // given
+        Member fora = memberFactory.save(b -> b.team(kia));
+        String accessToken = authFactory.getAccessTokenByMemberId(fora.getId(), Role.USER);
+
+        Game game = gameFactory.save(b -> b.stadium(stadiumJamsil).date(LocalDate.of(2025, 9, 3))
+                .homeTeam(kt).awayTeam(kia));
+        com.yagubogu.checkin.domain.CheckIn checkIn = checkInFactory.save(b -> b.game(game).team(kia).member(fora));
+
+        // when
+        CheckInImagesResponse actual = RestAssured.given().log().all()
+                .contentType(ContentType.JSON)
+                .header(HttpHeaders.AUTHORIZATION, accessToken)
+                .when().get("/api/v1/check-ins/" + checkIn.getId() + "/images")
+                .then().log().all()
+                .statusCode(200)
+                .extract().as(CheckInImagesResponse.class);
+
+        // then
+        assertThat(actual.images()).isEmpty();
+    }
+
+    @DisplayName("예외: 존재하지 않는 이미지를 삭제하면 404가 발생한다")
+    @Test
+    void deleteImage_notFound() {
+        // given
+        Member fora = memberFactory.save(b -> b.team(kia));
+        String accessToken = authFactory.getAccessTokenByMemberId(fora.getId(), Role.USER);
+
+        Game game = gameFactory.save(b -> b.stadium(stadiumJamsil).date(LocalDate.of(2025, 9, 4))
+                .homeTeam(kt).awayTeam(kia));
+        com.yagubogu.checkin.domain.CheckIn checkIn = checkInFactory.save(b -> b.game(game).team(kia).member(fora));
+        long invalidImageId = 999999L;
+
+        // when & then
+        RestAssured.given().log().all()
+                .contentType(ContentType.JSON)
+                .header(HttpHeaders.AUTHORIZATION, accessToken)
+                .when().delete("/api/v1/check-ins/" + checkIn.getId() + "/images/" + invalidImageId)
+                .then().log().all()
+                .statusCode(404);
+    }
+
+    @DisplayName("직관 내역 조회 시 메모가 포함된다")
+    @Test
+    void findCheckInHistory_includesMemo() {
+        // given
+        Member fora = memberFactory.save(b -> b.team(kia));
+        String accessToken = authFactory.getAccessTokenByMemberId(fora.getId(), Role.USER);
+
+        Game game = gameFactory.save(b -> b.stadium(stadiumJamsil).date(LocalDate.of(2025, 9, 5))
+                .gameState(GameState.COMPLETED)
+                .homeTeam(kt).homeScore(2).homeScoreBoard(TestFixture.getHomeScoreBoard())
+                .awayTeam(kia).awayScore(5).awayScoreBoard(TestFixture.getAwayScoreBoard()));
+        com.yagubogu.checkin.domain.CheckIn checkIn = checkInFactory.save(b -> b.game(game).team(kia).member(fora));
+
+        RestAssured.given()
+                .contentType(ContentType.JSON)
+                .header(HttpHeaders.AUTHORIZATION, accessToken)
+                .body(new com.yagubogu.checkin.dto.v1.UpdateCheckInMemoRequest("기록에 남길 메모"))
+                .when().put("/api/v1/check-ins/" + checkIn.getId() + "/memo");
+
+        // when
+        CheckInHistoryResponse response = RestAssured.given().log().all()
+                .contentType(ContentType.JSON)
+                .header(HttpHeaders.AUTHORIZATION, accessToken)
+                .queryParam("year", 2025)
+                .queryParam("result", CheckInResultFilter.ALL)
+                .queryParam("order", CheckInOrderFilter.LATEST)
+                .when().get("/api/v1/check-ins/members")
+                .then().log().all()
+                .statusCode(200)
+                .extract().as(CheckInHistoryResponse.class);
+
+        // then
+        assertThat(response.checkInHistory()).hasSize(1);
+        assertThat(response.checkInHistory().get(0).memo()).isEqualTo("기록에 남길 메모");
+        assertThat(response.checkInHistory().get(0).imageUrls()).isEmpty();
     }
 }

--- a/backend/app/src/test/java/com/yagubogu/checkin/service/CheckInImageServiceTest.java
+++ b/backend/app/src/test/java/com/yagubogu/checkin/service/CheckInImageServiceTest.java
@@ -1,0 +1,91 @@
+package com.yagubogu.checkin.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import com.yagubogu.global.config.S3Properties;
+import com.yagubogu.global.exception.PayloadTooLargeException;
+import com.yagubogu.global.exception.UnsupportedMediaTypeException;
+import com.yagubogu.member.dto.v1.PreSignedUrlStartRequest;
+import com.yagubogu.member.dto.v1.PresignedUrlStartResponse;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.time.Duration;
+import java.util.function.Consumer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
+
+@ExtendWith(MockitoExtension.class)
+class CheckInImageServiceTest {
+
+    private static final String TEST_BUCKET = "test-bucket";
+    private static final String TEST_ENDPOINT = "https://test-endpoint.com";
+
+    @Mock
+    private S3Presigner s3Presigner;
+    @Mock
+    private PresignedPutObjectRequest presignedPutObjectRequest;
+
+    private CheckInImageService checkInImageService;
+
+    @BeforeEach
+    void setUp() {
+        S3Properties s3Properties = new S3Properties(
+                TEST_BUCKET,
+                Duration.ofMinutes(10),
+                TEST_ENDPOINT,
+                "ap-chuncheon-1",
+                "http://default.img"
+        );
+        checkInImageService = new CheckInImageService(s3Properties, s3Presigner);
+    }
+
+    @DisplayName("pre-signed url을 발급한다")
+    @Test
+    void issuePresignedUrl_success() throws MalformedURLException {
+        // given
+        PreSignedUrlStartRequest request = new PreSignedUrlStartRequest("image/jpeg", 1_000_000L);
+        String fakeUrl = "https://test-bucket.s3.amazonaws.com/images/check-ins/some-uuid";
+        when(presignedPutObjectRequest.url()).thenReturn(new URL(fakeUrl));
+        when(s3Presigner.presignPutObject(any(Consumer.class))).thenReturn(presignedPutObjectRequest);
+
+        // when
+        PresignedUrlStartResponse response = checkInImageService.issuePresignedUrl(request);
+
+        // then
+        assertThat(response.key()).startsWith("images/check-ins/");
+        assertThat(response.url()).isEqualTo(fakeUrl);
+    }
+
+    @DisplayName("예외: contentLength가 최대 길이를 초과하면 예외를 던진다")
+    @Test
+    void issuePresignedUrl_tooLarge() {
+        // given
+        PreSignedUrlStartRequest request = new PreSignedUrlStartRequest("image/jpeg", 5L * 1024 * 1024 + 1L);
+
+        // when & then
+        assertThatThrownBy(() -> checkInImageService.issuePresignedUrl(request))
+                .isInstanceOf(PayloadTooLargeException.class)
+                .hasMessageContaining("Check-in image is too large");
+    }
+
+    @DisplayName("예외: 허용되지 않은 contentType이면 예외를 던진다")
+    @Test
+    void issuePresignedUrl_invalidContentType() {
+        // given
+        PreSignedUrlStartRequest request = new PreSignedUrlStartRequest("image/gif", 1_000_000L);
+
+        // when & then
+        assertThatThrownBy(() -> checkInImageService.issuePresignedUrl(request))
+                .isInstanceOf(UnsupportedMediaTypeException.class)
+                .hasMessageContaining("Check-in image content type not supported");
+    }
+}

--- a/backend/app/src/test/java/com/yagubogu/checkin/service/CheckInServiceTest.java
+++ b/backend/app/src/test/java/com/yagubogu/checkin/service/CheckInServiceTest.java
@@ -7,6 +7,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.tuple;
 
 import com.yagubogu.auth.config.AuthTestConfig;
 import com.yagubogu.checkin.domain.CheckIn;
+import com.yagubogu.checkin.domain.CheckInImage;
 import com.yagubogu.checkin.domain.CheckInOrderFilter;
 import com.yagubogu.checkin.domain.CheckInResultFilter;
 import com.yagubogu.checkin.domain.CheckInType;
@@ -16,6 +17,9 @@ import com.yagubogu.checkin.dto.StadiumCheckInCountParam;
 import com.yagubogu.checkin.dto.TeamFanRateParam;
 import com.yagubogu.checkin.dto.v1.CheckInCountsResponse;
 import com.yagubogu.checkin.dto.v1.CheckInHistoryResponse;
+import com.yagubogu.checkin.dto.v1.CheckInImageParam;
+import com.yagubogu.checkin.dto.v1.CheckInImagesResponse;
+import com.yagubogu.checkin.dto.v1.CheckInMemoResponse;
 import com.yagubogu.checkin.dto.v1.CheckInStatusResponse;
 import com.yagubogu.checkin.dto.v1.CreateCheckInRequest;
 import com.yagubogu.checkin.dto.v1.FanRateResponse;
@@ -25,6 +29,7 @@ import com.yagubogu.game.domain.Game;
 import com.yagubogu.game.domain.GameState;
 import com.yagubogu.game.repository.GameRepository;
 import com.yagubogu.global.config.JpaAuditingConfig;
+import com.yagubogu.global.config.S3Properties;
 import com.yagubogu.global.exception.ConflictException;
 import com.yagubogu.global.exception.ForbiddenException;
 import com.yagubogu.global.exception.NotFoundException;
@@ -50,7 +55,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.Import;
-import com.yagubogu.global.config.S3Properties;
 import software.amazon.awssdk.services.s3.S3Client;
 
 @Import({AuthTestConfig.class, JpaAuditingConfig.class})
@@ -58,6 +62,8 @@ import software.amazon.awssdk.services.s3.S3Client;
 class CheckInServiceTest {
 
     private CheckInService checkInService;
+    private S3Client mockS3Client;
+    private S3Properties mockS3Properties;
 
     @Autowired
     private CheckInFactory checkInFactory;
@@ -73,6 +79,9 @@ class CheckInServiceTest {
 
     @Autowired
     private CheckInRepository checkInRepository;
+
+    @Autowired
+    private com.yagubogu.checkin.repository.CheckInImageRepository checkInImageRepository;
 
     @Autowired
     private MemberRepository memberRepository;
@@ -91,13 +100,19 @@ class CheckInServiceTest {
 
     @BeforeEach
     void setUp() {
+        mockS3Client = Mockito.mock(S3Client.class);
+        mockS3Properties = Mockito.mock(S3Properties.class);
+        Mockito.when(mockS3Properties.endpoint()).thenReturn("http://s3.test");
+        Mockito.when(mockS3Properties.bucket()).thenReturn("test-bucket");
+
         checkInService = new CheckInService(
                 checkInRepository,
+                checkInImageRepository,
                 memberRepository,
                 gameRepository,
                 applicationEventPublisher,
-                Mockito.mock(S3Client.class),
-                Mockito.mock(S3Properties.class)
+                mockS3Client,
+                mockS3Properties
         );
 
         kia = teamRepository.findByTeamCode("HT").orElseThrow();
@@ -121,7 +136,7 @@ class CheckInServiceTest {
                 builder.stadium(stadiumJamsil)
                         .homeTeam(lotte).homeScore(10).homeScoreBoard(TestFixture.getHomeScoreBoardAbout(10))
                         .awayTeam(kia).awayScore(1).awayScoreBoard(TestFixture.getAwayScoreBoardAbout(1)));
-        CreateCheckInRequest request = new CreateCheckInRequest(game.getId(), null, null);
+        CreateCheckInRequest request = new CreateCheckInRequest(game.getId());
 
         // when & then
         assertThatCode(() -> checkInService.createCheckIn(member.getId(), request))
@@ -134,7 +149,7 @@ class CheckInServiceTest {
         // given
         long invalidGameId = 999999L;
         long memberId = 1L;
-        CreateCheckInRequest request = new CreateCheckInRequest(invalidGameId, null, null);
+        CreateCheckInRequest request = new CreateCheckInRequest(invalidGameId);
 
         // when & then
         assertThatThrownBy(() -> checkInService.createCheckIn(memberId, request))
@@ -149,7 +164,7 @@ class CheckInServiceTest {
         long invalidMemberId = 999L;
         Game game = gameFactory.save(builder -> builder.stadium(stadiumJamsil)
                 .homeTeam(kia).awayTeam(kt).date(LocalDate.now()));
-        CreateCheckInRequest request = new CreateCheckInRequest(game.getId(), null, null);
+        CreateCheckInRequest request = new CreateCheckInRequest(game.getId());
 
         // when & then
         assertThatThrownBy(() -> checkInService.createCheckIn(invalidMemberId, request))
@@ -167,7 +182,7 @@ class CheckInServiceTest {
                 builder.stadium(stadiumJamsil)
                         .homeTeam(lotte).homeScore(10).homeScoreBoard(TestFixture.getHomeScoreBoardAbout(10))
                         .awayTeam(kia).awayScore(1).awayScoreBoard(TestFixture.getAwayScoreBoardAbout(1)));
-        CreateCheckInRequest request = new CreateCheckInRequest(game.getId(), null, null);
+        CreateCheckInRequest request = new CreateCheckInRequest(game.getId());
         checkInService.createCheckIn(memberId, request);
 
         // when & then
@@ -1085,5 +1100,274 @@ class CheckInServiceTest {
         assertThatThrownBy(() -> checkInService.deleteCheckIn(otherMember.getId(), checkIn.getId()))
                 .isInstanceOf(ForbiddenException.class)
                 .hasMessageContaining("Only your own check-in can be deleted");
+    }
+
+    // ── 메모 CRUD ──────────────────────────────────────────────────────────────
+
+    @DisplayName("메모를 조회한다 - 메모 없는 경우 null 반환")
+    @Test
+    void getMemo_returnsNull_whenNoMemo() {
+        // given
+        Member member = memberFactory.save(b -> b.team(kia));
+        Game game = gameFactory.save(b -> b.stadium(stadiumJamsil).homeTeam(kia).awayTeam(kt).date(LocalDate.now()));
+        CheckIn checkIn = checkInFactory.save(b -> b.member(member).team(kia).game(game));
+
+        // when
+        CheckInMemoResponse response = checkInService.getMemo(member.getId(), checkIn.getId());
+
+        // then
+        assertThat(response.memo()).isNull();
+    }
+
+    @DisplayName("메모를 조회한다 - 메모 있는 경우")
+    @Test
+    void getMemo_returnsMemo() {
+        // given
+        Member member = memberFactory.save(b -> b.team(kia));
+        Game game = gameFactory.save(b -> b.stadium(stadiumJamsil).homeTeam(kia).awayTeam(kt).date(LocalDate.now()));
+        CheckIn checkIn = checkInFactory.save(b -> b.member(member).team(kia).game(game));
+        checkInService.updateMemo(member.getId(), checkIn.getId(), "오늘 직관 최고!");
+
+        // when
+        CheckInMemoResponse response = checkInService.getMemo(member.getId(), checkIn.getId());
+
+        // then
+        assertThat(response.memo()).isEqualTo("오늘 직관 최고!");
+    }
+
+    @DisplayName("예외: 직관 기록이 없으면 메모 조회 시 예외가 발생한다")
+    @Test
+    void getMemo_throwsNotFoundException_whenCheckInNotFound() {
+        // given
+        Member member = memberFactory.save(b -> b.team(kia));
+        long invalidCheckInId = 999999L;
+
+        // when & then
+        assertThatThrownBy(() -> checkInService.getMemo(member.getId(), invalidCheckInId))
+                .isExactlyInstanceOf(NotFoundException.class);
+    }
+
+    @DisplayName("예외: 다른 회원의 직관 기록은 메모 조회가 불가능하다")
+    @Test
+    void getMemo_throwsNotFoundException_whenNotOwner() {
+        // given
+        Member owner = memberFactory.save(b -> b.team(kia));
+        Member other = memberFactory.save(b -> b.team(kt));
+        Game game = gameFactory.save(b -> b.stadium(stadiumJamsil).homeTeam(kia).awayTeam(kt).date(LocalDate.now()));
+        CheckIn checkIn = checkInFactory.save(b -> b.member(owner).team(kia).game(game));
+
+        // when & then
+        assertThatThrownBy(() -> checkInService.getMemo(other.getId(), checkIn.getId()))
+                .isExactlyInstanceOf(NotFoundException.class);
+    }
+
+    @DisplayName("메모를 수정한다")
+    @Test
+    void updateMemo_setsMemo() {
+        // given
+        Member member = memberFactory.save(b -> b.team(kia));
+        Game game = gameFactory.save(b -> b.stadium(stadiumJamsil).homeTeam(kia).awayTeam(kt).date(LocalDate.now()));
+        CheckIn checkIn = checkInFactory.save(b -> b.member(member).team(kia).game(game));
+
+        // when
+        checkInService.updateMemo(member.getId(), checkIn.getId(), "첫 번째 메모");
+        checkInService.updateMemo(member.getId(), checkIn.getId(), "수정된 메모");
+
+        // then
+        CheckInMemoResponse response = checkInService.getMemo(member.getId(), checkIn.getId());
+        assertThat(response.memo()).isEqualTo("수정된 메모");
+    }
+
+    @DisplayName("예외: 다른 회원의 직관 기록 메모는 수정할 수 없다")
+    @Test
+    void updateMemo_throwsNotFoundException_whenNotOwner() {
+        // given
+        Member owner = memberFactory.save(b -> b.team(kia));
+        Member other = memberFactory.save(b -> b.team(kt));
+        Game game = gameFactory.save(b -> b.stadium(stadiumJamsil).homeTeam(kia).awayTeam(kt).date(LocalDate.now()));
+        CheckIn checkIn = checkInFactory.save(b -> b.member(owner).team(kia).game(game));
+
+        // when & then
+        assertThatThrownBy(() -> checkInService.updateMemo(other.getId(), checkIn.getId(), "불법 메모"))
+                .isExactlyInstanceOf(NotFoundException.class);
+    }
+
+    @DisplayName("메모를 삭제한다")
+    @Test
+    void deleteMemo_clearsMemo() {
+        // given
+        Member member = memberFactory.save(b -> b.team(kia));
+        Game game = gameFactory.save(b -> b.stadium(stadiumJamsil).homeTeam(kia).awayTeam(kt).date(LocalDate.now()));
+        CheckIn checkIn = checkInFactory.save(b -> b.member(member).team(kia).game(game));
+        checkInService.updateMemo(member.getId(), checkIn.getId(), "삭제될 메모");
+
+        // when
+        checkInService.deleteMemo(member.getId(), checkIn.getId());
+
+        // then
+        CheckInMemoResponse response = checkInService.getMemo(member.getId(), checkIn.getId());
+        assertThat(response.memo()).isNull();
+    }
+
+    // ── 이미지 CRUD ────────────────────────────────────────────────────────────
+
+    @DisplayName("이미지 목록을 조회한다 - 이미지 없는 경우 빈 리스트 반환")
+    @Test
+    void getImages_returnsEmptyList_whenNoImages() {
+        // given
+        Member member = memberFactory.save(b -> b.team(kia));
+        Game game = gameFactory.save(b -> b.stadium(stadiumJamsil).homeTeam(kia).awayTeam(kt).date(LocalDate.now()));
+        CheckIn checkIn = checkInFactory.save(b -> b.member(member).team(kia).game(game));
+
+        // when
+        CheckInImagesResponse response = checkInService.getImages(member.getId(), checkIn.getId());
+
+        // then
+        assertThat(response.images()).isEmpty();
+    }
+
+    @DisplayName("이미지 목록을 조회한다 - 이미지 있는 경우")
+    @Test
+    void getImages_returnsImages() {
+        // given
+        Member member = memberFactory.save(b -> b.team(kia));
+        Game game = gameFactory.save(b -> b.stadium(stadiumJamsil).homeTeam(kia).awayTeam(kt).date(LocalDate.now()));
+        CheckIn checkIn = checkInFactory.save(b -> b.member(member).team(kia).game(game));
+        checkInImageRepository.save(new CheckInImage(checkIn, "http://s3.test/test-bucket/img1"));
+        checkInImageRepository.save(new CheckInImage(checkIn, "http://s3.test/test-bucket/img2"));
+
+        // when
+        CheckInImagesResponse response = checkInService.getImages(member.getId(), checkIn.getId());
+
+        // then
+        assertThat(response.images()).hasSize(2);
+        assertThat(response.images()).extracting(CheckInImageParam::imageUrl)
+                .containsExactlyInAnyOrder(
+                        "http://s3.test/test-bucket/img1",
+                        "http://s3.test/test-bucket/img2"
+                );
+    }
+
+    @DisplayName("예외: 다른 회원의 직관 기록 이미지는 조회할 수 없다")
+    @Test
+    void getImages_throwsNotFoundException_whenNotOwner() {
+        // given
+        Member owner = memberFactory.save(b -> b.team(kia));
+        Member other = memberFactory.save(b -> b.team(kt));
+        Game game = gameFactory.save(b -> b.stadium(stadiumJamsil).homeTeam(kia).awayTeam(kt).date(LocalDate.now()));
+        CheckIn checkIn = checkInFactory.save(b -> b.member(owner).team(kia).game(game));
+
+        // when & then
+        assertThatThrownBy(() -> checkInService.getImages(other.getId(), checkIn.getId()))
+                .isExactlyInstanceOf(NotFoundException.class);
+    }
+
+    @DisplayName("이미지를 추가한다")
+    @Test
+    void addImage_savesImageAndReturnsParam() {
+        // given
+        Member member = memberFactory.save(b -> b.team(kia));
+        Game game = gameFactory.save(b -> b.stadium(stadiumJamsil).homeTeam(kia).awayTeam(kt).date(LocalDate.now()));
+        CheckIn checkIn = checkInFactory.save(b -> b.member(member).team(kia).game(game));
+
+        // when
+        CheckInImageParam result = checkInService.addImage(member.getId(), checkIn.getId(), "images/check-ins/test-key");
+
+        // then
+        assertThat(result.imageId()).isNotNull();
+        assertThat(result.imageUrl()).isEqualTo("http://s3.test/test-bucket/images/check-ins/test-key");
+        assertThat(checkInService.getImages(member.getId(), checkIn.getId()).images()).hasSize(1);
+    }
+
+    @DisplayName("이미지를 여러 장 추가한다")
+    @Test
+    void addImage_multipleImages() {
+        // given
+        Member member = memberFactory.save(b -> b.team(kia));
+        Game game = gameFactory.save(b -> b.stadium(stadiumJamsil).homeTeam(kia).awayTeam(kt).date(LocalDate.now()));
+        CheckIn checkIn = checkInFactory.save(b -> b.member(member).team(kia).game(game));
+
+        // when
+        checkInService.addImage(member.getId(), checkIn.getId(), "images/check-ins/key1");
+        checkInService.addImage(member.getId(), checkIn.getId(), "images/check-ins/key2");
+        checkInService.addImage(member.getId(), checkIn.getId(), "images/check-ins/key3");
+
+        // then
+        assertThat(checkInService.getImages(member.getId(), checkIn.getId()).images()).hasSize(3);
+    }
+
+    @DisplayName("이미지를 삭제한다")
+    @Test
+    void deleteImage_deletesImage() {
+        // given
+        Member member = memberFactory.save(b -> b.team(kia));
+        Game game = gameFactory.save(b -> b.stadium(stadiumJamsil).homeTeam(kia).awayTeam(kt).date(LocalDate.now()));
+        CheckIn checkIn = checkInFactory.save(b -> b.member(member).team(kia).game(game));
+        CheckInImageParam image = checkInService.addImage(member.getId(), checkIn.getId(), "images/check-ins/key1");
+
+        // when
+        checkInService.deleteImage(member.getId(), checkIn.getId(), image.imageId());
+
+        // then
+        assertThat(checkInService.getImages(member.getId(), checkIn.getId()).images()).isEmpty();
+    }
+
+    @DisplayName("예외: 존재하지 않는 이미지를 삭제하면 예외가 발생한다")
+    @Test
+    void deleteImage_throwsNotFoundException_whenImageNotFound() {
+        // given
+        Member member = memberFactory.save(b -> b.team(kia));
+        Game game = gameFactory.save(b -> b.stadium(stadiumJamsil).homeTeam(kia).awayTeam(kt).date(LocalDate.now()));
+        CheckIn checkIn = checkInFactory.save(b -> b.member(member).team(kia).game(game));
+        long invalidImageId = 999999L;
+
+        // when & then
+        assertThatThrownBy(() -> checkInService.deleteImage(member.getId(), checkIn.getId(), invalidImageId))
+                .isExactlyInstanceOf(NotFoundException.class);
+    }
+
+    @DisplayName("예외: 다른 직관 기록의 이미지는 삭제할 수 없다")
+    @Test
+    void deleteImage_throwsNotFoundException_whenImageBelongsToOtherCheckIn() {
+        // given
+        Member member = memberFactory.save(b -> b.team(kia));
+        Game game1 = gameFactory.save(b -> b.stadium(stadiumJamsil).homeTeam(kia).awayTeam(kt).date(LocalDate.of(2025, 7, 1)));
+        Game game2 = gameFactory.save(b -> b.stadium(stadiumJamsil).homeTeam(kia).awayTeam(kt).date(LocalDate.of(2025, 7, 2)));
+        CheckIn checkIn1 = checkInFactory.save(b -> b.member(member).team(kia).game(game1));
+        CheckIn checkIn2 = checkInFactory.save(b -> b.member(member).team(kia).game(game2));
+
+        CheckInImageParam imageOfCheckIn1 = checkInService.addImage(member.getId(), checkIn1.getId(), "images/check-ins/key1");
+
+        // when & then: checkIn2로 checkIn1의 이미지 삭제 시도
+        assertThatThrownBy(() -> checkInService.deleteImage(member.getId(), checkIn2.getId(), imageOfCheckIn1.imageId()))
+                .isExactlyInstanceOf(NotFoundException.class);
+    }
+
+    @DisplayName("직관 내역 조회 시 메모와 이미지 URL 목록이 포함된다")
+    @Test
+    void findCheckInHistory_includesMemoAndImageUrls() {
+        // given
+        Member member = memberFactory.save(b -> b.team(kia));
+        Game game = gameFactory.save(b -> b.stadium(stadiumJamsil)
+                .homeTeam(kia).homeScore(5).homeScoreBoard(TestFixture.getHomeScoreBoardAbout(5))
+                .awayTeam(kt).awayScore(3).awayScoreBoard(TestFixture.getAwayScoreBoardAbout(3))
+                .gameState(GameState.COMPLETED)
+                .date(LocalDate.of(2025, 8, 1)));
+        CheckIn checkIn = checkInFactory.save(b -> b.member(member).team(kia).game(game));
+
+        checkInService.updateMemo(member.getId(), checkIn.getId(), "역대급 직관");
+        checkInService.addImage(member.getId(), checkIn.getId(), "images/check-ins/img1");
+        checkInService.addImage(member.getId(), checkIn.getId(), "images/check-ins/img2");
+
+        // when
+        List<CheckInGameParam> history = checkInService.findCheckInHistory(
+                member.getId(), 2025, null, CheckInResultFilter.ALL, CheckInOrderFilter.LATEST
+        ).checkInHistory();
+
+        // then
+        assertThat(history).hasSize(1);
+        CheckInGameParam result = history.get(0);
+        assertThat(result.memo()).isEqualTo("역대급 직관");
+        assertThat(result.imageUrls()).hasSize(2);
     }
 }

--- a/backend/app/src/test/java/com/yagubogu/checkin/service/CheckInServiceTest.java
+++ b/backend/app/src/test/java/com/yagubogu/checkin/service/CheckInServiceTest.java
@@ -45,10 +45,13 @@ import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.Import;
+import com.yagubogu.global.config.S3Properties;
+import software.amazon.awssdk.services.s3.S3Client;
 
 @Import({AuthTestConfig.class, JpaAuditingConfig.class})
 @DataJpaTest
@@ -92,7 +95,9 @@ class CheckInServiceTest {
                 checkInRepository,
                 memberRepository,
                 gameRepository,
-                applicationEventPublisher
+                applicationEventPublisher,
+                Mockito.mock(S3Client.class),
+                Mockito.mock(S3Properties.class)
         );
 
         kia = teamRepository.findByTeamCode("HT").orElseThrow();
@@ -116,7 +121,7 @@ class CheckInServiceTest {
                 builder.stadium(stadiumJamsil)
                         .homeTeam(lotte).homeScore(10).homeScoreBoard(TestFixture.getHomeScoreBoardAbout(10))
                         .awayTeam(kia).awayScore(1).awayScoreBoard(TestFixture.getAwayScoreBoardAbout(1)));
-        CreateCheckInRequest request = new CreateCheckInRequest(game.getId());
+        CreateCheckInRequest request = new CreateCheckInRequest(game.getId(), null, null);
 
         // when & then
         assertThatCode(() -> checkInService.createCheckIn(member.getId(), request))
@@ -129,7 +134,7 @@ class CheckInServiceTest {
         // given
         long invalidGameId = 999999L;
         long memberId = 1L;
-        CreateCheckInRequest request = new CreateCheckInRequest(invalidGameId);
+        CreateCheckInRequest request = new CreateCheckInRequest(invalidGameId, null, null);
 
         // when & then
         assertThatThrownBy(() -> checkInService.createCheckIn(memberId, request))
@@ -144,7 +149,7 @@ class CheckInServiceTest {
         long invalidMemberId = 999L;
         Game game = gameFactory.save(builder -> builder.stadium(stadiumJamsil)
                 .homeTeam(kia).awayTeam(kt).date(LocalDate.now()));
-        CreateCheckInRequest request = new CreateCheckInRequest(game.getId());
+        CreateCheckInRequest request = new CreateCheckInRequest(game.getId(), null, null);
 
         // when & then
         assertThatThrownBy(() -> checkInService.createCheckIn(invalidMemberId, request))
@@ -162,7 +167,7 @@ class CheckInServiceTest {
                 builder.stadium(stadiumJamsil)
                         .homeTeam(lotte).homeScore(10).homeScoreBoard(TestFixture.getHomeScoreBoardAbout(10))
                         .awayTeam(kia).awayScore(1).awayScoreBoard(TestFixture.getAwayScoreBoardAbout(1)));
-        CreateCheckInRequest request = new CreateCheckInRequest(game.getId());
+        CreateCheckInRequest request = new CreateCheckInRequest(game.getId(), null, null);
         checkInService.createCheckIn(memberId, request);
 
         // when & then

--- a/backend/app/src/test/java/com/yagubogu/support/checkin/CheckInBuilder.java
+++ b/backend/app/src/test/java/com/yagubogu/support/checkin/CheckInBuilder.java
@@ -38,6 +38,6 @@ public class CheckInBuilder {
     }
 
     public CheckIn build() {
-        return new CheckIn(game, member, team, checkInType);
+        return new CheckIn(game, member, team, checkInType, null, null);
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈
- close #이슈번호

## ✨ 변경 내용
- 어떤 기능/수정이 포함되었는지 간단 요약

## 🎸 기타 참고 사항

### 메모 API
<img width="582" height="148" alt="image" src="https://github.com/user-attachments/assets/3e0fbfec-9716-4cee-8772-1c12ebdd162a" />
(최대 500자)

### 이미지 API
<img width="805" height="182" alt="image" src="https://github.com/user-attachments/assets/482aaeb3-c5b7-42ce-a62e-d8cf0b6ebf9e" />

- 이미지 업로드 플로우
  - POST /api/v1/check-ins/image/presigned-url 로 업로드 url 발급
  - 발급된 url로 OCI에 직접 업로드
  - POST /api/v1/check-ins/{checkInId}/images 로 imageKey 등록