### PR TITLE
feat: 직관내역 연간 조회 구현

### DIFF
--- a/mobile/composeApp/src/commonMain/composeResources/drawable/ic_check.xml
+++ b/mobile/composeApp/src/commonMain/composeResources/drawable/ic_check.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:pathData="M20,6L9,17L4,12"
+        android:strokeLineJoin="round"
+        android:strokeWidth="2"
+        android:fillColor="#00000000"
+        android:strokeColor="#000000"
+        android:strokeLineCap="round" />
+</vector>

--- a/mobile/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/mobile/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -117,7 +117,7 @@
     <string name="attendance_history_empty_description">직관 내역이 없어요</string>
     <string name="attendance_history_empty_scoreboard_illustration_description">비어있는 스코어보드 일러스트</string>
     <string name="attendance_history_win_only">승리한 경기</string>
-    <string name="attendance_history_yearly">%1$s년 전체</string>
+    <string name="attendance_history_yearly">%1$d년 전체</string>
     <string name="attendance_history_latest">최신순</string>
     <string name="attendance_history_oldest">오래된순</string>
     <string name="attendance_history_winning_pitcher">승 - %1$s</string>

--- a/mobile/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/mobile/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -116,8 +116,8 @@
     <string name="attendance_history_no_game_description">경기가 없는 날이에요</string>
     <string name="attendance_history_empty_description">직관 내역이 없어요</string>
     <string name="attendance_history_empty_scoreboard_illustration_description">비어있는 스코어보드 일러스트</string>
-    <string name="attendance_history_all">전체 경기</string>
-    <string name="attendance_history_win">승리한 경기</string>
+    <string name="attendance_history_win_only">승리한 경기</string>
+    <string name="attendance_history_yearly">%1$s년 전체</string>
     <string name="attendance_history_latest">최신순</string>
     <string name="attendance_history_oldest">오래된순</string>
     <string name="attendance_history_winning_pitcher">승 - %1$s</string>

--- a/mobile/composeApp/src/commonMain/kotlin/com/yagubogu/data/datasource/checkin/CheckInDataSource.kt
+++ b/mobile/composeApp/src/commonMain/kotlin/com/yagubogu/data/datasource/checkin/CheckInDataSource.kt
@@ -16,9 +16,9 @@ interface CheckInDataSource {
 
     suspend fun getCheckInHistories(
         year: Int,
-        month: Int,
-        filter: String,
+        month: Int?,
         sort: String,
+        isWinOnly: Boolean,
     ): Result<CheckInHistoryResponse>
 
     suspend fun getCheckInStatus(date: LocalDate): Result<CheckInStatusResponse>

--- a/mobile/composeApp/src/commonMain/kotlin/com/yagubogu/data/datasource/checkin/CheckInRemoteDataSource.kt
+++ b/mobile/composeApp/src/commonMain/kotlin/com/yagubogu/data/datasource/checkin/CheckInRemoteDataSource.kt
@@ -33,12 +33,17 @@ class CheckInRemoteDataSource(
 
     override suspend fun getCheckInHistories(
         year: Int,
-        month: Int,
-        filter: String,
+        month: Int?,
         sort: String,
+        isWinOnly: Boolean,
     ): Result<CheckInHistoryResponse> =
         safeApiCall {
-            checkInApiService.getCheckInHistories(year, month, filter, sort)
+            checkInApiService.getCheckInHistories(
+                year = year,
+                month = month,
+                result = if (isWinOnly) "WIN" else "ALL",
+                order = sort,
+            )
         }
 
     override suspend fun getCheckInStatus(date: LocalDate): Result<CheckInStatusResponse> =

--- a/mobile/composeApp/src/commonMain/kotlin/com/yagubogu/data/repository/checkin/CheckInDefaultRepository.kt
+++ b/mobile/composeApp/src/commonMain/kotlin/com/yagubogu/data/repository/checkin/CheckInDefaultRepository.kt
@@ -32,12 +32,12 @@ class CheckInDefaultRepository(
 
     override suspend fun getCheckInHistories(
         year: Int,
-        month: Int,
-        filter: String,
+        month: Int?,
         sort: String,
+        isWinOnly: Boolean,
     ): Result<List<CheckInGameDto>> =
         checkInDataSource
-            .getCheckInHistories(year, month, filter, sort)
+            .getCheckInHistories(year, month, sort, isWinOnly)
             .map { checkInHistoryResponse: CheckInHistoryResponse ->
                 checkInHistoryResponse.checkInHistory
             }

--- a/mobile/composeApp/src/commonMain/kotlin/com/yagubogu/data/repository/checkin/CheckInRepository.kt
+++ b/mobile/composeApp/src/commonMain/kotlin/com/yagubogu/data/repository/checkin/CheckInRepository.kt
@@ -14,9 +14,9 @@ interface CheckInRepository {
 
     suspend fun getCheckInHistories(
         year: Int,
-        month: Int,
-        filter: String,
+        month: Int?,
         sort: String,
+        isWinOnly: Boolean,
     ): Result<List<CheckInGameDto>>
 
     suspend fun getCheckInStatus(date: LocalDate): Result<Boolean>

--- a/mobile/composeApp/src/commonMain/kotlin/com/yagubogu/data/service/CheckInApiService.kt
+++ b/mobile/composeApp/src/commonMain/kotlin/com/yagubogu/data/service/CheckInApiService.kt
@@ -31,7 +31,7 @@ interface CheckInApiService {
     @GET("/api/v1/check-ins/members")
     suspend fun getCheckInHistories(
         @Query("year") year: Int,
-        @Query("month") month: Int,
+        @Query("month") month: Int?,
         @Query("result") result: String,
         @Query("order") order: String,
     ): CheckInHistoryResponse

--- a/mobile/composeApp/src/commonMain/kotlin/com/yagubogu/ui/attendance/AttendanceHistoryScreen.kt
+++ b/mobile/composeApp/src/commonMain/kotlin/com/yagubogu/ui/attendance/AttendanceHistoryScreen.kt
@@ -39,7 +39,7 @@ import com.yagubogu.ui.attendance.component.ATTENDANCE_HISTORY_ITEMS
 import com.yagubogu.ui.attendance.component.AttendanceCalendarContent
 import com.yagubogu.ui.attendance.component.AttendanceListContent
 import com.yagubogu.ui.attendance.component.YearMonthPickerDialog
-import com.yagubogu.ui.attendance.model.AttendanceHistoryFilter
+import com.yagubogu.ui.attendance.model.AttendanceFilterState
 import com.yagubogu.ui.attendance.model.AttendanceHistoryItem
 import com.yagubogu.ui.attendance.model.AttendanceHistorySort
 import com.yagubogu.ui.attendance.model.AttendanceHistoryViewType
@@ -84,7 +84,7 @@ fun AttendanceHistoryScreen(
     val attendanceItems: List<AttendanceHistoryItem> by viewModel.items.collectAsStateWithLifecycle()
     val selectedMonth: YearMonth by viewModel.selectedMonth.collectAsStateWithLifecycle()
     val selectedDate: LocalDate by viewModel.selectedDate.collectAsStateWithLifecycle()
-    val filter: AttendanceHistoryFilter by viewModel.filter.collectAsStateWithLifecycle()
+    val filterState: AttendanceFilterState by viewModel.filterState.collectAsStateWithLifecycle()
     val sort: AttendanceHistorySort by viewModel.sort.collectAsStateWithLifecycle()
     val pastGameUiState: PastGameUiState by viewModel.pastGameUiState.collectAsStateWithLifecycle()
 
@@ -97,8 +97,19 @@ fun AttendanceHistoryScreen(
     }
     val snackbarScope = LocalSnackbarHostState.current
 
-    LaunchedEffect(selectedMonth, viewType, filter, sort) {
-        viewModel.fetchAttendanceHistoryItems()
+    LaunchedEffect(selectedMonth, viewType, filterState, sort) {
+        when (viewType) {
+            AttendanceHistoryViewType.CALENDAR ->
+                viewModel.fetchAttendanceHistoryItems(yearMonth = selectedMonth)
+
+            AttendanceHistoryViewType.LIST ->
+                viewModel.fetchAttendanceHistoryItems(
+                    yearMonth = selectedMonth,
+                    isYearly = filterState.isYearly,
+                    isWinOnly = filterState.isWinOnly,
+                    sort = sort,
+                )
+        }
     }
 
     LaunchedEffect(selectedMonth) {
@@ -129,8 +140,9 @@ fun AttendanceHistoryScreen(
         selectedDate = selectedDate,
         onDateChange = viewModel::updateSelectedDate,
         items = attendanceItems,
-        filter = filter,
-        updateFilter = viewModel::updateFilter,
+        filterState = filterState,
+        onWinOnlyFilterToggle = viewModel::toggleWinOnlyFilter,
+        onYearlyFilterToggle = viewModel::toggleYearlyFilter,
         sort = sort,
         updateSort = viewModel::updateSort,
         pastGameUiState = pastGameUiState,
@@ -152,8 +164,9 @@ private fun AttendanceHistoryScreen(
     selectedDate: LocalDate,
     onDateChange: (LocalDate) -> Unit,
     items: List<AttendanceHistoryItem>,
-    filter: AttendanceHistoryFilter,
-    updateFilter: (AttendanceHistoryFilter) -> Unit,
+    filterState: AttendanceFilterState,
+    onWinOnlyFilterToggle: () -> Unit,
+    onYearlyFilterToggle: () -> Unit,
     sort: AttendanceHistorySort,
     updateSort: (AttendanceHistorySort) -> Unit,
     pastGameUiState: PastGameUiState,
@@ -198,8 +211,9 @@ private fun AttendanceHistoryScreen(
             AttendanceHistoryViewType.LIST ->
                 AttendanceListContent(
                     items = items,
-                    filter = filter,
-                    updateFilter = updateFilter,
+                    filterState = filterState,
+                    onWinOnlyFilterToggle = onWinOnlyFilterToggle,
+                    onYearlyFilterToggle = onYearlyFilterToggle,
                     sort = sort,
                     updateSort = updateSort,
                     scrollToTopEvent = scrollToTopEvent,
@@ -367,8 +381,9 @@ private fun AttendanceCalenderScreenPreview() {
         selectedDate = LocalDate.now(),
         onDateChange = {},
         items = ATTENDANCE_HISTORY_ITEMS,
-        filter = AttendanceHistoryFilter.ALL,
-        updateFilter = {},
+        filterState = AttendanceFilterState(yearMonth = YearMonth.now()),
+        onWinOnlyFilterToggle = {},
+        onYearlyFilterToggle = {},
         sort = AttendanceHistorySort.LATEST,
         updateSort = {},
         pastGameUiState = PastGameUiState.Loading,
@@ -390,8 +405,9 @@ private fun AttendanceListScreenPreview() {
         selectedDate = LocalDate.now(),
         onDateChange = {},
         items = ATTENDANCE_HISTORY_ITEMS,
-        filter = AttendanceHistoryFilter.ALL,
-        updateFilter = {},
+        filterState = AttendanceFilterState(yearMonth = YearMonth.now()),
+        onWinOnlyFilterToggle = {},
+        onYearlyFilterToggle = {},
         sort = AttendanceHistorySort.LATEST,
         updateSort = {},
         pastGameUiState = PastGameUiState.Loading,

--- a/mobile/composeApp/src/commonMain/kotlin/com/yagubogu/ui/attendance/AttendanceHistoryViewModel.kt
+++ b/mobile/composeApp/src/commonMain/kotlin/com/yagubogu/ui/attendance/AttendanceHistoryViewModel.kt
@@ -7,7 +7,6 @@ import com.yagubogu.data.dto.response.game.GameWithCheckInDto
 import com.yagubogu.data.repository.checkin.CheckInRepository
 import com.yagubogu.data.repository.game.GameRepository
 import com.yagubogu.ui.attendance.model.AttendanceFilterState
-import com.yagubogu.ui.attendance.model.AttendanceHistoryFilter
 import com.yagubogu.ui.attendance.model.AttendanceHistoryItem
 import com.yagubogu.ui.attendance.model.AttendanceHistorySort
 import com.yagubogu.ui.attendance.model.PastGameUiModel
@@ -23,6 +22,7 @@ import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.YearMonth
@@ -44,11 +44,8 @@ class AttendanceHistoryViewModel(
     val selectedDate: StateFlow<LocalDate> = _selectedDate.asStateFlow()
 
     private val _filterState =
-        MutableStateFlow(AttendanceFilterState(year = selectedMonth.value.year))
+        MutableStateFlow(AttendanceFilterState(yearMonth = selectedMonth.value))
     val filterState: StateFlow<AttendanceFilterState> = _filterState.asStateFlow()
-
-    private val _filter = MutableStateFlow(AttendanceHistoryFilter.ALL)
-    val filter: StateFlow<AttendanceHistoryFilter> = _filter.asStateFlow()
 
     private val _sort = MutableStateFlow(AttendanceHistorySort.LATEST)
     val sort: StateFlow<AttendanceHistorySort> = _sort.asStateFlow()
@@ -64,15 +61,19 @@ class AttendanceHistoryViewModel(
         )
     val pastCheckInUiEvent: SharedFlow<Unit> = _pastCheckInUiEvent.asSharedFlow()
 
-    fun fetchAttendanceHistoryItems() {
+    fun fetchAttendanceHistoryItems(
+        yearMonth: YearMonth,
+        isYearly: Boolean = false,
+        isWinOnly: Boolean = false,
+        sort: AttendanceHistorySort = AttendanceHistorySort.LATEST,
+    ) {
         viewModelScope.launch {
-            val yearMonth: YearMonth = selectedMonth.value
             checkInRepository
                 .getCheckInHistories(
-                    yearMonth.year,
-                    yearMonth.month.number,
-                    filter.value.name,
-                    sort.value.name,
+                    year = yearMonth.year,
+                    month = if (isYearly) null else yearMonth.month.number,
+                    sort = sort.name,
+                    isWinOnly = isWinOnly,
                 ).mapList { it.toUiModel() }
                 .onSuccess { attendanceItems: List<AttendanceHistoryItem> ->
                     _items.value = attendanceItems
@@ -106,7 +107,7 @@ class AttendanceHistoryViewModel(
                 .addPastCheckIn(gameId)
                 .onSuccess {
                     _pastCheckInUiEvent.emit(Unit)
-                    fetchAttendanceHistoryItems()
+                    fetchAttendanceHistoryItems(yearMonth = selectedMonth.value)
                 }.onFailure { exception: Throwable ->
                     logger.w(exception) { "API 호출 실패" }
                 }
@@ -115,19 +116,20 @@ class AttendanceHistoryViewModel(
 
     fun updateSelectedMonth(yearMonth: YearMonth) {
         _selectedMonth.value = yearMonth
+        _filterState.update { it.copy(yearMonth = yearMonth) }
     }
 
     fun updateSelectedDate(date: LocalDate) {
         _selectedDate.value = date
     }
 
-    fun updateFilter(filter: AttendanceHistoryFilter) {
-        _filter.value = filter
+    fun toggleWinOnlyFilter() {
+        _filterState.update { it.copy(isWinOnly = !it.isWinOnly) }
     }
 
-    fun toggleWinOnlyFilter() {}
-
-    fun toggleYearlyFilter() {}
+    fun toggleYearlyFilter() {
+        _filterState.update { it.copy(isYearly = !it.isYearly) }
+    }
 
     fun updateSort(sort: AttendanceHistorySort) {
         _sort.value = sort

--- a/mobile/composeApp/src/commonMain/kotlin/com/yagubogu/ui/attendance/AttendanceHistoryViewModel.kt
+++ b/mobile/composeApp/src/commonMain/kotlin/com/yagubogu/ui/attendance/AttendanceHistoryViewModel.kt
@@ -6,6 +6,7 @@ import co.touchlab.kermit.Logger
 import com.yagubogu.data.dto.response.game.GameWithCheckInDto
 import com.yagubogu.data.repository.checkin.CheckInRepository
 import com.yagubogu.data.repository.game.GameRepository
+import com.yagubogu.ui.attendance.model.AttendanceFilterState
 import com.yagubogu.ui.attendance.model.AttendanceHistoryFilter
 import com.yagubogu.ui.attendance.model.AttendanceHistoryItem
 import com.yagubogu.ui.attendance.model.AttendanceHistorySort
@@ -41,6 +42,10 @@ class AttendanceHistoryViewModel(
 
     private val _selectedDate = MutableStateFlow<LocalDate>(LocalDate.now())
     val selectedDate: StateFlow<LocalDate> = _selectedDate.asStateFlow()
+
+    private val _filterState =
+        MutableStateFlow(AttendanceFilterState(year = selectedMonth.value.year))
+    val filterState: StateFlow<AttendanceFilterState> = _filterState.asStateFlow()
 
     private val _filter = MutableStateFlow(AttendanceHistoryFilter.ALL)
     val filter: StateFlow<AttendanceHistoryFilter> = _filter.asStateFlow()
@@ -119,6 +124,10 @@ class AttendanceHistoryViewModel(
     fun updateFilter(filter: AttendanceHistoryFilter) {
         _filter.value = filter
     }
+
+    fun toggleWinOnlyFilter() {}
+
+    fun toggleYearlyFilter() {}
 
     fun updateSort(sort: AttendanceHistorySort) {
         _sort.value = sort

--- a/mobile/composeApp/src/commonMain/kotlin/com/yagubogu/ui/attendance/component/AttendanceListContent.kt
+++ b/mobile/composeApp/src/commonMain/kotlin/com/yagubogu/ui/attendance/component/AttendanceListContent.kt
@@ -1,9 +1,7 @@
 package com.yagubogu.ui.attendance.component
 
-import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
@@ -17,48 +15,40 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.rememberLazyListState
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.DropdownMenu
-import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.yagubogu.analytics.AnalyticsLogger
+import com.yagubogu.ui.attendance.model.AttendanceFilterState
 import com.yagubogu.ui.attendance.model.AttendanceHistoryFilter
 import com.yagubogu.ui.attendance.model.AttendanceHistoryItem
 import com.yagubogu.ui.attendance.model.AttendanceHistorySort
-import com.yagubogu.ui.theme.Gray300
 import com.yagubogu.ui.theme.Gray400
 import com.yagubogu.ui.theme.Gray500
 import com.yagubogu.ui.theme.PretendardMedium
 import com.yagubogu.ui.theme.PretendardRegular
-import com.yagubogu.ui.theme.White
-import com.yagubogu.ui.util.crop
 import com.yagubogu.ui.util.noRippleClickable
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
 import yagubogu.composeapp.generated.resources.Res
-import yagubogu.composeapp.generated.resources.attendance_history_all
 import yagubogu.composeapp.generated.resources.attendance_history_empty_description
 import yagubogu.composeapp.generated.resources.attendance_history_empty_scoreboard_illustration_description
 import yagubogu.composeapp.generated.resources.attendance_history_latest
 import yagubogu.composeapp.generated.resources.attendance_history_oldest
-import yagubogu.composeapp.generated.resources.attendance_history_win
-import yagubogu.composeapp.generated.resources.ic_arrow_down
+import yagubogu.composeapp.generated.resources.attendance_history_win_only
+import yagubogu.composeapp.generated.resources.attendance_history_yearly
 import yagubogu.composeapp.generated.resources.ic_switch
 import yagubogu.composeapp.generated.resources.img_baseball_scoreboard
 
@@ -74,34 +64,60 @@ fun AttendanceListContent(
     modifier: Modifier = Modifier,
     scrollToTopEvent: SharedFlow<Unit> = MutableSharedFlow(),
 ) {
-    when (items.isNotEmpty()) {
-        true ->
-            AttendanceList(
-                items = items,
-                filter = filter,
-                updateFilter = updateFilter,
-                sort = sort,
-                updateSort = updateSort,
-                modifier = modifier,
-                scrollToTopEvent = scrollToTopEvent,
-            )
+    var detailItemPosition: Int? by rememberSaveable { mutableStateOf(if (items.isNotEmpty()) FIRST_INDEX else null) }
 
-        false -> EmptyAttendanceList()
+    Column(
+        modifier = modifier.fillMaxSize(),
+    ) {
+        AttendanceListHeader(
+            filterState = AttendanceFilterState(year = 2026, isYearly = true),
+            onWinOnlyClick = {
+                // TODO
+                detailItemPosition = if (items.isNotEmpty()) FIRST_INDEX else null
+            },
+            onYearlyClick = {
+                // TODO
+                detailItemPosition = if (items.isNotEmpty()) FIRST_INDEX else null
+            },
+            sort = sort,
+            updateSort = { sort: AttendanceHistorySort ->
+                updateSort(sort)
+                detailItemPosition = if (items.isNotEmpty()) FIRST_INDEX else null
+            },
+        )
+        when (items.isNotEmpty()) {
+            true ->
+                AttendanceList(
+                    items = items,
+                    detailItemPosition = detailItemPosition,
+                    onItemClick = { item: AttendanceHistoryItem ->
+                        val position: Int = items.indexOf(item)
+                        if (position >= FIRST_INDEX) {
+                            detailItemPosition =
+                                if (position == detailItemPosition) {
+                                    null
+                                } else {
+                                    position
+                                }
+                        }
+                    },
+                    modifier = modifier,
+                    scrollToTopEvent = scrollToTopEvent,
+                )
+
+            false -> EmptyAttendanceList()
+        }
     }
 }
 
 @Composable
 private fun AttendanceList(
     items: List<AttendanceHistoryItem>,
-    filter: AttendanceHistoryFilter,
-    updateFilter: (AttendanceHistoryFilter) -> Unit,
-    sort: AttendanceHistorySort,
-    updateSort: (AttendanceHistorySort) -> Unit,
+    detailItemPosition: Int?,
+    onItemClick: (AttendanceHistoryItem) -> Unit,
     modifier: Modifier = Modifier,
     scrollToTopEvent: SharedFlow<Unit> = MutableSharedFlow(),
 ) {
-    var detailItemPosition: Int? by rememberSaveable { mutableStateOf(if (items.isNotEmpty()) FIRST_INDEX else null) }
-
     val lazyListState: LazyListState = rememberLazyListState()
     LaunchedEffect(Unit) {
         scrollToTopEvent.collect {
@@ -117,33 +133,6 @@ private fun AttendanceList(
     Column(
         modifier = modifier.fillMaxSize(),
     ) {
-        Row(
-            modifier =
-                Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 20.dp),
-            horizontalArrangement = Arrangement.SpaceBetween,
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            AttendanceHistoryFilterDropdown(
-                filter = filter,
-                onClick = { newFilter: AttendanceHistoryFilter ->
-                    if (filter != newFilter) {
-                        updateFilter(newFilter)
-                        detailItemPosition = if (items.isNotEmpty()) FIRST_INDEX else null
-                    }
-                },
-            )
-            AttendanceHistorySortSwitch(
-                sort = sort,
-                onClick = {
-                    val newSort: AttendanceHistorySort = sort.toggle()
-                    updateSort(newSort)
-                    detailItemPosition = if (items.isNotEmpty()) FIRST_INDEX else null
-                },
-            )
-        }
-
         LazyColumn(
             state = lazyListState,
             modifier =
@@ -167,17 +156,7 @@ private fun AttendanceList(
                 AttendanceItem(
                     item = item,
                     isExpanded = index == detailItemPosition,
-                    onItemClick = { item: AttendanceHistoryItem ->
-                        val position: Int = items.indexOf(item)
-                        if (position >= FIRST_INDEX) {
-                            detailItemPosition =
-                                if (position == detailItemPosition) {
-                                    null
-                                } else {
-                                    position
-                                }
-                        }
-                    },
+                    onItemClick = onItemClick,
                 )
             }
         }
@@ -208,71 +187,61 @@ private fun EmptyAttendanceList(modifier: Modifier = Modifier) {
 }
 
 @Composable
-private fun AttendanceHistoryFilterDropdown(
-    filter: AttendanceHistoryFilter,
-    onClick: (AttendanceHistoryFilter) -> Unit,
+private fun AttendanceListHeader(
+    filterState: AttendanceFilterState,
+    onWinOnlyClick: () -> Unit,
+    onYearlyClick: () -> Unit,
+    sort: AttendanceHistorySort,
+    updateSort: (AttendanceHistorySort) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    var isExpanded by remember { mutableStateOf(false) }
-    Box(modifier = modifier) {
-        Row(
-            modifier = Modifier.noRippleClickable { isExpanded = !isExpanded },
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            Text(
-                text =
-                    stringResource(
-                        when (filter) {
-                            AttendanceHistoryFilter.ALL -> Res.string.attendance_history_all
-                            AttendanceHistoryFilter.WIN -> Res.string.attendance_history_win
-                        },
-                    ),
-                style = PretendardRegular.copy(fontSize = 14.sp, color = Gray500),
-            )
-            Spacer(modifier = Modifier.width(4.dp))
-            Icon(
-                modifier = Modifier.size(20.dp),
-                painter = painterResource(Res.drawable.ic_arrow_down),
-                contentDescription = null,
-                tint = Gray500,
-            )
-        }
-        DropdownMenu(
-            expanded = isExpanded,
-            onDismissRequest = { isExpanded = false },
-            offset = DpOffset(0.dp, 4.dp),
-            containerColor = White,
-            shape = RoundedCornerShape(8.dp),
-            border = BorderStroke(0.4.dp, Gray300),
-            modifier =
-                Modifier
-                    .crop(vertical = 8.dp)
-                    .padding(vertical = 4.dp),
-        ) {
-            AttendanceHistoryFilter.entries.forEach { filter: AttendanceHistoryFilter ->
-                DropdownMenuItem(
-                    text = {
-                        Text(
-                            text =
-                                stringResource(
-                                    when (filter) {
-                                        AttendanceHistoryFilter.ALL -> Res.string.attendance_history_all
-                                        AttendanceHistoryFilter.WIN -> Res.string.attendance_history_win
-                                    },
-                                ),
-                            style = PretendardRegular.copy(fontSize = 14.sp, color = Gray500),
-                        )
-                    },
-                    onClick = {
-                        onClick(filter)
-                        isExpanded = false
-                        AnalyticsLogger.logEvent("attendance_history_change_filter")
-                    },
-                    contentPadding = PaddingValues(horizontal = 12.dp, vertical = 0.dp),
-                    modifier = Modifier.crop(horizontal = 0.dp, vertical = 8.dp),
-                )
-            }
-        }
+    Row(
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .padding(horizontal = 20.dp),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        AttendanceFilterRow(
+            filterState = filterState,
+            onWinOnlyClick = onWinOnlyClick,
+            onYearlyClick = onYearlyClick,
+        )
+
+        AttendanceHistorySortSwitch(
+            sort = sort,
+            onClick = {
+                val newSort: AttendanceHistorySort = sort.toggle()
+                updateSort(newSort)
+            },
+        )
+    }
+}
+
+@Composable
+private fun AttendanceFilterRow(
+    filterState: AttendanceFilterState,
+    onWinOnlyClick: () -> Unit,
+    onYearlyClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = modifier,
+    ) {
+        FilterCheckbox(
+            text = stringResource(Res.string.attendance_history_win_only),
+            isSelected = filterState.isWinOnly,
+            onClick = onWinOnlyClick,
+        )
+
+        FilterCheckbox(
+            text = stringResource(Res.string.attendance_history_yearly, filterState.year),
+            isSelected = filterState.isYearly,
+            onClick = onYearlyClick,
+        )
     }
 }
 
@@ -316,10 +285,8 @@ private fun AttendanceHistorySortSwitch(
 private fun AttendanceListPreview() {
     AttendanceList(
         items = ATTENDANCE_HISTORY_ITEMS,
-        filter = AttendanceHistoryFilter.ALL,
-        updateFilter = {},
-        sort = AttendanceHistorySort.LATEST,
-        updateSort = {},
+        detailItemPosition = 0,
+        onItemClick = {},
     )
 }
 

--- a/mobile/composeApp/src/commonMain/kotlin/com/yagubogu/ui/attendance/component/AttendanceListContent.kt
+++ b/mobile/composeApp/src/commonMain/kotlin/com/yagubogu/ui/attendance/component/AttendanceListContent.kt
@@ -30,7 +30,6 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.yagubogu.analytics.AnalyticsLogger
 import com.yagubogu.ui.attendance.model.AttendanceFilterState
-import com.yagubogu.ui.attendance.model.AttendanceHistoryFilter
 import com.yagubogu.ui.attendance.model.AttendanceHistoryItem
 import com.yagubogu.ui.attendance.model.AttendanceHistorySort
 import com.yagubogu.ui.theme.Gray400
@@ -38,8 +37,10 @@ import com.yagubogu.ui.theme.Gray500
 import com.yagubogu.ui.theme.PretendardMedium
 import com.yagubogu.ui.theme.PretendardRegular
 import com.yagubogu.ui.util.noRippleClickable
+import com.yagubogu.ui.util.now
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.datetime.YearMonth
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
 import yagubogu.composeapp.generated.resources.Res
@@ -57,8 +58,9 @@ private const val FIRST_INDEX = 0
 @Composable
 fun AttendanceListContent(
     items: List<AttendanceHistoryItem>,
-    filter: AttendanceHistoryFilter,
-    updateFilter: (AttendanceHistoryFilter) -> Unit,
+    filterState: AttendanceFilterState,
+    onWinOnlyFilterToggle: () -> Unit,
+    onYearlyFilterToggle: () -> Unit,
     sort: AttendanceHistorySort,
     updateSort: (AttendanceHistorySort) -> Unit,
     modifier: Modifier = Modifier,
@@ -70,13 +72,13 @@ fun AttendanceListContent(
         modifier = modifier.fillMaxSize(),
     ) {
         AttendanceListHeader(
-            filterState = AttendanceFilterState(year = 2026, isYearly = true),
-            onWinOnlyClick = {
-                // TODO
+            filterState = filterState,
+            onWinOnlyFilterToggle = {
+                onWinOnlyFilterToggle()
                 detailItemPosition = if (items.isNotEmpty()) FIRST_INDEX else null
             },
-            onYearlyClick = {
-                // TODO
+            onYearlyFilterToggle = {
+                onYearlyFilterToggle()
                 detailItemPosition = if (items.isNotEmpty()) FIRST_INDEX else null
             },
             sort = sort,
@@ -189,8 +191,8 @@ private fun EmptyAttendanceList(modifier: Modifier = Modifier) {
 @Composable
 private fun AttendanceListHeader(
     filterState: AttendanceFilterState,
-    onWinOnlyClick: () -> Unit,
-    onYearlyClick: () -> Unit,
+    onWinOnlyFilterToggle: () -> Unit,
+    onYearlyFilterToggle: () -> Unit,
     sort: AttendanceHistorySort,
     updateSort: (AttendanceHistorySort) -> Unit,
     modifier: Modifier = Modifier,
@@ -205,8 +207,8 @@ private fun AttendanceListHeader(
     ) {
         AttendanceFilterRow(
             filterState = filterState,
-            onWinOnlyClick = onWinOnlyClick,
-            onYearlyClick = onYearlyClick,
+            onWinOnlyClick = onWinOnlyFilterToggle,
+            onYearlyClick = onYearlyFilterToggle,
         )
 
         AttendanceHistorySortSwitch(
@@ -238,7 +240,7 @@ private fun AttendanceFilterRow(
         )
 
         FilterCheckbox(
-            text = stringResource(Res.string.attendance_history_yearly, filterState.year),
+            text = stringResource(Res.string.attendance_history_yearly, filterState.yearMonth.year),
             isSelected = filterState.isYearly,
             onClick = onYearlyClick,
         )
@@ -282,16 +284,26 @@ private fun AttendanceHistorySortSwitch(
 
 @Preview("리스트 화면", showBackground = true)
 @Composable
-private fun AttendanceListPreview() {
-    AttendanceList(
+private fun AttendanceListContentPreview() {
+    AttendanceListContent(
         items = ATTENDANCE_HISTORY_ITEMS,
-        detailItemPosition = 0,
-        onItemClick = {},
+        filterState = AttendanceFilterState(yearMonth = YearMonth.now()),
+        onWinOnlyFilterToggle = {},
+        onYearlyFilterToggle = {},
+        sort = AttendanceHistorySort.LATEST,
+        updateSort = {},
     )
 }
 
 @Preview("빈 리스트 화면", showBackground = true)
 @Composable
-private fun EmptyAttendancePreview() {
-    EmptyAttendanceList()
+private fun EmptyAttendanceListContentPreview() {
+    AttendanceListContent(
+        items = emptyList(),
+        filterState = AttendanceFilterState(yearMonth = YearMonth.now()),
+        onWinOnlyFilterToggle = {},
+        onYearlyFilterToggle = {},
+        sort = AttendanceHistorySort.LATEST,
+        updateSort = {},
+    )
 }

--- a/mobile/composeApp/src/commonMain/kotlin/com/yagubogu/ui/attendance/component/FilterCheckbox.kt
+++ b/mobile/composeApp/src/commonMain/kotlin/com/yagubogu/ui/attendance/component/FilterCheckbox.kt
@@ -1,0 +1,83 @@
+package com.yagubogu.ui.attendance.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.yagubogu.ui.theme.Gray500
+import com.yagubogu.ui.theme.PretendardRegular
+import com.yagubogu.ui.theme.White
+import com.yagubogu.ui.util.noRippleClickable
+import org.jetbrains.compose.resources.painterResource
+import yagubogu.composeapp.generated.resources.Res
+import yagubogu.composeapp.generated.resources.ic_check
+
+@Composable
+fun FilterCheckbox(
+    text: String,
+    isSelected: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier.noRippleClickable { onClick() },
+        horizontalArrangement = Arrangement.spacedBy(4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Box(
+            modifier =
+                Modifier
+                    .size(16.dp)
+                    .border(width = 1.dp, color = Gray500, shape = CircleShape)
+                    .background(
+                        color = if (isSelected) Gray500 else Color.Transparent,
+                        shape = CircleShape,
+                    ),
+        ) {
+            if (isSelected) {
+                Icon(
+                    painter = painterResource(Res.drawable.ic_check),
+                    contentDescription = null,
+                    tint = White,
+                    modifier = Modifier.size(12.dp).align(Alignment.Center),
+                )
+            }
+        }
+        Text(
+            text = text,
+            style = PretendardRegular.copy(fontSize = 14.sp, color = Gray500),
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun FilterCheckboxOnPreview() {
+    FilterCheckbox(
+        text = "체크박스 On",
+        isSelected = true,
+        onClick = {},
+    )
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun FilterCheckboxOffPreview() {
+    FilterCheckbox(
+        text = "체크박스 Off",
+        isSelected = false,
+        onClick = {},
+    )
+}

--- a/mobile/composeApp/src/commonMain/kotlin/com/yagubogu/ui/attendance/model/AttendanceFilterState.kt
+++ b/mobile/composeApp/src/commonMain/kotlin/com/yagubogu/ui/attendance/model/AttendanceFilterState.kt
@@ -1,0 +1,7 @@
+package com.yagubogu.ui.attendance.model
+
+data class AttendanceFilterState(
+    val year: Int,
+    val isWinOnly: Boolean = false,
+    val isYearly: Boolean = false,
+)

--- a/mobile/composeApp/src/commonMain/kotlin/com/yagubogu/ui/attendance/model/AttendanceFilterState.kt
+++ b/mobile/composeApp/src/commonMain/kotlin/com/yagubogu/ui/attendance/model/AttendanceFilterState.kt
@@ -1,7 +1,9 @@
 package com.yagubogu.ui.attendance.model
 
+import kotlinx.datetime.YearMonth
+
 data class AttendanceFilterState(
-    val year: Int,
+    val yearMonth: YearMonth,
     val isWinOnly: Boolean = false,
     val isYearly: Boolean = false,
 )

--- a/mobile/composeApp/src/commonMain/kotlin/com/yagubogu/ui/attendance/model/AttendanceHistoryFilter.kt
+++ b/mobile/composeApp/src/commonMain/kotlin/com/yagubogu/ui/attendance/model/AttendanceHistoryFilter.kt
@@ -1,6 +1,0 @@
-package com.yagubogu.ui.attendance.model
-
-enum class AttendanceHistoryFilter {
-    ALL,
-    WIN,
-}


### PR DESCRIPTION
## 📌 관련 이슈
- close #982 

## ✨ 변경 내용
### 직관내역 연간 조회 (두리가 계속 해달라고 재촉함..)
직관내역 목록 화면에서 필터 UI를 드롭다운에서 체크박스로 변경했습니다.
체크박스를 통해 `전체 경기/승리한 경기`와 `월간 조회/연간 조회` 필터링이 가능합니다.

## 🎸 기타 참고 사항
- 스크린샷, 참고 링크, 추가 설명 등 (없으면 생략 가능)


https://github.com/user-attachments/assets/559ef80d-5d14-4e24-a32d-3838cfe12ecc

