### PR TITLE
feat: 승리요정 랭킹 점수 계산에 과거 직관(NON_LOCATION_CHECK_IN) 포함

### DIFF
--- a/backend/app/src/main/java/com/yagubogu/checkin/repository/CheckInRepository.java
+++ b/backend/app/src/main/java/com/yagubogu/checkin/repository/CheckInRepository.java
@@ -58,7 +58,6 @@ public interface CheckInRepository extends JpaRepository<CheckIn, Long>, CustomC
             FROM CheckIn c
             JOIN c.game g
             WHERE YEAR(g.date) = :year
-            AND c.checkInType = 'LOCATION_CHECK_IN'
             ORDER BY c.member.id
             """)
     Slice<Long> findDistinctMemberIdsByYear(

--- a/backend/app/src/main/java/com/yagubogu/checkin/repository/CustomCheckInRepositoryImpl.java
+++ b/backend/app/src/main/java/com/yagubogu/checkin/repository/CustomCheckInRepositoryImpl.java
@@ -122,8 +122,7 @@ public class CustomCheckInRepositoryImpl implements CustomCheckInRepository {
                 .where(
                         CHECK_IN.member.id.in(memberIds),
                         isBetweenYear(year),
-                        isComplete(),
-                        isLocationCheckIn()
+                        isComplete()
                 )
                 .groupBy(CHECK_IN.member.id)
                 .fetch();

--- a/backend/app/src/test/java/com/yagubogu/stat/service/StatSyncServiceUsingMysqlTest.java
+++ b/backend/app/src/test/java/com/yagubogu/stat/service/StatSyncServiceUsingMysqlTest.java
@@ -166,16 +166,16 @@ class StatSyncServiceUsingMysqlTest extends ServiceUsingMysqlTestBase {
         assertThat(victoryFairyRankingRepository.findAll()).isEmpty();
     }
 
-    @DisplayName("과거 직관(NON_LOCATION_CHECK_IN)은 승리요정 랭킹 점수 계산에 포함되지 않는다")
+    @DisplayName("과거 직관(NON_LOCATION_CHECK_IN)도 승리요정 랭킹 점수 계산에 포함된다")
     @Test
-    void updateRankings_excludesPastCheckIn() {
+    void updateRankings_includesPastCheckIn() {
         // given
         LocalDate date = LocalDate.of(2025, 7, 21);
         int year = date.getYear();
 
         Member member = memberFactory.save(b -> b.team(HT));
 
-        // 일반 직관: HT 승 (랭킹에 포함되어야 함)
+        // 일반 직관: HT 승
         Game normalGame = gameFactory.save(b -> b.stadium(kia)
                 .homeTeam(HT).awayTeam(LT)
                 .date(date)
@@ -183,7 +183,7 @@ class StatSyncServiceUsingMysqlTest extends ServiceUsingMysqlTestBase {
                 .gameState(GameState.COMPLETED));
         checkInFactory.save(b -> b.game(normalGame).member(member).team(HT));
 
-        // 과거 직관: HT 승 (랭킹에 포함되면 안 됨)
+        // 과거 직관: HT 승 (랭킹에도 포함되어야 함)
         Game pastGame = gameFactory.save(b -> b.stadium(kia)
                 .homeTeam(HT).awayTeam(LT)
                 .date(LocalDate.of(2025, 6, 1))
@@ -195,20 +195,20 @@ class StatSyncServiceUsingMysqlTest extends ServiceUsingMysqlTestBase {
         // when
         statSyncService.updateRankings(date);
 
-        // then: 과거 직관 제외, 일반 직관 1회만 반영 (checkInCount=1, winCount=1)
+        // then: 과거 직관 포함, 총 2회 직관 반영 (checkInCount=2, winCount=2)
         List<VictoryFairyRanking> results = victoryFairyRankingRepository
                 .findByMemberIdsAndYear(List.of(member.getId()), year);
 
         assertSoftly(softAssertions -> {
             softAssertions.assertThat(results).hasSize(1);
-            softAssertions.assertThat(results.get(0).getCheckInCount()).isEqualTo(1);
-            softAssertions.assertThat(results.get(0).getWinCount()).isEqualTo(1);
+            softAssertions.assertThat(results.get(0).getCheckInCount()).isEqualTo(2);
+            softAssertions.assertThat(results.get(0).getWinCount()).isEqualTo(2);
         });
     }
 
-    @DisplayName("과거 직관(NON_LOCATION_CHECK_IN)만 있는 회원은 승리요정 랭킹에 등록되지 않는다")
+    @DisplayName("과거 직관(NON_LOCATION_CHECK_IN)만 있는 회원도 승리요정 랭킹에 등록된다")
     @Test
-    void updateRankings_memberWithOnlyPastCheckIn_isNotRanked() {
+    void updateRankings_memberWithOnlyPastCheckIn_isRanked() {
         // given
         LocalDate date = LocalDate.of(2025, 7, 21);
         int year = date.getYear();
@@ -216,7 +216,7 @@ class StatSyncServiceUsingMysqlTest extends ServiceUsingMysqlTestBase {
         Member normalMember = memberFactory.save(b -> b.team(HT));
         Member pastOnlyMember = memberFactory.save(b -> b.team(HT));
 
-        // normalMember: 일반 직관
+        // normalMember: 일반 직관 (해당 날짜)
         Game normalGame = gameFactory.save(b -> b.stadium(kia)
                 .homeTeam(HT).awayTeam(LT)
                 .date(date)
@@ -224,7 +224,7 @@ class StatSyncServiceUsingMysqlTest extends ServiceUsingMysqlTestBase {
                 .gameState(GameState.COMPLETED));
         checkInFactory.save(b -> b.game(normalGame).member(normalMember).team(HT));
 
-        // pastOnlyMember: 과거 직관만 존재
+        // pastOnlyMember: 과거 직관만 존재 (랭킹에도 포함되어야 함)
         Game pastGame = gameFactory.save(b -> b.stadium(kia)
                 .homeTeam(HT).awayTeam(LT)
                 .date(LocalDate.of(2025, 6, 1))
@@ -236,13 +236,15 @@ class StatSyncServiceUsingMysqlTest extends ServiceUsingMysqlTestBase {
         // when
         statSyncService.updateRankings(date);
 
-        // then: normalMember만 랭킹에 등록, pastOnlyMember는 등록되지 않음
+        // then: normalMember와 pastOnlyMember 모두 랭킹에 등록
         List<VictoryFairyRanking> results = victoryFairyRankingRepository
                 .findByMemberIdsAndYear(List.of(normalMember.getId(), pastOnlyMember.getId()), year);
 
         assertSoftly(softAssertions -> {
-            softAssertions.assertThat(results).hasSize(1);
-            softAssertions.assertThat(results.get(0).getMember().getId()).isEqualTo(normalMember.getId());
+            softAssertions.assertThat(results).hasSize(2);
+            softAssertions.assertThat(results)
+                    .extracting(r -> r.getMember().getId())
+                    .containsExactlyInAnyOrder(normalMember.getId(), pastOnlyMember.getId());
         });
     }
 


### PR DESCRIPTION
## 개요

승리요정 랭킹 점수 계산 시 `LOCATION_CHECK_IN`(현장 직관)만 집계하던 로직을 `NON_LOCATION_CHECK_IN`(과거 직관)도 포함하도록 수정합니다.

Resolves #1001

## 변경 사항

### `CheckInRepository.java`
- `findDistinctMemberIdsByYear`: 배치 대상 회원 조회 쿼리에서 `checkInType = 'LOCATION_CHECK_IN'` 조건 제거
  - 과거 직관만 있는 회원도 배치에 포함됨

### `CustomCheckInRepositoryImpl.java`
- `findCheckInAndWinCountBatch`: 점수 계산 쿼리에서 `isLocationCheckIn()` 조건 제거
  - 모든 타입의 체크인이 `checkInCount`, `winCount` 계산에 반영됨

### `StatSyncServiceUsingMysqlTest.java`
- `updateRankings_excludesPastCheckIn` → `updateRankings_includesPastCheckIn`: 과거 직관도 집계에 포함됨을 검증
- `updateRankings_memberWithOnlyPastCheckIn_isNotRanked` → `updateRankings_memberWithOnlyPastCheckIn_isRanked`: 과거 직관만 있는 회원도 랭킹에 등록됨을 검증