### PR TITLE
feat: 직관 랭킹 API 및 QueryDSL 구현 (#1003)

### DIFF
--- a/.agents/workflows/github-flow.md
+++ b/.agents/workflows/github-flow.md
@@ -1,0 +1,27 @@
+---
+description: GitHub 이슈 생성부터 브랜치 작업, PR 생성까지 E2E 자동화
+---
+# GitHub Feature Workflow
+
+## Objective
+요구사항을 바탕으로 GitHub 이슈 생성, 브랜치 작업, 코드 작성 후 PR 생성까지의 과정을 자동화합니다.
+
+## Required Context & Tools
+- GitHub MCP 활성화 확인
+- 로컬 Git CLI 접근 권한
+- 에디터 및 파일 시스템 접근 권한
+
+## Workflow Steps
+다음 순서를 엄격하게 준수하여 작업을 수행합니다:
+
+1. **요구사항 확인**: 구현할 기능의 상세 요구사항을 요청하고 대기합니다.
+2. **이슈 생성**: GitHub MCP를 사용하여 요구사항 기반의 새 Issue를 생성하고, 반환된 Issue 번호를 기록합니다.
+3. **브랜치 생성**: 터미널을 사용하여 다음 규칙으로 브랜치를 생성하고 체크아웃합니다.
+   - `git checkout -b feat/{Issue-Number}`
+4. **코드 구현**: 에디터 뷰 및 파일 시스템에 접근하여 코드를 작성 및 수정합니다.
+5. **커밋 및 푸시**: 터미널을 사용하여 변경 사항을 원격 저장소에 푸시합니다.
+   - `git add .`
+   - `git commit -m "feat: 핵심 요약 (#Issue-Number)"`
+   - `git push -u origin HEAD`
+6. **PR 생성**: GitHub MCP를 사용하여 Pull Request를 생성합니다. PR 본문에 `Resolves #{Issue-Number}`를 포함합니다.
+

--- a/.claude/skills/github-flow/SKILL.md
+++ b/.claude/skills/github-flow/SKILL.md
@@ -1,0 +1,24 @@
+# GitHub Feature Workflow Skill
+
+## Objective
+요구사항을 바탕으로 GitHub 이슈 생성, 브랜치 작업, 코드 작성 후 PR 생성까지의 E2E 과정을 자동화합니다.
+
+## Required Tools
+- GitHub MCP (Issue, Pull Request 관리)
+- Bash (로컬 Git 명령어 실행)
+- File Edit (코드 작성 및 수정)
+
+## Step-by-Step Workflow
+반드시 다음 순서를 엄격하게 준수하여 작업을 수행하십시오.
+
+1. **요구사항 확인**: 사용자에게 구현할 기능의 상세 요구사항을 요청하고 대기합니다.
+2. **이슈 생성**: GitHub MCP를 사용하여 수신한 요구사항 기반의 새 Issue를 생성하고, 반환된 Issue Number를 기록합니다.
+3. **브랜치 생성**: Bash 도구를 사용하여 다음 규칙으로 브랜치를 생성하고 체크아웃합니다.
+   - 명령어: `git checkout -b feat/{Issue-Number}`
+4. **코드 구현**: 로컬 파일 시스템에 접근하여 요구사항에 맞게 코드를 작성하고 수정합니다.
+5. **커밋 및 푸시**: Bash 도구를 사용하여 변경 사항을 원격 저장소에 푸시합니다.
+   - 명령어: `git add .`
+   - 명령어: `git commit -m "feat: 핵심 요약 (#Issue-Number)"`
+   - 명령어: `git push -u origin HEAD`
+6. **PR 생성**: GitHub MCP를 사용하여 Pull Request를 엽니다. PR 본문에 `Resolves #{Issue-Number}`를 포함시켜 이슈와 연결합니다.
+

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/2025-yagu-bogu.iml
+++ b/.idea/2025-yagu-bogu.iml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="CheckStyle-IDEA-Module" serialisationVersion="2">
+    <option name="activeLocationsIds" />
+  </component>
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/checkstyle-idea.xml
+++ b/.idea/checkstyle-idea.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="CheckStyle-IDEA" serialisationVersion="2">
+    <checkstyleVersion>10.26.1</checkstyleVersion>
+    <scanScope>JavaOnly</scanScope>
+    <option name="thirdPartyClasspath" />
+    <option name="activeLocationIds" />
+    <option name="locations">
+      <list>
+        <ConfigurationLocation id="bundled-sun-checks" type="BUNDLED" scope="All" description="Sun Checks">(bundled)</ConfigurationLocation>
+        <ConfigurationLocation id="bundled-google-checks" type="BUNDLED" scope="All" description="Google Checks">(bundled)</ConfigurationLocation>
+      </list>
+    </option>
+  </component>
+</project>

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="GradleMigrationSettings" migrationVersion="1" />
+  <component name="GradleSettings">
+    <option name="linkedExternalProjectsSettings">
+      <GradleProjectSettings>
+        <option name="externalProjectPath" value="$PROJECT_DIR$/android" />
+        <option name="gradleJvm" value="corretto-21" />
+        <option name="modules">
+          <set>
+            <option value="$PROJECT_DIR$/android" />
+            <option value="$PROJECT_DIR$/android/app" />
+          </set>
+        </option>
+      </GradleProjectSettings>
+      <GradleProjectSettings>
+        <option name="externalProjectPath" value="$PROJECT_DIR$/backend" />
+        <option name="gradleJvm" value="corretto-21" />
+        <option name="modules">
+          <set>
+            <option value="$PROJECT_DIR$/backend" />
+            <option value="$PROJECT_DIR$/backend/app" />
+            <option value="$PROJECT_DIR$/backend/crawling" />
+          </set>
+        </option>
+      </GradleProjectSettings>
+    </option>
+  </component>
+</project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ExternalStorageConfigurationManager" enabled="true" />
+  <component name="FrameworkDetectionExcludesConfiguration">
+    <file type="web" url="file://$PROJECT_DIR$/android" />
+    <file type="web" url="file://$PROJECT_DIR$/backend" />
+  </component>
+  <component name="ProjectRootManager">
+    <output url="file://$PROJECT_DIR$/out" />
+  </component>
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/2025-yagu-bogu.iml" filepath="$PROJECT_DIR$/.idea/2025-yagu-bogu.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/modules/app/yagubogu-backend.app.iml
+++ b/.idea/modules/app/yagubogu-backend.app.iml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module version="4">
+  <component name="CheckStyle-IDEA-Module" serialisationVersion="2">
+    <option name="activeLocationsIds" />
+  </component>
+</module>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/backend/app/src/main/generated/com/yagubogu/auth/domain/QRefreshToken.java
+++ b/backend/app/src/main/generated/com/yagubogu/auth/domain/QRefreshToken.java
@@ -1,0 +1,55 @@
+package com.yagubogu.auth.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QRefreshToken is a Querydsl query type for RefreshToken
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QRefreshToken extends EntityPathBase<RefreshToken> {
+
+    private static final long serialVersionUID = -1128874798L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QRefreshToken refreshToken = new QRefreshToken("refreshToken");
+
+    public final DateTimePath<java.time.Instant> expiresAt = createDateTime("expiresAt", java.time.Instant.class);
+
+    public final StringPath id = createString("id");
+
+    public final BooleanPath isRevoked = createBoolean("isRevoked");
+
+    public final com.yagubogu.member.domain.QMember member;
+
+    public QRefreshToken(String variable) {
+        this(RefreshToken.class, forVariable(variable), INITS);
+    }
+
+    public QRefreshToken(Path<? extends RefreshToken> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QRefreshToken(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QRefreshToken(PathMetadata metadata, PathInits inits) {
+        this(RefreshToken.class, metadata, inits);
+    }
+
+    public QRefreshToken(Class<? extends RefreshToken> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.member = inits.isInitialized("member") ? new com.yagubogu.member.domain.QMember(forProperty("member"), inits.get("member")) : null;
+    }
+
+}
+

--- a/backend/app/src/main/generated/com/yagubogu/badge/domain/QBadge.java
+++ b/backend/app/src/main/generated/com/yagubogu/badge/domain/QBadge.java
@@ -1,0 +1,47 @@
+package com.yagubogu.badge.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QBadge is a Querydsl query type for Badge
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QBadge extends EntityPathBase<Badge> {
+
+    private static final long serialVersionUID = 2033888116L;
+
+    public static final QBadge badge = new QBadge("badge");
+
+    public final StringPath badgeImageUrl = createString("badgeImageUrl");
+
+    public final StringPath description = createString("description");
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final StringPath name = createString("name");
+
+    public final EnumPath<Policy> policy = createEnum("policy", Policy.class);
+
+    public final NumberPath<Integer> threshold = createNumber("threshold", Integer.class);
+
+    public QBadge(String variable) {
+        super(Badge.class, forVariable(variable));
+    }
+
+    public QBadge(Path<? extends Badge> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QBadge(PathMetadata metadata) {
+        super(Badge.class, metadata);
+    }
+
+}
+

--- a/backend/app/src/main/generated/com/yagubogu/badge/domain/QMemberBadge.java
+++ b/backend/app/src/main/generated/com/yagubogu/badge/domain/QMemberBadge.java
@@ -1,0 +1,71 @@
+package com.yagubogu.badge.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QMemberBadge is a Querydsl query type for MemberBadge
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QMemberBadge extends EntityPathBase<MemberBadge> {
+
+    private static final long serialVersionUID = 334815290L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QMemberBadge memberBadge = new QMemberBadge("memberBadge");
+
+    public final com.yagubogu.global.domain.QBaseEntity _super = new com.yagubogu.global.domain.QBaseEntity(this);
+
+    public final DateTimePath<java.time.LocalDateTime> achievedAt = createDateTime("achievedAt", java.time.LocalDateTime.class);
+
+    public final QBadge badge;
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> deletedAt = _super.deletedAt;
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final BooleanPath isAchieved = createBoolean("isAchieved");
+
+    public final com.yagubogu.member.domain.QMember member;
+
+    public final NumberPath<Integer> progress = createNumber("progress", Integer.class);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> updatedAt = _super.updatedAt;
+
+    public QMemberBadge(String variable) {
+        this(MemberBadge.class, forVariable(variable), INITS);
+    }
+
+    public QMemberBadge(Path<? extends MemberBadge> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QMemberBadge(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QMemberBadge(PathMetadata metadata, PathInits inits) {
+        this(MemberBadge.class, metadata, inits);
+    }
+
+    public QMemberBadge(Class<? extends MemberBadge> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.badge = inits.isInitialized("badge") ? new QBadge(forProperty("badge")) : null;
+        this.member = inits.isInitialized("member") ? new com.yagubogu.member.domain.QMember(forProperty("member"), inits.get("member")) : null;
+    }
+
+}
+

--- a/backend/app/src/main/generated/com/yagubogu/checkin/domain/QCheckIn.java
+++ b/backend/app/src/main/generated/com/yagubogu/checkin/domain/QCheckIn.java
@@ -1,0 +1,70 @@
+package com.yagubogu.checkin.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QCheckIn is a Querydsl query type for CheckIn
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QCheckIn extends EntityPathBase<CheckIn> {
+
+    private static final long serialVersionUID = 1847363092L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QCheckIn checkIn = new QCheckIn("checkIn");
+
+    public final com.yagubogu.global.domain.QBaseEntity _super = new com.yagubogu.global.domain.QBaseEntity(this);
+
+    public final EnumPath<CheckInType> checkInType = createEnum("checkInType", CheckInType.class);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> deletedAt = _super.deletedAt;
+
+    public final com.yagubogu.game.domain.QGame game;
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final com.yagubogu.member.domain.QMember member;
+
+    public final com.yagubogu.team.domain.QTeam team;
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> updatedAt = _super.updatedAt;
+
+    public QCheckIn(String variable) {
+        this(CheckIn.class, forVariable(variable), INITS);
+    }
+
+    public QCheckIn(Path<? extends CheckIn> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QCheckIn(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QCheckIn(PathMetadata metadata, PathInits inits) {
+        this(CheckIn.class, metadata, inits);
+    }
+
+    public QCheckIn(Class<? extends CheckIn> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.game = inits.isInitialized("game") ? new com.yagubogu.game.domain.QGame(forProperty("game"), inits.get("game")) : null;
+        this.member = inits.isInitialized("member") ? new com.yagubogu.member.domain.QMember(forProperty("member"), inits.get("member")) : null;
+        this.team = inits.isInitialized("team") ? new com.yagubogu.team.domain.QTeam(forProperty("team")) : null;
+    }
+
+}
+

--- a/backend/app/src/main/generated/com/yagubogu/game/domain/QBronzeGame.java
+++ b/backend/app/src/main/generated/com/yagubogu/game/domain/QBronzeGame.java
@@ -1,0 +1,57 @@
+package com.yagubogu.game.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QBronzeGame is a Querydsl query type for BronzeGame
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QBronzeGame extends EntityPathBase<BronzeGame> {
+
+    private static final long serialVersionUID = 968866410L;
+
+    public static final QBronzeGame bronzeGame = new QBronzeGame("bronzeGame");
+
+    public final StringPath awayTeam = createString("awayTeam");
+
+    public final DateTimePath<java.time.LocalDateTime> collectedAt = createDateTime("collectedAt", java.time.LocalDateTime.class);
+
+    public final StringPath contentHash = createString("contentHash");
+
+    public final DatePath<java.time.LocalDate> date = createDate("date", java.time.LocalDate.class);
+
+    public final DateTimePath<java.time.LocalDateTime> etlProcessedAt = createDateTime("etlProcessedAt", java.time.LocalDateTime.class);
+
+    public final StringPath homeTeam = createString("homeTeam");
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final StringPath payload = createString("payload");
+
+    public final StringPath stadium = createString("stadium");
+
+    public final TimePath<java.time.LocalTime> startTime = createTime("startTime", java.time.LocalTime.class);
+
+    public final EnumPath<GameState> state = createEnum("state", GameState.class);
+
+    public QBronzeGame(String variable) {
+        super(BronzeGame.class, forVariable(variable));
+    }
+
+    public QBronzeGame(Path<? extends BronzeGame> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QBronzeGame(PathMetadata metadata) {
+        super(BronzeGame.class, metadata);
+    }
+
+}
+

--- a/backend/app/src/main/generated/com/yagubogu/game/domain/QGame.java
+++ b/backend/app/src/main/generated/com/yagubogu/game/domain/QGame.java
@@ -1,0 +1,79 @@
+package com.yagubogu.game.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QGame is a Querydsl query type for Game
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QGame extends EntityPathBase<Game> {
+
+    private static final long serialVersionUID = 1012974640L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QGame game = new QGame("game");
+
+    public final StringPath awayPitcher = createString("awayPitcher");
+
+    public final NumberPath<Integer> awayScore = createNumber("awayScore", Integer.class);
+
+    public final QScoreBoard awayScoreBoard;
+
+    public final com.yagubogu.team.domain.QTeam awayTeam;
+
+    public final DatePath<java.time.LocalDate> date = createDate("date", java.time.LocalDate.class);
+
+    public final StringPath gameCode = createString("gameCode");
+
+    public final EnumPath<GameState> gameState = createEnum("gameState", GameState.class);
+
+    public final StringPath homePitcher = createString("homePitcher");
+
+    public final NumberPath<Integer> homeScore = createNumber("homeScore", Integer.class);
+
+    public final QScoreBoard homeScoreBoard;
+
+    public final com.yagubogu.team.domain.QTeam homeTeam;
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final com.yagubogu.stadium.domain.QStadium stadium;
+
+    public final TimePath<java.time.LocalTime> startAt = createTime("startAt", java.time.LocalTime.class);
+
+    public QGame(String variable) {
+        this(Game.class, forVariable(variable), INITS);
+    }
+
+    public QGame(Path<? extends Game> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QGame(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QGame(PathMetadata metadata, PathInits inits) {
+        this(Game.class, metadata, inits);
+    }
+
+    public QGame(Class<? extends Game> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.awayScoreBoard = inits.isInitialized("awayScoreBoard") ? new QScoreBoard(forProperty("awayScoreBoard")) : null;
+        this.awayTeam = inits.isInitialized("awayTeam") ? new com.yagubogu.team.domain.QTeam(forProperty("awayTeam")) : null;
+        this.homeScoreBoard = inits.isInitialized("homeScoreBoard") ? new QScoreBoard(forProperty("homeScoreBoard")) : null;
+        this.homeTeam = inits.isInitialized("homeTeam") ? new com.yagubogu.team.domain.QTeam(forProperty("homeTeam")) : null;
+        this.stadium = inits.isInitialized("stadium") ? new com.yagubogu.stadium.domain.QStadium(forProperty("stadium")) : null;
+    }
+
+}
+

--- a/backend/app/src/main/generated/com/yagubogu/game/domain/QScoreBoard.java
+++ b/backend/app/src/main/generated/com/yagubogu/game/domain/QScoreBoard.java
@@ -1,0 +1,48 @@
+package com.yagubogu.game.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QScoreBoard is a Querydsl query type for ScoreBoard
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QScoreBoard extends EntityPathBase<ScoreBoard> {
+
+    private static final long serialVersionUID = 1887821106L;
+
+    public static final QScoreBoard scoreBoard = new QScoreBoard("scoreBoard");
+
+    public final NumberPath<Integer> basesOnBalls = createNumber("basesOnBalls", Integer.class);
+
+    public final NumberPath<Integer> errors = createNumber("errors", Integer.class);
+
+    public final NumberPath<Integer> hits = createNumber("hits", Integer.class);
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final ListPath<String, StringPath> inningScores = this.<String, StringPath>createList("inningScores", String.class, StringPath.class, PathInits.DIRECT2);
+
+    public final NumberPath<Integer> runs = createNumber("runs", Integer.class);
+
+    public QScoreBoard(String variable) {
+        super(ScoreBoard.class, forVariable(variable));
+    }
+
+    public QScoreBoard(Path<? extends ScoreBoard> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QScoreBoard(PathMetadata metadata) {
+        super(ScoreBoard.class, metadata);
+    }
+
+}
+

--- a/backend/app/src/main/generated/com/yagubogu/global/domain/QBaseEntity.java
+++ b/backend/app/src/main/generated/com/yagubogu/global/domain/QBaseEntity.java
@@ -1,0 +1,41 @@
+package com.yagubogu.global.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QBaseEntity is a Querydsl query type for BaseEntity
+ */
+@Generated("com.querydsl.codegen.DefaultSupertypeSerializer")
+public class QBaseEntity extends EntityPathBase<BaseEntity> {
+
+    private static final long serialVersionUID = 1687193923L;
+
+    public static final QBaseEntity baseEntity = new QBaseEntity("baseEntity");
+
+    public final DateTimePath<java.time.LocalDateTime> createdAt = createDateTime("createdAt", java.time.LocalDateTime.class);
+
+    public final DateTimePath<java.time.LocalDateTime> deletedAt = createDateTime("deletedAt", java.time.LocalDateTime.class);
+
+    public final DateTimePath<java.time.LocalDateTime> updatedAt = createDateTime("updatedAt", java.time.LocalDateTime.class);
+
+    public QBaseEntity(String variable) {
+        super(BaseEntity.class, forVariable(variable));
+    }
+
+    public QBaseEntity(Path<? extends BaseEntity> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QBaseEntity(PathMetadata metadata) {
+        super(BaseEntity.class, metadata);
+    }
+
+}
+

--- a/backend/app/src/main/generated/com/yagubogu/like/domain/QLike.java
+++ b/backend/app/src/main/generated/com/yagubogu/like/domain/QLike.java
@@ -1,0 +1,56 @@
+package com.yagubogu.like.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QLike is a Querydsl query type for Like
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QLike extends EntityPathBase<Like> {
+
+    private static final long serialVersionUID = -1352909830L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QLike like = new QLike("like1");
+
+    public final com.yagubogu.game.domain.QGame game;
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final com.yagubogu.team.domain.QTeam team;
+
+    public final NumberPath<Long> totalCount = createNumber("totalCount", Long.class);
+
+    public QLike(String variable) {
+        this(Like.class, forVariable(variable), INITS);
+    }
+
+    public QLike(Path<? extends Like> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QLike(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QLike(PathMetadata metadata, PathInits inits) {
+        this(Like.class, metadata, inits);
+    }
+
+    public QLike(Class<? extends Like> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.game = inits.isInitialized("game") ? new com.yagubogu.game.domain.QGame(forProperty("game"), inits.get("game")) : null;
+        this.team = inits.isInitialized("team") ? new com.yagubogu.team.domain.QTeam(forProperty("team")) : null;
+    }
+
+}
+

--- a/backend/app/src/main/generated/com/yagubogu/member/domain/QMember.java
+++ b/backend/app/src/main/generated/com/yagubogu/member/domain/QMember.java
@@ -1,0 +1,78 @@
+package com.yagubogu.member.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QMember is a Querydsl query type for Member
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QMember extends EntityPathBase<Member> {
+
+    private static final long serialVersionUID = -968763392L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QMember member = new QMember("member1");
+
+    public final com.yagubogu.global.domain.QBaseEntity _super = new com.yagubogu.global.domain.QBaseEntity(this);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> deletedAt = _super.deletedAt;
+
+    public final StringPath email = createString("email");
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final StringPath imageUrl = createString("imageUrl");
+
+    public final QNickname nickname;
+
+    public final StringPath oauthId = createString("oauthId");
+
+    public final EnumPath<OAuthProvider> provider = createEnum("provider", OAuthProvider.class);
+
+    public final com.yagubogu.badge.domain.QBadge representativeBadge;
+
+    public final EnumPath<Role> role = createEnum("role", Role.class);
+
+    public final com.yagubogu.team.domain.QTeam team;
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> updatedAt = _super.updatedAt;
+
+    public QMember(String variable) {
+        this(Member.class, forVariable(variable), INITS);
+    }
+
+    public QMember(Path<? extends Member> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QMember(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QMember(PathMetadata metadata, PathInits inits) {
+        this(Member.class, metadata, inits);
+    }
+
+    public QMember(Class<? extends Member> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.nickname = inits.isInitialized("nickname") ? new QNickname(forProperty("nickname")) : null;
+        this.representativeBadge = inits.isInitialized("representativeBadge") ? new com.yagubogu.badge.domain.QBadge(forProperty("representativeBadge")) : null;
+        this.team = inits.isInitialized("team") ? new com.yagubogu.team.domain.QTeam(forProperty("team")) : null;
+    }
+
+}
+

--- a/backend/app/src/main/generated/com/yagubogu/member/domain/QNickname.java
+++ b/backend/app/src/main/generated/com/yagubogu/member/domain/QNickname.java
@@ -1,0 +1,37 @@
+package com.yagubogu.member.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QNickname is a Querydsl query type for Nickname
+ */
+@Generated("com.querydsl.codegen.DefaultEmbeddableSerializer")
+public class QNickname extends BeanPath<Nickname> {
+
+    private static final long serialVersionUID = 1746416724L;
+
+    public static final QNickname nickname = new QNickname("nickname");
+
+    public final StringPath value = createString("value");
+
+    public QNickname(String variable) {
+        super(Nickname.class, forVariable(variable));
+    }
+
+    public QNickname(Path<? extends Nickname> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QNickname(PathMetadata metadata) {
+        super(Nickname.class, metadata);
+    }
+
+}
+

--- a/backend/app/src/main/generated/com/yagubogu/stadium/domain/QStadium.java
+++ b/backend/app/src/main/generated/com/yagubogu/stadium/domain/QStadium.java
@@ -1,0 +1,49 @@
+package com.yagubogu.stadium.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QStadium is a Querydsl query type for Stadium
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QStadium extends EntityPathBase<Stadium> {
+
+    private static final long serialVersionUID = 1554870260L;
+
+    public static final QStadium stadium = new QStadium("stadium");
+
+    public final StringPath fullName = createString("fullName");
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final NumberPath<Double> latitude = createNumber("latitude", Double.class);
+
+    public final EnumPath<StadiumLevel> level = createEnum("level", StadiumLevel.class);
+
+    public final StringPath location = createString("location");
+
+    public final NumberPath<Double> longitude = createNumber("longitude", Double.class);
+
+    public final StringPath shortName = createString("shortName");
+
+    public QStadium(String variable) {
+        super(Stadium.class, forVariable(variable));
+    }
+
+    public QStadium(Path<? extends Stadium> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QStadium(PathMetadata metadata) {
+        super(Stadium.class, metadata);
+    }
+
+}
+

--- a/backend/app/src/main/generated/com/yagubogu/stat/domain/QVictoryFairyRanking.java
+++ b/backend/app/src/main/generated/com/yagubogu/stat/domain/QVictoryFairyRanking.java
@@ -1,0 +1,61 @@
+package com.yagubogu.stat.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QVictoryFairyRanking is a Querydsl query type for VictoryFairyRanking
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QVictoryFairyRanking extends EntityPathBase<VictoryFairyRanking> {
+
+    private static final long serialVersionUID = -1557947341L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QVictoryFairyRanking victoryFairyRanking = new QVictoryFairyRanking("victoryFairyRanking");
+
+    public final NumberPath<Integer> checkInCount = createNumber("checkInCount", Integer.class);
+
+    public final NumberPath<Integer> gameYear = createNumber("gameYear", Integer.class);
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final com.yagubogu.member.domain.QMember member;
+
+    public final NumberPath<Double> score = createNumber("score", Double.class);
+
+    public final DateTimePath<java.time.LocalDateTime> updatedAt = createDateTime("updatedAt", java.time.LocalDateTime.class);
+
+    public final NumberPath<Integer> winCount = createNumber("winCount", Integer.class);
+
+    public QVictoryFairyRanking(String variable) {
+        this(VictoryFairyRanking.class, forVariable(variable), INITS);
+    }
+
+    public QVictoryFairyRanking(Path<? extends VictoryFairyRanking> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QVictoryFairyRanking(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QVictoryFairyRanking(PathMetadata metadata, PathInits inits) {
+        this(VictoryFairyRanking.class, metadata, inits);
+    }
+
+    public QVictoryFairyRanking(Class<? extends VictoryFairyRanking> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.member = inits.isInitialized("member") ? new com.yagubogu.member.domain.QMember(forProperty("member"), inits.get("member")) : null;
+    }
+
+}
+

--- a/backend/app/src/main/generated/com/yagubogu/talk/domain/QTalk.java
+++ b/backend/app/src/main/generated/com/yagubogu/talk/domain/QTalk.java
@@ -1,0 +1,66 @@
+package com.yagubogu.talk.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QTalk is a Querydsl query type for Talk
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QTalk extends EntityPathBase<Talk> {
+
+    private static final long serialVersionUID = 1711492772L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QTalk talk = new QTalk("talk");
+
+    public final com.yagubogu.global.domain.QBaseEntity _super = new com.yagubogu.global.domain.QBaseEntity(this);
+
+    public final StringPath content = createString("content");
+
+    public final DateTimePath<java.time.LocalDateTime> createdAt = createDateTime("createdAt", java.time.LocalDateTime.class);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> deletedAt = _super.deletedAt;
+
+    public final com.yagubogu.game.domain.QGame game;
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final com.yagubogu.member.domain.QMember member;
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> updatedAt = _super.updatedAt;
+
+    public QTalk(String variable) {
+        this(Talk.class, forVariable(variable), INITS);
+    }
+
+    public QTalk(Path<? extends Talk> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QTalk(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QTalk(PathMetadata metadata, PathInits inits) {
+        this(Talk.class, metadata, inits);
+    }
+
+    public QTalk(Class<? extends Talk> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.game = inits.isInitialized("game") ? new com.yagubogu.game.domain.QGame(forProperty("game"), inits.get("game")) : null;
+        this.member = inits.isInitialized("member") ? new com.yagubogu.member.domain.QMember(forProperty("member"), inits.get("member")) : null;
+    }
+
+}
+

--- a/backend/app/src/main/generated/com/yagubogu/talk/domain/QTalkReport.java
+++ b/backend/app/src/main/generated/com/yagubogu/talk/domain/QTalkReport.java
@@ -1,0 +1,56 @@
+package com.yagubogu.talk.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QTalkReport is a Querydsl query type for TalkReport
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QTalkReport extends EntityPathBase<TalkReport> {
+
+    private static final long serialVersionUID = 855639288L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QTalkReport talkReport = new QTalkReport("talkReport");
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final DateTimePath<java.time.LocalDateTime> reportedAt = createDateTime("reportedAt", java.time.LocalDateTime.class);
+
+    public final com.yagubogu.member.domain.QMember reporter;
+
+    public final QTalk talk;
+
+    public QTalkReport(String variable) {
+        this(TalkReport.class, forVariable(variable), INITS);
+    }
+
+    public QTalkReport(Path<? extends TalkReport> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QTalkReport(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QTalkReport(PathMetadata metadata, PathInits inits) {
+        this(TalkReport.class, metadata, inits);
+    }
+
+    public QTalkReport(Class<? extends TalkReport> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.reporter = inits.isInitialized("reporter") ? new com.yagubogu.member.domain.QMember(forProperty("reporter"), inits.get("reporter")) : null;
+        this.talk = inits.isInitialized("talk") ? new QTalk(forProperty("talk"), inits.get("talk")) : null;
+    }
+
+}
+

--- a/backend/app/src/main/generated/com/yagubogu/team/domain/QTeam.java
+++ b/backend/app/src/main/generated/com/yagubogu/team/domain/QTeam.java
@@ -1,0 +1,45 @@
+package com.yagubogu.team.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QTeam is a Querydsl query type for Team
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QTeam extends EntityPathBase<Team> {
+
+    private static final long serialVersionUID = -168859514L;
+
+    public static final QTeam team = new QTeam("team");
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final StringPath name = createString("name");
+
+    public final StringPath shortName = createString("shortName");
+
+    public final EnumPath<TeamStatus> status = createEnum("status", TeamStatus.class);
+
+    public final StringPath teamCode = createString("teamCode");
+
+    public QTeam(String variable) {
+        super(Team.class, forVariable(variable));
+    }
+
+    public QTeam(Path<? extends Team> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QTeam(PathMetadata metadata) {
+        super(Team.class, metadata);
+    }
+
+}
+

--- a/backend/app/src/main/java/com/yagubogu/checkin/dto/LocationCheckInRankParam.java
+++ b/backend/app/src/main/java/com/yagubogu/checkin/dto/LocationCheckInRankParam.java
@@ -1,0 +1,10 @@
+package com.yagubogu.checkin.dto;
+
+public record LocationCheckInRankParam(
+        long memberId,
+        String nickname,
+        String profileImageUrl,
+        String teamShortName,
+        long visitCount
+) {
+}

--- a/backend/app/src/main/java/com/yagubogu/checkin/repository/CheckInRepository.java
+++ b/backend/app/src/main/java/com/yagubogu/checkin/repository/CheckInRepository.java
@@ -58,7 +58,6 @@ public interface CheckInRepository extends JpaRepository<CheckIn, Long>, CustomC
             FROM CheckIn c
             JOIN c.game g
             WHERE YEAR(g.date) = :year
-            AND c.checkInType = 'LOCATION_CHECK_IN'
             ORDER BY c.member.id
             """)
     Slice<Long> findDistinctMemberIdsByYear(

--- a/backend/app/src/main/java/com/yagubogu/checkin/repository/CustomCheckInRepository.java
+++ b/backend/app/src/main/java/com/yagubogu/checkin/repository/CustomCheckInRepository.java
@@ -4,6 +4,7 @@ import com.yagubogu.checkin.domain.CheckInOrderFilter;
 import com.yagubogu.checkin.domain.CheckInResultFilter;
 import com.yagubogu.checkin.dto.CheckInGameParam;
 import com.yagubogu.checkin.dto.GameWithFanCountsParam;
+import com.yagubogu.checkin.dto.LocationCheckInRankParam;
 import com.yagubogu.checkin.dto.StadiumCheckInCountParam;
 import com.yagubogu.checkin.dto.StatCountsParam;
 import com.yagubogu.checkin.dto.VictoryFairyCountResult;
@@ -72,4 +73,10 @@ public interface CustomCheckInRepository {
     List<Long> findDrawMemberIdByGameId(long gameId);
 
     List<StadiumStatsParam> findWinAndNonDrawCountByStadium(Long memberId, Integer year);
+
+    List<LocationCheckInRankParam> findLocationCheckInRanking(Integer year, int limit);
+
+    long findLocationCheckInRank(long memberId, Integer year);
+
+    LocationCheckInRankParam findLocationCheckInCountByMember(Member member, Integer year);
 }

--- a/backend/app/src/main/java/com/yagubogu/checkin/repository/CustomCheckInRepositoryImpl.java
+++ b/backend/app/src/main/java/com/yagubogu/checkin/repository/CustomCheckInRepositoryImpl.java
@@ -122,8 +122,7 @@ public class CustomCheckInRepositoryImpl implements CustomCheckInRepository {
                 .where(
                         CHECK_IN.member.id.in(memberIds),
                         isBetweenYear(year),
-                        isComplete(),
-                        isLocationCheckIn()
+                        isComplete()
                 )
                 .groupBy(CHECK_IN.member.id)
                 .fetch();

--- a/backend/app/src/main/java/com/yagubogu/checkin/repository/CustomCheckInRepositoryImpl.java
+++ b/backend/app/src/main/java/com/yagubogu/checkin/repository/CustomCheckInRepositoryImpl.java
@@ -18,6 +18,7 @@ import com.yagubogu.checkin.dto.CheckInGameTeamParam;
 import com.yagubogu.checkin.dto.GameWithFanCountsParam;
 import com.yagubogu.checkin.dto.StadiumCheckInCountParam;
 import com.yagubogu.checkin.dto.StatCountsParam;
+import com.yagubogu.checkin.dto.LocationCheckInRankParam;
 import com.yagubogu.checkin.dto.VictoryFairyCountResult;
 import com.yagubogu.game.domain.GameState;
 import com.yagubogu.game.domain.QGame;
@@ -470,6 +471,90 @@ public class CustomCheckInRepositoryImpl implements CustomCheckInRepository {
                 )
                 .groupBy(STADIUM.id, STADIUM.shortName)
                 .fetch();
+    }
+
+    @Override
+    public List<LocationCheckInRankParam> findLocationCheckInRanking(final Integer year, final int limit) {
+        return jpaQueryFactory
+                .select(Projections.constructor(
+                        LocationCheckInRankParam.class,
+                        CHECK_IN.member.id,
+                        CHECK_IN.member.nickname.value,
+                        CHECK_IN.member.imageUrl,
+                        CHECK_IN.team.shortName,
+                        CHECK_IN.id.count()
+                ))
+                .from(CHECK_IN)
+                .join(CHECK_IN.game, GAME)
+                .join(CHECK_IN.member, MEMBER)
+                .where(
+                        isLocationCheckIn(),
+                        isMemberNotDeleted(),
+                        isBetweenYear(GAME, year)
+                )
+                .groupBy(CHECK_IN.member.id, CHECK_IN.member.nickname.value, CHECK_IN.member.imageUrl, CHECK_IN.team.shortName)
+                .orderBy(CHECK_IN.id.count().desc(), CHECK_IN.member.id.asc())
+                .limit(limit)
+                .fetch();
+    }
+
+    @Override
+    public long findLocationCheckInRank(final long memberId, final Integer year) {
+        Long myCount = jpaQueryFactory
+                .select(CHECK_IN.id.count())
+                .from(CHECK_IN)
+                .join(CHECK_IN.game, GAME)
+                .where(
+                        CHECK_IN.member.id.eq(memberId),
+                        isLocationCheckIn(),
+                        isBetweenYear(GAME, year)
+                )
+                .fetchOne();
+
+        if (myCount == null || myCount == 0) {
+            return 0L;
+        }
+
+        Long rank = jpaQueryFactory
+                .select(CHECK_IN.member.id.countDistinct())
+                .from(CHECK_IN)
+                .join(CHECK_IN.game, GAME)
+                .join(CHECK_IN.member, MEMBER)
+                .where(
+                        isLocationCheckIn(),
+                        isMemberNotDeleted(),
+                        isBetweenYear(GAME, year)
+                )
+                .groupBy(CHECK_IN.member.id)
+                .having(CHECK_IN.id.count().gt(myCount)
+                        .or(CHECK_IN.id.count().eq(myCount).and(CHECK_IN.member.id.lt(memberId))))
+                .fetchCount();
+
+        return rank + 1;
+    }
+
+    @Override
+    public LocationCheckInRankParam findLocationCheckInCountByMember(final Member member, final Integer year) {
+        return jpaQueryFactory
+                .select(Projections.constructor(
+                        LocationCheckInRankParam.class,
+                        CHECK_IN.member.id,
+                        CHECK_IN.member.nickname.value,
+                        CHECK_IN.member.imageUrl,
+                        CHECK_IN.team.shortName,
+                        CHECK_IN.id.count()
+                ))
+                .from(CHECK_IN)
+                .join(CHECK_IN.game, GAME)
+                .join(CHECK_IN.member, MEMBER)
+                .where(
+                        CHECK_IN.member.eq(member),
+                        isLocationCheckIn(),
+                        isMemberNotDeleted(),
+                        isBetweenYear(GAME, year)
+                )
+                .groupBy(CHECK_IN.member.id, CHECK_IN.member.nickname.value, CHECK_IN.member.imageUrl, CHECK_IN.team.shortName)
+                .fetchOne();
     }
 
     private int conditionCount(final Member member, final Integer year, final BooleanExpression condition) {

--- a/backend/app/src/main/java/com/yagubogu/stat/controller/v1/StatController.java
+++ b/backend/app/src/main/java/com/yagubogu/stat/controller/v1/StatController.java
@@ -5,6 +5,7 @@ import com.yagubogu.auth.dto.MemberClaims;
 import com.yagubogu.checkin.dto.v1.TeamFilter;
 import com.yagubogu.checkin.dto.v1.VictoryFairyRankingResponse;
 import com.yagubogu.stat.dto.v1.AverageStatisticResponse;
+import com.yagubogu.stat.dto.v1.LocationCheckInRankingResponse;
 import com.yagubogu.stat.dto.v1.LuckyStadiumResponse;
 import com.yagubogu.stat.dto.v1.OpponentWinRateResponse;
 import com.yagubogu.stat.dto.v1.RecentGamesWinRateResponse;
@@ -84,6 +85,15 @@ public class StatController implements StatControllerInterface {
     ) {
         VictoryFairyRankingResponse response = statService.findVictoryFairyRankings(memberClaims.id(), teamFilter,
                 year);
+
+        return ResponseEntity.ok(response);
+    }
+
+    public ResponseEntity<LocationCheckInRankingResponse> findLocationCheckInRankings(
+            final MemberClaims memberClaims,
+            @RequestParam(required = false) final Integer year
+    ) {
+        LocationCheckInRankingResponse response = statService.findLocationCheckInRankings(memberClaims.id(), year);
 
         return ResponseEntity.ok(response);
     }

--- a/backend/app/src/main/java/com/yagubogu/stat/controller/v1/StatControllerInterface.java
+++ b/backend/app/src/main/java/com/yagubogu/stat/controller/v1/StatControllerInterface.java
@@ -4,6 +4,7 @@ import com.yagubogu.auth.dto.MemberClaims;
 import com.yagubogu.checkin.dto.v1.TeamFilter;
 import com.yagubogu.checkin.dto.v1.VictoryFairyRankingResponse;
 import com.yagubogu.stat.dto.v1.AverageStatisticResponse;
+import com.yagubogu.stat.dto.v1.LocationCheckInRankingResponse;
 import com.yagubogu.stat.dto.v1.LuckyStadiumResponse;
 import com.yagubogu.stat.dto.v1.OpponentWinRateResponse;
 import com.yagubogu.stat.dto.v1.RecentGamesWinRateResponse;
@@ -101,6 +102,18 @@ public interface StatControllerInterface {
     ResponseEntity<VictoryFairyRankingResponse> findVictoryFairyRankings(
             @Parameter(hidden = true) MemberClaims memberClaims,
             @RequestParam(name = "team", defaultValue = "ALL") TeamFilter teamFilter,
+            @RequestParam(required = false) Integer year
+    );
+
+    @Operation(summary = "직관 랭킹 조회", description = "LOCATION_CHECK_IN 기준 상위 5명 및 본인의 직관 랭킹을 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "직관 랭킹 조회 성공"),
+            @ApiResponse(responseCode = "403", description = "관리자는 사용할 수 없음"),
+            @ApiResponse(responseCode = "404", description = "멤버를 찾을 수 없음")
+    })
+    @GetMapping("/location-check-in/rankings")
+    ResponseEntity<LocationCheckInRankingResponse> findLocationCheckInRankings(
+            @Parameter(hidden = true) MemberClaims memberClaims,
             @RequestParam(required = false) Integer year
     );
 }

--- a/backend/app/src/main/java/com/yagubogu/stat/dto/v1/LocationCheckInRankingResponse.java
+++ b/backend/app/src/main/java/com/yagubogu/stat/dto/v1/LocationCheckInRankingResponse.java
@@ -1,0 +1,57 @@
+package com.yagubogu.stat.dto.v1;
+
+import com.yagubogu.checkin.dto.LocationCheckInRankParam;
+import com.yagubogu.member.domain.Member;
+import java.util.List;
+
+public record LocationCheckInRankingResponse(
+        List<LocationCheckInRankingEntry> topRankings,
+        LocationCheckInRankingEntry myRanking
+) {
+
+    public record LocationCheckInRankingEntry(
+            long ranking,
+            long memberId,
+            String nickname,
+            String profileImageUrl,
+            String teamShortName,
+            long visitCount
+    ) {
+
+        public static LocationCheckInRankingEntry emptyRanking(final Member member) {
+            return new LocationCheckInRankingEntry(
+                    0,
+                    member.getId(),
+                    member.getNickname().toString(),
+                    member.getImageUrl(),
+                    member.getTeam() != null ? member.getTeam().getShortName() : null,
+                    0
+            );
+        }
+
+        public static LocationCheckInRankingEntry from(final long ranking, final LocationCheckInRankParam param) {
+            return new LocationCheckInRankingEntry(
+                    ranking,
+                    param.memberId(),
+                    param.nickname(),
+                    param.profileImageUrl(),
+                    param.teamShortName(),
+                    param.visitCount()
+            );
+        }
+    }
+
+    public static LocationCheckInRankingResponse of(
+            final List<LocationCheckInRankParam> topRankings,
+            final LocationCheckInRankingEntry myRanking
+    ) {
+        List<LocationCheckInRankingEntry> entries = topRankings.stream()
+                .map(param -> LocationCheckInRankingEntry.from(
+                        topRankings.indexOf(param) + 1L,
+                        param
+                ))
+                .toList();
+
+        return new LocationCheckInRankingResponse(entries, myRanking);
+    }
+}

--- a/backend/app/src/main/java/com/yagubogu/stat/service/StatService.java
+++ b/backend/app/src/main/java/com/yagubogu/stat/service/StatService.java
@@ -1,5 +1,6 @@
 package com.yagubogu.stat.service;
 
+import com.yagubogu.checkin.dto.LocationCheckInRankParam;
 import com.yagubogu.checkin.dto.StatCountsParam;
 import com.yagubogu.checkin.dto.VictoryFairyRankParam;
 import com.yagubogu.checkin.dto.v1.TeamFilter;
@@ -18,6 +19,8 @@ import com.yagubogu.stat.dto.OpponentWinRateTeamParam;
 import com.yagubogu.stat.dto.StadiumStatsParam;
 import com.yagubogu.stat.dto.VictoryFairySummaryParam;
 import com.yagubogu.stat.dto.v1.AverageStatisticResponse;
+import com.yagubogu.stat.dto.v1.LocationCheckInRankingResponse;
+import com.yagubogu.stat.dto.v1.LocationCheckInRankingResponse.LocationCheckInRankingEntry;
 import com.yagubogu.stat.dto.v1.LuckyStadiumResponse;
 import com.yagubogu.stat.dto.v1.OpponentWinRateResponse;
 import com.yagubogu.stat.dto.v1.RecentGamesWinRateResponse;
@@ -42,6 +45,7 @@ public class StatService {
 
     private static final int RECENT_LIMIT = 10;
     private static final int VICTORY_RANKING_LIMIT = 5;
+    private static final int LOCATION_RANKING_LIMIT = 5;
     private static final Comparator<OpponentWinRateTeamParam> OPPONENT_WIN_RATE_TEAM_COMPARATOR = Comparator
             .comparingDouble(
                     OpponentWinRateTeamParam::winRate)
@@ -213,6 +217,27 @@ public class StatService {
                     return VictoryFairySummaryParam.from(overallRankInfo, teamRank);
                 })
                 .orElseGet(VictoryFairySummaryParam::empty);
+    }
+
+    public LocationCheckInRankingResponse findLocationCheckInRankings(
+            final long memberId,
+            final Integer year
+    ) {
+        Member member = getMember(memberId);
+        validateUser(member);
+
+        List<LocationCheckInRankParam> topRankings =
+                checkInRepository.findLocationCheckInRanking(year, LOCATION_RANKING_LIMIT);
+
+        long myRank = checkInRepository.findLocationCheckInRank(memberId, year);
+        LocationCheckInRankParam myData =
+                checkInRepository.findLocationCheckInCountByMember(member, year);
+
+        LocationCheckInRankingEntry myRanking = (myData != null)
+                ? LocationCheckInRankingEntry.from(myRank, myData)
+                : LocationCheckInRankingEntry.emptyRanking(member);
+
+        return LocationCheckInRankingResponse.of(topRankings, myRanking);
     }
 
     private double calculateWinRate(final long winCounts, final long favoriteCheckInCounts) {

--- a/backend/app/src/test/java/com/yagubogu/stat/service/StatSyncServiceUsingMysqlTest.java
+++ b/backend/app/src/test/java/com/yagubogu/stat/service/StatSyncServiceUsingMysqlTest.java
@@ -166,16 +166,16 @@ class StatSyncServiceUsingMysqlTest extends ServiceUsingMysqlTestBase {
         assertThat(victoryFairyRankingRepository.findAll()).isEmpty();
     }
 
-    @DisplayName("과거 직관(NON_LOCATION_CHECK_IN)은 승리요정 랭킹 점수 계산에 포함되지 않는다")
+    @DisplayName("과거 직관(NON_LOCATION_CHECK_IN)도 승리요정 랭킹 점수 계산에 포함된다")
     @Test
-    void updateRankings_excludesPastCheckIn() {
+    void updateRankings_includesPastCheckIn() {
         // given
         LocalDate date = LocalDate.of(2025, 7, 21);
         int year = date.getYear();
 
         Member member = memberFactory.save(b -> b.team(HT));
 
-        // 일반 직관: HT 승 (랭킹에 포함되어야 함)
+        // 일반 직관: HT 승
         Game normalGame = gameFactory.save(b -> b.stadium(kia)
                 .homeTeam(HT).awayTeam(LT)
                 .date(date)
@@ -183,7 +183,7 @@ class StatSyncServiceUsingMysqlTest extends ServiceUsingMysqlTestBase {
                 .gameState(GameState.COMPLETED));
         checkInFactory.save(b -> b.game(normalGame).member(member).team(HT));
 
-        // 과거 직관: HT 승 (랭킹에 포함되면 안 됨)
+        // 과거 직관: HT 승 (랭킹에도 포함되어야 함)
         Game pastGame = gameFactory.save(b -> b.stadium(kia)
                 .homeTeam(HT).awayTeam(LT)
                 .date(LocalDate.of(2025, 6, 1))
@@ -195,20 +195,20 @@ class StatSyncServiceUsingMysqlTest extends ServiceUsingMysqlTestBase {
         // when
         statSyncService.updateRankings(date);
 
-        // then: 과거 직관 제외, 일반 직관 1회만 반영 (checkInCount=1, winCount=1)
+        // then: 과거 직관 포함, 총 2회 직관 반영 (checkInCount=2, winCount=2)
         List<VictoryFairyRanking> results = victoryFairyRankingRepository
                 .findByMemberIdsAndYear(List.of(member.getId()), year);
 
         assertSoftly(softAssertions -> {
             softAssertions.assertThat(results).hasSize(1);
-            softAssertions.assertThat(results.get(0).getCheckInCount()).isEqualTo(1);
-            softAssertions.assertThat(results.get(0).getWinCount()).isEqualTo(1);
+            softAssertions.assertThat(results.get(0).getCheckInCount()).isEqualTo(2);
+            softAssertions.assertThat(results.get(0).getWinCount()).isEqualTo(2);
         });
     }
 
-    @DisplayName("과거 직관(NON_LOCATION_CHECK_IN)만 있는 회원은 승리요정 랭킹에 등록되지 않는다")
+    @DisplayName("과거 직관(NON_LOCATION_CHECK_IN)만 있는 회원도 승리요정 랭킹에 등록된다")
     @Test
-    void updateRankings_memberWithOnlyPastCheckIn_isNotRanked() {
+    void updateRankings_memberWithOnlyPastCheckIn_isRanked() {
         // given
         LocalDate date = LocalDate.of(2025, 7, 21);
         int year = date.getYear();
@@ -216,7 +216,7 @@ class StatSyncServiceUsingMysqlTest extends ServiceUsingMysqlTestBase {
         Member normalMember = memberFactory.save(b -> b.team(HT));
         Member pastOnlyMember = memberFactory.save(b -> b.team(HT));
 
-        // normalMember: 일반 직관
+        // normalMember: 일반 직관 (해당 날짜)
         Game normalGame = gameFactory.save(b -> b.stadium(kia)
                 .homeTeam(HT).awayTeam(LT)
                 .date(date)
@@ -224,7 +224,7 @@ class StatSyncServiceUsingMysqlTest extends ServiceUsingMysqlTestBase {
                 .gameState(GameState.COMPLETED));
         checkInFactory.save(b -> b.game(normalGame).member(normalMember).team(HT));
 
-        // pastOnlyMember: 과거 직관만 존재
+        // pastOnlyMember: 과거 직관만 존재 (랭킹에도 포함되어야 함)
         Game pastGame = gameFactory.save(b -> b.stadium(kia)
                 .homeTeam(HT).awayTeam(LT)
                 .date(LocalDate.of(2025, 6, 1))
@@ -236,13 +236,15 @@ class StatSyncServiceUsingMysqlTest extends ServiceUsingMysqlTestBase {
         // when
         statSyncService.updateRankings(date);
 
-        // then: normalMember만 랭킹에 등록, pastOnlyMember는 등록되지 않음
+        // then: normalMember와 pastOnlyMember 모두 랭킹에 등록
         List<VictoryFairyRanking> results = victoryFairyRankingRepository
                 .findByMemberIdsAndYear(List.of(normalMember.getId(), pastOnlyMember.getId()), year);
 
         assertSoftly(softAssertions -> {
-            softAssertions.assertThat(results).hasSize(1);
-            softAssertions.assertThat(results.get(0).getMember().getId()).isEqualTo(normalMember.getId());
+            softAssertions.assertThat(results).hasSize(2);
+            softAssertions.assertThat(results)
+                    .extracting(r -> r.getMember().getId())
+                    .containsExactlyInAnyOrder(normalMember.getId(), pastOnlyMember.getId());
         });
     }
 


### PR DESCRIPTION
## 목적
직관 랭킹(LOCATION_CHECK_IN) API 구현

## 작업 내용
- `CustomCheckInRepository` 내 직관 랭킹을 위한 쿼리(`findLocationCheckInRanking`, `findLocationCheckInRank`, `findLocationCheckInCountByMember`) QueryDSL 구현
- 직관 랭킹 API 응답을 위한 DTO `LocationCheckInRankingResponse` 및 관련 파라미터 클래스 추가
- `StatService` 내 로직 추가
- `StatControllerInterface` 및 `StatController`에 `GET /stats/location-check-in/rankings` 엔드포인트 추가

Resolves #1003