### PR TITLE
feat: 승리요정 랭킹 페이지네이션 추가

### DIFF
--- a/backend/app/src/main/java/com/yagubogu/checkin/dto/v1/VictoryFairyRankingResponse.java
+++ b/backend/app/src/main/java/com/yagubogu/checkin/dto/v1/VictoryFairyRankingResponse.java
@@ -8,8 +8,17 @@ import java.util.List;
 
 public record VictoryFairyRankingResponse(
         List<VictoryFairyRankingParam> topRankings,
-        VictoryFairyRankingParam myRanking
+        VictoryFairyRankingParam myRanking,
+        Long nextCursorId,
+        boolean hasNext
 ) {
+
+    public VictoryFairyRankingResponse(
+            final List<VictoryFairyRankingParam> topRankings,
+            final VictoryFairyRankingParam myRanking
+    ) {
+        this(topRankings, myRanking, null, false);
+    }
 
     public record VictoryFairyRankingParam(
             long ranking,

--- a/backend/app/src/main/java/com/yagubogu/stat/controller/v1/StatController.java
+++ b/backend/app/src/main/java/com/yagubogu/stat/controller/v1/StatController.java
@@ -82,7 +82,7 @@ public class StatController implements StatControllerInterface {
             @RequestParam(name = "team", defaultValue = "ALL") final TeamFilter teamFilter,
             @RequestParam(required = false) final Integer year,
             @RequestParam(value = "before", required = false) final Long cursorId,
-            @RequestParam("limit") final int limit
+            @RequestParam(value = "limit", defaultValue = "5") final int limit
     ) {
         VictoryFairyRankingResponse response = statService.findVictoryFairyRankings(memberClaims.id(), teamFilter,
                 year, cursorId, limit);

--- a/backend/app/src/main/java/com/yagubogu/stat/controller/v1/StatController.java
+++ b/backend/app/src/main/java/com/yagubogu/stat/controller/v1/StatController.java
@@ -80,10 +80,12 @@ public class StatController implements StatControllerInterface {
     public ResponseEntity<VictoryFairyRankingResponse> findVictoryFairyRankings(
             final MemberClaims memberClaims,
             @RequestParam(name = "team", defaultValue = "ALL") final TeamFilter teamFilter,
-            @RequestParam(required = false) final Integer year
+            @RequestParam(required = false) final Integer year,
+            @RequestParam(value = "before", required = false) final Long cursorId,
+            @RequestParam("limit") final int limit
     ) {
         VictoryFairyRankingResponse response = statService.findVictoryFairyRankings(memberClaims.id(), teamFilter,
-                year);
+                year, cursorId, limit);
 
         return ResponseEntity.ok(response);
     }

--- a/backend/app/src/main/java/com/yagubogu/stat/controller/v1/StatControllerInterface.java
+++ b/backend/app/src/main/java/com/yagubogu/stat/controller/v1/StatControllerInterface.java
@@ -95,12 +95,15 @@ public interface StatControllerInterface {
 
     @Operation(summary = "승리 요정 랭킹 조회", description = "전체 유저 중 상위 승리 요정을 조회합니다.")
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "승리 요정 랭킹 조회 성공")
+            @ApiResponse(responseCode = "200", description = "승리 요정 랭킹 조회 성공"),
+            @ApiResponse(responseCode = "400", description = "limit가 허용 범위를 벗어남")
     })
     @GetMapping("/victory-fairy/rankings")
     ResponseEntity<VictoryFairyRankingResponse> findVictoryFairyRankings(
             @Parameter(hidden = true) MemberClaims memberClaims,
             @RequestParam(name = "team", defaultValue = "ALL") TeamFilter teamFilter,
-            @RequestParam(required = false) Integer year
+            @RequestParam(required = false) Integer year,
+            @RequestParam(value = "before", required = false) Long cursorId,
+            @RequestParam("limit") int limit
     );
 }

--- a/backend/app/src/main/java/com/yagubogu/stat/controller/v1/StatControllerInterface.java
+++ b/backend/app/src/main/java/com/yagubogu/stat/controller/v1/StatControllerInterface.java
@@ -104,6 +104,6 @@ public interface StatControllerInterface {
             @RequestParam(name = "team", defaultValue = "ALL") TeamFilter teamFilter,
             @RequestParam(required = false) Integer year,
             @RequestParam(value = "before", required = false) Long cursorId,
-            @RequestParam("limit") int limit
+            @RequestParam(value = "limit", defaultValue = "5") int limit
     );
 }

--- a/backend/app/src/main/java/com/yagubogu/stat/repository/VictoryFairyRankingRepository.java
+++ b/backend/app/src/main/java/com/yagubogu/stat/repository/VictoryFairyRankingRepository.java
@@ -57,15 +57,9 @@ public interface VictoryFairyRankingRepository extends JpaRepository<VictoryFair
     );
 
     @Query(value = """
-            SELECT
-                RANK() OVER (ORDER BY T.score DESC) AS `rank`,
-                T.memberId,
-                T.score,
-                T.nickname,
-                T.imageUrl,
-                T.shortName
-            FROM (
-                SELECT STRAIGHT_JOIN
+            WITH ranked AS (
+                SELECT
+                    RANK() OVER (ORDER BY vfr.score DESC) AS `rank`,
                     m.member_id AS memberId,
                     vfr.score,
                     m.nickname,
@@ -82,15 +76,31 @@ public interface VictoryFairyRankingRepository extends JpaRepository<VictoryFair
                     AND m.deleted_at IS NULL
                     AND m.team_id IS NOT NULL
                     AND (:#{#teamFilter.name()} = 'ALL' OR t.team_code = :#{#teamFilter.name()})
-                ORDER BY
-                    vfr.score DESC
-                LIMIT :limit
-            ) AS T
-            ORDER BY T.score DESC
+            ),
+            cursor_ranking AS (
+                SELECT score
+                FROM ranked
+                WHERE memberId = :cursorId
+            )
+            SELECT
+                `rank`,
+                memberId,
+                score,
+                nickname,
+                imageUrl,
+                shortName
+            FROM ranked
+            WHERE
+                :cursorId IS NULL
+                OR score < (SELECT score FROM cursor_ranking)
+                OR (score = (SELECT score FROM cursor_ranking) AND memberId > :cursorId)
+            ORDER BY score DESC, memberId ASC
+            LIMIT :limit
             """, nativeQuery = true)
     List<VictoryFairyRankParam> findTopRankingByTeamFilterAndYear(
             @Param("teamFilter") TeamFilter teamFilter,
             @Param("limit") int limit,
-            @Param("gameYear") Integer gameYear
+            @Param("gameYear") Integer gameYear,
+            @Param("cursorId") Long cursorId
     );
 }

--- a/backend/app/src/main/java/com/yagubogu/stat/service/StatService.java
+++ b/backend/app/src/main/java/com/yagubogu/stat/service/StatService.java
@@ -6,6 +6,7 @@ import com.yagubogu.checkin.dto.v1.TeamFilter;
 import com.yagubogu.checkin.dto.v1.VictoryFairyRankingResponse;
 import com.yagubogu.checkin.dto.v1.VictoryFairyRankingResponse.VictoryFairyRankingParam;
 import com.yagubogu.checkin.repository.CheckInRepository;
+import com.yagubogu.global.exception.BadRequestException;
 import com.yagubogu.global.exception.ForbiddenException;
 import com.yagubogu.global.exception.NotFoundException;
 import com.yagubogu.global.exception.UnprocessableEntityException;
@@ -42,6 +43,7 @@ public class StatService {
 
     private static final int RECENT_LIMIT = 10;
     private static final int VICTORY_RANKING_LIMIT = 5;
+    private static final int VICTORY_RANKING_MAX_LIMIT = 50;
     private static final Comparator<OpponentWinRateTeamParam> OPPONENT_WIN_RATE_TEAM_COMPARATOR = Comparator
             .comparingDouble(
                     OpponentWinRateTeamParam::winRate)
@@ -162,8 +164,20 @@ public class StatService {
             final TeamFilter teamFilter,
             Integer year
     ) {
+        return findVictoryFairyRankings(memberId, teamFilter, year, null, VICTORY_RANKING_LIMIT);
+    }
+
+    public VictoryFairyRankingResponse findVictoryFairyRankings(
+            final long memberId,
+            final TeamFilter teamFilter,
+            Integer year,
+            final Long cursorId,
+            final int limit
+    ) {
+        validateVictoryRankingLimit(limit);
+
         Member member = getMember(memberId);
-        List<VictoryFairyRankingParam> topRankingResponses = findTopVictoryRanking(teamFilter, year);
+        List<VictoryFairyRankingParam> topRankingResponses = findTopVictoryRanking(teamFilter, year, cursorId, limit);
 
         VictoryFairyRankingParam myRankingResponse = victoryFairyRankingRepository.findByMemberAndTeamFilterAndYear(
                         member,
@@ -173,21 +187,44 @@ public class StatService {
                 .map(VictoryFairyRankingParam::from)
                 .orElseGet(() -> VictoryFairyRankingParam.emptyRanking(member));
 
-        return new VictoryFairyRankingResponse(topRankingResponses, myRankingResponse);
+        boolean hasNext = topRankingResponses.size() > limit;
+        List<VictoryFairyRankingParam> pagedTopRankings = topRankingResponses.stream()
+                .limit(limit)
+                .toList();
+        Long nextCursorId = getNextCursorIdOrNull(hasNext, pagedTopRankings);
+
+        return new VictoryFairyRankingResponse(pagedTopRankings, myRankingResponse, nextCursorId, hasNext);
     }
 
 
     private List<VictoryFairyRankingParam> findTopVictoryRanking(
             final TeamFilter teamFilter,
-            final Integer year
+            final Integer year,
+            final Long cursorId,
+            final int limit
     ) {
         List<VictoryFairyRankParam> victoryFairyRankings = victoryFairyRankingRepository.findTopRankingByTeamFilterAndYear(
                 teamFilter,
-                VICTORY_RANKING_LIMIT,
-                year
+                limit + 1,
+                year,
+                cursorId
         );
 
         return VictoryFairyRankingParam.from(victoryFairyRankings);
+    }
+
+    private void validateVictoryRankingLimit(final int limit) {
+        if (limit <= 0 || limit > VICTORY_RANKING_MAX_LIMIT) {
+            throw new BadRequestException("limit must be between 1 and 50");
+        }
+    }
+
+    private Long getNextCursorIdOrNull(final boolean hasNext, final List<VictoryFairyRankingParam> rankings) {
+        if (!hasNext || rankings.isEmpty()) {
+            return null;
+        }
+
+        return rankings.get(rankings.size() - 1).memberId();
     }
 
     public CheckInSummaryParam findCheckInSummary(final long memberId, final Integer year) {

--- a/backend/app/src/test/java/com/yagubogu/stat/StatE2eTest.java
+++ b/backend/app/src/test/java/com/yagubogu/stat/StatE2eTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 import com.yagubogu.auth.config.AuthTestConfig;
 import com.yagubogu.checkin.domain.CheckInType;
+import com.yagubogu.checkin.dto.v1.VictoryFairyRankingResponse;
 import com.yagubogu.game.domain.Game;
 import com.yagubogu.game.domain.GameState;
 import com.yagubogu.game.domain.ScoreBoard;
@@ -14,6 +15,7 @@ import com.yagubogu.member.domain.Role;
 import com.yagubogu.member.dto.v1.MemberFavoriteRequest;
 import com.yagubogu.stadium.domain.Stadium;
 import com.yagubogu.stadium.repository.StadiumRepository;
+import com.yagubogu.stat.domain.VictoryFairyRanking;
 import com.yagubogu.stat.dto.OpponentWinRateTeamParam;
 import com.yagubogu.stat.dto.v1.AverageStatisticResponse;
 import com.yagubogu.stat.dto.v1.LuckyStadiumResponse;
@@ -21,6 +23,7 @@ import com.yagubogu.stat.dto.v1.OpponentWinRateResponse;
 import com.yagubogu.stat.dto.v1.RecentGamesWinRateResponse;
 import com.yagubogu.stat.dto.v1.StatCountsResponse;
 import com.yagubogu.stat.dto.v1.WinRateResponse;
+import com.yagubogu.stat.repository.VictoryFairyRankingRepository;
 import com.yagubogu.support.auth.AuthFactory;
 import com.yagubogu.support.base.E2eTestBase;
 import com.yagubogu.support.checkin.CheckInFactory;
@@ -65,6 +68,9 @@ public class StatE2eTest extends E2eTestBase {
 
     @Autowired
     private StadiumRepository stadiumRepository;
+
+    @Autowired
+    private VictoryFairyRankingRepository victoryFairyRankingRepository;
 
     private String accessToken;
 
@@ -495,6 +501,37 @@ public class StatE2eTest extends E2eTestBase {
                 .when().get("/api/v1/stats/win-rate/opponents")
                 .then().log().all()
                 .statusCode(422);
+    }
+
+    @DisplayName("승리 요정 랭킹 조회 시 limit를 생략하면 기본값 5를 사용한다")
+    @Test
+    void findVictoryFairyRankings_defaultLimit() {
+        // given
+        Member member = memberFactory.save(b -> b.team(ht));
+        accessToken = authFactory.getAccessTokenByMemberId(member.getId(), Role.USER);
+
+        victoryFairyRankingRepository.save(new VictoryFairyRanking(member, 100.0, 10, 10, 2025, null));
+        for (int i = 0; i < 5; i++) {
+            Member other = memberFactory.save(b -> b.team(ht));
+            victoryFairyRankingRepository.save(new VictoryFairyRanking(other, 90.0 - i, 9 - i, 10, 2025, null));
+        }
+
+        // when
+        VictoryFairyRankingResponse actual = RestAssured.given().log().all()
+                .contentType(ContentType.JSON)
+                .header(HttpHeaders.AUTHORIZATION, accessToken)
+                .queryParam("year", 2025)
+                .when().get("/api/v1/stats/victory-fairy/rankings")
+                .then().log().all()
+                .statusCode(200)
+                .extract()
+                .as(VictoryFairyRankingResponse.class);
+
+        // then
+        assertSoftly(s -> {
+            s.assertThat(actual.topRankings()).hasSize(5);
+            s.assertThat(actual.hasNext()).isTrue();
+        });
     }
 
     @DisplayName("PastCheckIn과 CheckIn을 통합하여 승패무 횟수를 조회한다")

--- a/backend/app/src/test/java/com/yagubogu/stat/service/StatServiceUsingMysqlTest.java
+++ b/backend/app/src/test/java/com/yagubogu/stat/service/StatServiceUsingMysqlTest.java
@@ -11,6 +11,7 @@ import com.yagubogu.checkin.repository.CheckInRepository;
 import com.yagubogu.game.domain.Game;
 import com.yagubogu.game.domain.GameState;
 import com.yagubogu.global.config.JpaAuditingConfig;
+import com.yagubogu.global.exception.BadRequestException;
 import com.yagubogu.member.domain.Member;
 import com.yagubogu.stadium.domain.Stadium;
 import com.yagubogu.stadium.repository.StadiumRepository;
@@ -352,6 +353,57 @@ class StatServiceUsingMysqlTest extends ServiceUsingMysqlTestBase {
                     softAssertions.assertThat(actual.myRanking().ranking()).isEqualTo(4);
                 }
         );
+    }
+
+    @DisplayName("승리 요정 랭킹을 페이지네이션으로 조회한다")
+    @Test
+    void findVictoryFairyRankings_withPagination() {
+        // given
+        Member first = memberFactory.save(b -> b.team(kia).nickname("첫째"));
+        Member second = memberFactory.save(b -> b.team(kt).nickname("둘째"));
+        Member third = memberFactory.save(b -> b.team(lg).nickname("셋째"));
+
+        int year = 2025;
+        victoryFairyRankingRepository.save(new VictoryFairyRanking(first, 90.0, 9, 10, year, null));
+        victoryFairyRankingRepository.save(new VictoryFairyRanking(second, 80.0, 8, 10, year, null));
+        victoryFairyRankingRepository.save(new VictoryFairyRanking(third, 70.0, 7, 10, year, null));
+
+        // when
+        VictoryFairyRankingResponse firstPage = statService.findVictoryFairyRankings(first.getId(), TeamFilter.ALL,
+                year, null, 2);
+        VictoryFairyRankingResponse secondPage = statService.findVictoryFairyRankings(first.getId(), TeamFilter.ALL,
+                year, firstPage.nextCursorId(), 2);
+
+        // then
+        assertSoftly(softAssertions -> {
+            softAssertions.assertThat(firstPage.topRankings())
+                    .extracting(VictoryFairyRankingParam::nickname)
+                    .containsExactly("첫째", "둘째");
+            softAssertions.assertThat(firstPage.nextCursorId()).isEqualTo(second.getId());
+            softAssertions.assertThat(firstPage.hasNext()).isTrue();
+            softAssertions.assertThat(secondPage.topRankings())
+                    .extracting(VictoryFairyRankingParam::nickname)
+                    .containsExactly("셋째");
+            softAssertions.assertThat(secondPage.nextCursorId()).isNull();
+            softAssertions.assertThat(secondPage.hasNext()).isFalse();
+        });
+    }
+
+    @DisplayName("승리 요정 랭킹 조회 limit가 1 미만이거나 50 초과이면 예외가 발생한다")
+    @Test
+    void findVictoryFairyRankings_invalidLimit() {
+        // given
+        Member member = memberFactory.save(b -> b.team(kia));
+
+        // when & then
+        assertSoftly(softAssertions -> {
+            softAssertions.assertThatThrownBy(
+                            () -> statService.findVictoryFairyRankings(member.getId(), TeamFilter.ALL, 2025, null, 0))
+                    .isInstanceOf(BadRequestException.class);
+            softAssertions.assertThatThrownBy(
+                            () -> statService.findVictoryFairyRankings(member.getId(), TeamFilter.ALL, 2025, null, 51))
+                    .isInstanceOf(BadRequestException.class);
+        });
     }
 
     @DisplayName("승리 요정 랭킹을 팀별로 조회한다")


### PR DESCRIPTION
## Summary

- 승리요정 랭킹 조회 API에 `before`, `limit` 기반 페이지네이션을 추가했습니다.
- 랭킹 응답에 `nextCursorId`, `hasNext`를 추가해 다음 페이지 조회 여부와 커서를 전달합니다.
- `limit <= 0` 또는 `limit > 50` 요청 시 `BadRequestException`을 발생시켜 400으로 응답하도록 했습니다.
- 페이지네이션 및 limit 검증 테스트를 추가했습니다.

Resolves #1016

## Verification

- `./gradlew :app:test --tests com.yagubogu.stat.service.StatServiceUsingMysqlTest`
- `./gradlew :app:cleanTest :app:test --tests com.yagubogu.stat.StatE2eTest`

## API Spec

### Changed: GET `/api/v1/stats/victory-fairy/rankings`

Query parameters:
- `team`: optional, default `ALL`. 팀 필터입니다.
- `year`: optional. 조회 연도입니다.
- `before`: optional. 이전 응답의 `nextCursorId`를 전달하면 해당 커서 이후의 랭킹을 조회합니다. 커서는 페이지 마지막 랭킹 항목의 `memberId`입니다.
- `limit`: optional, default `5`. 조회할 랭킹 개수입니다.

Response body shape:
```json
{
  "topRankings": [
    {
      "ranking": 1,
      "memberId": 1,
      "nickname": "nickname",
      "profileImageUrl": "https://example.com/image.png",
      "teamShortName": "KIA",
      "victoryFairyScore": 90.0
    }
  ],
  "myRanking": {
    "ranking": 1,
    "memberId": 1,
    "nickname": "nickname",
    "profileImageUrl": "https://example.com/image.png",
    "teamShortName": "KIA",
    "victoryFairyScore": 90.0
  },
  "nextCursorId": 1,
  "hasNext": true
}
```

Validation rules:
- `limit <= 0`: `400 Bad Request`
- `limit > 50`: `400 Bad Request`

Status codes:
- `200 OK`: 승리요정 랭킹 조회 성공
- `400 Bad Request`: `limit`가 허용 범위를 벗어남

Compatibility notes:
- `limit`은 생략 가능하며, 생략 시 기본값 `5`가 적용됩니다.
- 응답 최상위 필드에 `nextCursorId`, `hasNext`가 추가되었습니다.