### PR TITLE
어드민 웹 페이지 추가

### DIFF
--- a/.github/workflows/backend-dev.yml
+++ b/.github/workflows/backend-dev.yml
@@ -118,7 +118,9 @@ jobs:
             -e DB_USERNAME="${{ secrets.DB_USERNAME }}" \
             -e DB_PASSWORD="${{ secrets.DB_PASSWORD }}" \
             -e GOOGLE_CLIENT_ID="${{ secrets.GOOGLE_CLIENT_ID }}" \
+            -e ADMIN_GOOGLE_CLIENT_ID="${{ secrets.ADMIN_GOOGLE_CLIENT_ID }}" \
             -e APPLE_CLIENT_ID="${{ secrets.APPLE_CLIENT_ID }}" \
+            -e ADMIN_APPLE_CLIENT_ID="${{ secrets.ADMIN_APPLE_CLIENT_ID }}" \
             -e ACCESS_TOKEN_SECRET_KEY="${{ secrets.ACCESS_TOKEN_SECRET_KEY_DEV }}" \
             -e REFRESH_TOKEN_SECRET_KEY="${{ secrets.REFRESH_TOKEN_SECRET_KEY }}" \
             -e AWS_ACCESS_KEY_ID="${{ secrets.AWS_ACCESS_KEY_ID }}" \

--- a/.github/workflows/backend-dev.yml
+++ b/.github/workflows/backend-dev.yml
@@ -120,7 +120,6 @@ jobs:
             -e GOOGLE_CLIENT_ID="${{ secrets.GOOGLE_CLIENT_ID }}" \
             -e ADMIN_GOOGLE_CLIENT_ID="${{ secrets.ADMIN_GOOGLE_CLIENT_ID }}" \
             -e APPLE_CLIENT_ID="${{ secrets.APPLE_CLIENT_ID }}" \
-            -e ADMIN_APPLE_CLIENT_ID="${{ secrets.ADMIN_APPLE_CLIENT_ID }}" \
             -e ACCESS_TOKEN_SECRET_KEY="${{ secrets.ACCESS_TOKEN_SECRET_KEY_DEV }}" \
             -e REFRESH_TOKEN_SECRET_KEY="${{ secrets.REFRESH_TOKEN_SECRET_KEY }}" \
             -e AWS_ACCESS_KEY_ID="${{ secrets.AWS_ACCESS_KEY_ID }}" \

--- a/.github/workflows/backend-main.yml
+++ b/.github/workflows/backend-main.yml
@@ -171,7 +171,6 @@ jobs:
             -e GOOGLE_CLIENT_ID="${{ secrets.GOOGLE_CLIENT_ID }}" \
             -e ADMIN_GOOGLE_CLIENT_ID="${{ secrets.ADMIN_GOOGLE_CLIENT_ID }}" \
             -e APPLE_CLIENT_ID="${{ secrets.APPLE_CLIENT_ID }}" \
-            -e ADMIN_APPLE_CLIENT_ID="${{ secrets.ADMIN_APPLE_CLIENT_ID }}" \
             -e ACCESS_TOKEN_SECRET_KEY="${{ secrets.ACCESS_TOKEN_SECRET_KEY }}" \
             -e REFRESH_TOKEN_SECRET_KEY="${{ secrets.REFRESH_TOKEN_SECRET_KEY }}" \
             -e AWS_ACCESS_KEY_ID="${{ secrets.AWS_ACCESS_KEY_ID }}" \

--- a/.github/workflows/backend-main.yml
+++ b/.github/workflows/backend-main.yml
@@ -169,7 +169,9 @@ jobs:
             -e DB_USERNAME="${{ secrets.DB_USERNAME }}" \
             -e DB_PASSWORD="${{ secrets.DB_PASSWORD }}" \
             -e GOOGLE_CLIENT_ID="${{ secrets.GOOGLE_CLIENT_ID }}" \
+            -e ADMIN_GOOGLE_CLIENT_ID="${{ secrets.ADMIN_GOOGLE_CLIENT_ID }}" \
             -e APPLE_CLIENT_ID="${{ secrets.APPLE_CLIENT_ID }}" \
+            -e ADMIN_APPLE_CLIENT_ID="${{ secrets.ADMIN_APPLE_CLIENT_ID }}" \
             -e ACCESS_TOKEN_SECRET_KEY="${{ secrets.ACCESS_TOKEN_SECRET_KEY }}" \
             -e REFRESH_TOKEN_SECRET_KEY="${{ secrets.REFRESH_TOKEN_SECRET_KEY }}" \
             -e AWS_ACCESS_KEY_ID="${{ secrets.AWS_ACCESS_KEY_ID }}" \

--- a/.github/workflows/backend-rollback-main.yml
+++ b/.github/workflows/backend-rollback-main.yml
@@ -93,6 +93,9 @@ jobs:
             -e DB_USERNAME="${{ secrets.DB_USERNAME }}" \
             -e DB_PASSWORD="${{ secrets.DB_PASSWORD }}" \
             -e GOOGLE_CLIENT_ID="${{ secrets.GOOGLE_CLIENT_ID }}" \
+            -e ADMIN_GOOGLE_CLIENT_ID="${{ secrets.ADMIN_GOOGLE_CLIENT_ID }}" \
+            -e APPLE_CLIENT_ID="${{ secrets.APPLE_CLIENT_ID }}" \
+            -e ADMIN_APPLE_CLIENT_ID="${{ secrets.ADMIN_APPLE_CLIENT_ID }}" \
             -e ACCESS_TOKEN_SECRET_KEY="${{ secrets.ACCESS_TOKEN_SECRET_KEY }}" \
             -e REFRESH_TOKEN_SECRET_KEY="${{ secrets.REFRESH_TOKEN_SECRET_KEY }}" \
             -l app=yagubogu-backend \

--- a/.github/workflows/backend-rollback-main.yml
+++ b/.github/workflows/backend-rollback-main.yml
@@ -95,7 +95,6 @@ jobs:
             -e GOOGLE_CLIENT_ID="${{ secrets.GOOGLE_CLIENT_ID }}" \
             -e ADMIN_GOOGLE_CLIENT_ID="${{ secrets.ADMIN_GOOGLE_CLIENT_ID }}" \
             -e APPLE_CLIENT_ID="${{ secrets.APPLE_CLIENT_ID }}" \
-            -e ADMIN_APPLE_CLIENT_ID="${{ secrets.ADMIN_APPLE_CLIENT_ID }}" \
             -e ACCESS_TOKEN_SECRET_KEY="${{ secrets.ACCESS_TOKEN_SECRET_KEY }}" \
             -e REFRESH_TOKEN_SECRET_KEY="${{ secrets.REFRESH_TOKEN_SECRET_KEY }}" \
             -l app=yagubogu-backend \

--- a/backend/app/build.gradle
+++ b/backend/app/build.gradle
@@ -6,6 +6,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
     implementation 'com.auth0:java-jwt:4.4.0'
     implementation 'com.auth0:jwks-rsa:0.22.1'

--- a/backend/app/src/main/java/com/yagubogu/admin/config/AdminOAuthProperties.java
+++ b/backend/app/src/main/java/com/yagubogu/admin/config/AdminOAuthProperties.java
@@ -4,8 +4,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties(prefix = "admin.oauth")
 public record AdminOAuthProperties(
-        OAuthClient google,
-        OAuthClient apple
+        OAuthClient google
 ) {
 
     public record OAuthClient(

--- a/backend/app/src/main/java/com/yagubogu/admin/config/AdminOAuthProperties.java
+++ b/backend/app/src/main/java/com/yagubogu/admin/config/AdminOAuthProperties.java
@@ -1,0 +1,15 @@
+package com.yagubogu.admin.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "admin.oauth")
+public record AdminOAuthProperties(
+        OAuthClient google,
+        OAuthClient apple
+) {
+
+    public record OAuthClient(
+            String clientId
+    ) {
+    }
+}

--- a/backend/app/src/main/java/com/yagubogu/admin/config/AdminWebConfig.java
+++ b/backend/app/src/main/java/com/yagubogu/admin/config/AdminWebConfig.java
@@ -1,0 +1,9 @@
+package com.yagubogu.admin.config;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@EnableConfigurationProperties(AdminOAuthProperties.class)
+@Configuration
+public class AdminWebConfig {
+}

--- a/backend/app/src/main/java/com/yagubogu/admin/controller/AdminWebController.java
+++ b/backend/app/src/main/java/com/yagubogu/admin/controller/AdminWebController.java
@@ -1,8 +1,7 @@
 package com.yagubogu.admin.controller;
 
 import com.yagubogu.admin.dto.AdminLoginRequest;
-import com.yagubogu.auth.config.AppleAuthProperties;
-import com.yagubogu.auth.config.GoogleAuthProperties;
+import com.yagubogu.admin.config.AdminOAuthProperties;
 import com.yagubogu.auth.dto.LoginParam;
 import com.yagubogu.auth.dto.v1.LoginResponse;
 import com.yagubogu.auth.service.AuthService;
@@ -13,7 +12,6 @@ import com.yagubogu.global.exception.UnAuthorizedException;
 import com.yagubogu.member.domain.Role;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import java.util.Arrays;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
@@ -38,8 +36,7 @@ public class AdminWebController {
 
     private final AuthService authService;
     private final AuthTokenProvider authTokenProvider;
-    private final GoogleAuthProperties googleAuthProperties;
-    private final AppleAuthProperties appleAuthProperties;
+    private final AdminOAuthProperties adminOAuthProperties;
 
     @GetMapping({"", "/"})
     public String dashboard(
@@ -61,8 +58,8 @@ public class AdminWebController {
             return "redirect:/admin";
         }
 
-        model.addAttribute("googleClientId", firstClientId(googleAuthProperties.clientId()));
-        model.addAttribute("appleClientId", firstClientId(appleAuthProperties.clientId()));
+        model.addAttribute("googleClientId", adminOAuthProperties.google().clientId());
+        model.addAttribute("appleClientId", adminOAuthProperties.apple().clientId());
 
         return LOGIN_VIEW;
     }
@@ -135,15 +132,4 @@ public class AdminWebController {
                 .build();
     }
 
-    private String firstClientId(final String clientIds) {
-        if (clientIds == null) {
-            return "";
-        }
-
-        return Arrays.stream(clientIds.split(","))
-                .map(String::trim)
-                .filter(clientId -> !clientId.isBlank())
-                .findFirst()
-                .orElse("");
-    }
 }

--- a/backend/app/src/main/java/com/yagubogu/admin/controller/AdminWebController.java
+++ b/backend/app/src/main/java/com/yagubogu/admin/controller/AdminWebController.java
@@ -1,0 +1,149 @@
+package com.yagubogu.admin.controller;
+
+import com.yagubogu.admin.dto.AdminLoginRequest;
+import com.yagubogu.auth.config.AppleAuthProperties;
+import com.yagubogu.auth.config.GoogleAuthProperties;
+import com.yagubogu.auth.dto.LoginParam;
+import com.yagubogu.auth.dto.v1.LoginResponse;
+import com.yagubogu.auth.service.AuthService;
+import com.yagubogu.auth.support.AuthTokenProvider;
+import com.yagubogu.auth.support.AuthorizationExtractor;
+import com.yagubogu.global.exception.ForbiddenException;
+import com.yagubogu.global.exception.UnAuthorizedException;
+import com.yagubogu.member.domain.Role;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.util.Arrays;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@RequiredArgsConstructor
+@RequestMapping("/admin")
+@Controller
+public class AdminWebController {
+
+    private static final String LOGIN_VIEW = "admin/login";
+    private static final String DASHBOARD_VIEW = "admin/dashboard";
+    private static final int ACCESS_TOKEN_COOKIE_MAX_AGE_SECONDS = 60 * 15;
+    private static final int DELETE_COOKIE_MAX_AGE_SECONDS = 0;
+
+    private final AuthService authService;
+    private final AuthTokenProvider authTokenProvider;
+    private final GoogleAuthProperties googleAuthProperties;
+    private final AppleAuthProperties appleAuthProperties;
+
+    @GetMapping({"", "/"})
+    public String dashboard(
+            @CookieValue(name = AuthorizationExtractor.ADMIN_ACCESS_TOKEN_COOKIE, required = false) final String accessToken
+    ) {
+        if (!hasAdminPermission(accessToken)) {
+            return "redirect:/admin/login";
+        }
+
+        return DASHBOARD_VIEW;
+    }
+
+    @GetMapping("/login")
+    public String login(
+            @CookieValue(name = AuthorizationExtractor.ADMIN_ACCESS_TOKEN_COOKIE, required = false) final String accessToken,
+            final Model model
+    ) {
+        if (hasAdminPermission(accessToken)) {
+            return "redirect:/admin";
+        }
+
+        model.addAttribute("googleClientId", firstClientId(googleAuthProperties.clientId()));
+        model.addAttribute("appleClientId", firstClientId(appleAuthProperties.clientId()));
+
+        return LOGIN_VIEW;
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<Void> login(
+            @RequestBody final AdminLoginRequest request,
+            final HttpServletRequest servletRequest,
+            final HttpServletResponse response
+    ) {
+        LoginResponse loginResponse = authService.login(new LoginParam(request.idToken(), request.provider()));
+        validateAdmin(loginResponse.accessToken());
+
+        response.addHeader(
+                HttpHeaders.SET_COOKIE,
+                createAdminAccessTokenCookie(
+                                loginResponse.accessToken(),
+                                ACCESS_TOKEN_COOKIE_MAX_AGE_SECONDS,
+                                servletRequest.isSecure()
+                        )
+                        .toString()
+        );
+
+        return ResponseEntity.noContent().build();
+    }
+
+    @PostMapping("/logout")
+    public ResponseEntity<Void> logout(
+            final HttpServletRequest request,
+            final HttpServletResponse response
+    ) {
+        response.addHeader(
+                HttpHeaders.SET_COOKIE,
+                createAdminAccessTokenCookie("", DELETE_COOKIE_MAX_AGE_SECONDS, request.isSecure()).toString()
+        );
+
+        return ResponseEntity.noContent().build();
+    }
+
+    private boolean hasAdminPermission(final String accessToken) {
+        if (accessToken == null || accessToken.isBlank()) {
+            return false;
+        }
+
+        try {
+            return authTokenProvider.getRoleByAccessToken(accessToken).hasPermission(Role.ADMIN);
+        } catch (UnAuthorizedException exception) {
+            return false;
+        }
+    }
+
+    private void validateAdmin(final String accessToken) {
+        Role role = authTokenProvider.getRoleByAccessToken(accessToken);
+        if (!role.hasPermission(Role.ADMIN)) {
+            throw new ForbiddenException("Admin permission required");
+        }
+    }
+
+    private ResponseCookie createAdminAccessTokenCookie(
+            final String accessToken,
+            final int maxAgeSeconds,
+            final boolean secure
+    ) {
+        return ResponseCookie.from(AuthorizationExtractor.ADMIN_ACCESS_TOKEN_COOKIE, accessToken)
+                .httpOnly(true)
+                .secure(secure)
+                .sameSite("Strict")
+                .path("/")
+                .maxAge(maxAgeSeconds)
+                .build();
+    }
+
+    private String firstClientId(final String clientIds) {
+        if (clientIds == null) {
+            return "";
+        }
+
+        return Arrays.stream(clientIds.split(","))
+                .map(String::trim)
+                .filter(clientId -> !clientId.isBlank())
+                .findFirst()
+                .orElse("");
+    }
+}

--- a/backend/app/src/main/java/com/yagubogu/admin/controller/AdminWebController.java
+++ b/backend/app/src/main/java/com/yagubogu/admin/controller/AdminWebController.java
@@ -59,8 +59,6 @@ public class AdminWebController {
         }
 
         model.addAttribute("googleClientId", adminOAuthProperties.google().clientId());
-        model.addAttribute("appleClientId", adminOAuthProperties.apple().clientId());
-
         return LOGIN_VIEW;
     }
 

--- a/backend/app/src/main/java/com/yagubogu/admin/dto/AdminLoginRequest.java
+++ b/backend/app/src/main/java/com/yagubogu/admin/dto/AdminLoginRequest.java
@@ -1,0 +1,9 @@
+package com.yagubogu.admin.dto;
+
+import com.yagubogu.member.domain.OAuthProvider;
+
+public record AdminLoginRequest(
+        String idToken,
+        OAuthProvider provider
+) {
+}

--- a/backend/app/src/main/java/com/yagubogu/auth/support/AuthorizationExtractor.java
+++ b/backend/app/src/main/java/com/yagubogu/auth/support/AuthorizationExtractor.java
@@ -1,6 +1,7 @@
 package com.yagubogu.auth.support;
 
 import jakarta.servlet.http.HttpServletRequest;
+import java.util.Arrays;
 import java.util.Enumeration;
 import java.util.Optional;
 import org.springframework.http.HttpHeaders;
@@ -10,12 +11,18 @@ import org.springframework.web.context.request.NativeWebRequest;
 @Component
 public class AuthorizationExtractor {
 
+    public static final String ADMIN_ACCESS_TOKEN_COOKIE = "admin_access_token";
     private static final String BEARER_PREFIX = "Bearer";
 
     public Optional<String> extract(final NativeWebRequest request) {
         String header = request.getHeader(HttpHeaders.AUTHORIZATION);
         if (header != null && header.startsWith(BEARER_PREFIX)) {
             return Optional.of(extractToken(header));
+        }
+
+        HttpServletRequest servletRequest = request.getNativeRequest(HttpServletRequest.class);
+        if (servletRequest != null) {
+            return extractAdminAccessTokenCookie(servletRequest);
         }
 
         return Optional.empty();
@@ -29,8 +36,20 @@ public class AuthorizationExtractor {
                 return Optional.of(extractToken(header));
             }
         }
-        
-        return Optional.empty();
+
+        return extractAdminAccessTokenCookie(httpServletRequest);
+    }
+
+    private Optional<String> extractAdminAccessTokenCookie(final HttpServletRequest request) {
+        if (request.getCookies() == null) {
+            return Optional.empty();
+        }
+
+        return Arrays.stream(request.getCookies())
+                .filter(cookie -> ADMIN_ACCESS_TOKEN_COOKIE.equals(cookie.getName()))
+                .map(cookie -> cookie.getValue())
+                .filter(value -> value != null && !value.isBlank())
+                .findFirst();
     }
 
     private String extractToken(final String header) {

--- a/backend/app/src/main/resources/application.yml
+++ b/backend/app/src/main/resources/application.yml
@@ -53,6 +53,13 @@ oauth:
     jwks-uri: 'https://appleid.apple.com/auth/keys'
     client-id: ${APPLE_CLIENT_ID}
 
+admin:
+  oauth:
+    google:
+      client-id: ${ADMIN_GOOGLE_CLIENT_ID:${GOOGLE_CLIENT_ID}}
+    apple:
+      client-id: ${ADMIN_APPLE_CLIENT_ID:${APPLE_CLIENT_ID}}
+
 security:
   token:
     access-token:

--- a/backend/app/src/main/resources/application.yml
+++ b/backend/app/src/main/resources/application.yml
@@ -57,8 +57,6 @@ admin:
   oauth:
     google:
       client-id: ${ADMIN_GOOGLE_CLIENT_ID:${GOOGLE_CLIENT_ID}}
-    apple:
-      client-id: ${ADMIN_APPLE_CLIENT_ID:${APPLE_CLIENT_ID}}
 
 security:
   token:

--- a/backend/app/src/main/resources/static/admin/admin.css
+++ b/backend/app/src/main/resources/static/admin/admin.css
@@ -1,0 +1,198 @@
+:root {
+    color-scheme: light;
+    --background: #f4f7fb;
+    --surface: #ffffff;
+    --surface-muted: #edf2f7;
+    --text: #132032;
+    --text-muted: #667085;
+    --line: #d9e2ec;
+    --primary: #155eef;
+    --primary-hover: #0f4fcc;
+    --danger: #c83232;
+    --shadow: 0 18px 45px rgba(15, 23, 42, 0.08);
+}
+
+* {
+    box-sizing: border-box;
+}
+
+body {
+    margin: 0;
+    font-family: Arial, "Apple SD Gothic Neo", "Noto Sans KR", sans-serif;
+    color: var(--text);
+    background: var(--background);
+}
+
+button {
+    border: 0;
+    cursor: pointer;
+    font: inherit;
+}
+
+button:disabled {
+    cursor: progress;
+    opacity: 0.72;
+}
+
+.admin-shell {
+    min-height: 100vh;
+}
+
+.login-shell {
+    display: grid;
+    place-items: center;
+    padding: 32px 18px;
+}
+
+.login-panel {
+    width: min(100%, 420px);
+    display: grid;
+    gap: 32px;
+    padding: 40px;
+    border: 1px solid var(--line);
+    border-radius: 8px;
+    background: var(--surface);
+    box-shadow: var(--shadow);
+}
+
+.brand-block,
+.login-actions {
+    display: grid;
+    gap: 14px;
+}
+
+.eyebrow,
+.panel-kicker {
+    margin: 0;
+    color: var(--primary);
+    font-size: 12px;
+    font-weight: 700;
+    letter-spacing: 0;
+}
+
+h1,
+h2 {
+    margin: 0;
+    line-height: 1.18;
+}
+
+h1 {
+    font-size: 42px;
+}
+
+h2 {
+    font-size: 22px;
+}
+
+.oauth-button,
+.primary-button,
+.ghost-button {
+    min-height: 44px;
+    border-radius: 6px;
+    font-weight: 700;
+}
+
+.oauth-button {
+    width: 280px;
+    border: 1px solid #111827;
+    background: #111827;
+    color: #ffffff;
+}
+
+.oauth-button-apple:disabled {
+    display: none;
+}
+
+.login-message {
+    min-height: 22px;
+    margin: 0;
+    color: var(--text-muted);
+    font-size: 14px;
+}
+
+.topbar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 20px;
+    padding: 28px clamp(20px, 5vw, 64px);
+    border-bottom: 1px solid var(--line);
+    background: var(--surface);
+}
+
+.dashboard-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 18px;
+    width: min(100%, 1120px);
+    margin: 0 auto;
+    padding: 32px clamp(18px, 5vw, 40px);
+}
+
+.admin-panel {
+    display: grid;
+    align-content: space-between;
+    gap: 30px;
+    min-height: 190px;
+    padding: 24px;
+    border: 1px solid var(--line);
+    border-radius: 8px;
+    background: var(--surface);
+    box-shadow: var(--shadow);
+}
+
+.primary-button {
+    width: 112px;
+    background: var(--primary);
+    color: #ffffff;
+}
+
+.primary-button:hover {
+    background: var(--primary-hover);
+}
+
+.ghost-button {
+    padding: 0 16px;
+    border: 1px solid var(--line);
+    background: var(--surface-muted);
+    color: var(--text);
+}
+
+.toast {
+    position: fixed;
+    right: 24px;
+    bottom: 24px;
+    max-width: min(340px, calc(100vw - 48px));
+    padding: 14px 16px;
+    border-radius: 8px;
+    background: #14213d;
+    color: #ffffff;
+    opacity: 0;
+    transform: translateY(8px);
+    transition: opacity 160ms ease, transform 160ms ease;
+    pointer-events: none;
+}
+
+.toast[data-type="error"] {
+    background: var(--danger);
+}
+
+.toast.is-visible {
+    opacity: 1;
+    transform: translateY(0);
+}
+
+@media (max-width: 560px) {
+    .login-panel {
+        padding: 28px 22px;
+    }
+
+    .oauth-button {
+        width: 100%;
+    }
+
+    .topbar {
+        align-items: flex-start;
+        flex-direction: column;
+    }
+}

--- a/backend/app/src/main/resources/static/admin/admin.css
+++ b/backend/app/src/main/resources/static/admin/admin.css
@@ -99,10 +99,6 @@ h2 {
     color: #ffffff;
 }
 
-.oauth-button-apple:disabled {
-    display: none;
-}
-
 .login-message {
     min-height: 22px;
     margin: 0;

--- a/backend/app/src/main/resources/static/admin/dashboard.js
+++ b/backend/app/src/main/resources/static/admin/dashboard.js
@@ -1,0 +1,46 @@
+const toast = document.querySelector("#toast");
+const logoutButton = document.querySelector("#logout-button");
+
+const showToast = (message, type = "success") => {
+  toast.textContent = message;
+  toast.dataset.type = type;
+  toast.classList.add("is-visible");
+  window.setTimeout(() => toast.classList.remove("is-visible"), 3200);
+};
+
+document.querySelectorAll("[data-admin-action]").forEach((button) => {
+  button.addEventListener("click", async () => {
+    const originalText = button.textContent;
+    button.disabled = true;
+    button.textContent = "처리 중";
+
+    try {
+      const response = await fetch(button.dataset.adminAction, {
+        method: "POST",
+      });
+
+      if (response.status === 401 || response.status === 403) {
+        window.location.assign("/admin/login");
+        return;
+      }
+
+      if (!response.ok) {
+        showToast("실패했습니다", "error");
+        return;
+      }
+
+      const body = await response.text();
+      showToast(body ? `완료: ${body}` : "완료되었습니다");
+    } finally {
+      button.disabled = false;
+      button.textContent = originalText;
+    }
+  });
+});
+
+logoutButton.addEventListener("click", async () => {
+  await fetch("/admin/logout", {
+    method: "POST",
+  });
+  window.location.assign("/admin/login");
+});

--- a/backend/app/src/main/resources/static/admin/login.js
+++ b/backend/app/src/main/resources/static/admin/login.js
@@ -1,0 +1,68 @@
+const loginPanel = document.querySelector(".login-panel");
+const message = document.querySelector("#login-message");
+const googleClientId = loginPanel.dataset.googleClientId;
+const appleClientId = loginPanel.dataset.appleClientId;
+
+const setMessage = (text) => {
+  message.textContent = text;
+};
+
+const login = async (idToken, provider) => {
+  setMessage("로그인 중");
+
+  const response = await fetch("/admin/login", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ idToken, provider }),
+  });
+
+  if (response.status === 204) {
+    window.location.assign("/admin");
+    return;
+  }
+
+  if (response.status === 403) {
+    setMessage("어드민 권한이 없습니다");
+    return;
+  }
+
+  setMessage("로그인에 실패했습니다");
+};
+
+window.addEventListener("load", () => {
+  if (googleClientId && window.google?.accounts?.id) {
+    google.accounts.id.initialize({
+      client_id: googleClientId,
+      callback: (response) => login(response.credential, "GOOGLE"),
+    });
+    google.accounts.id.renderButton(document.querySelector("#google-login"), {
+      theme: "outline",
+      size: "large",
+      width: 280,
+    });
+  }
+
+  const appleButton = document.querySelector("#apple-login");
+  if (!appleClientId || !window.AppleID?.auth) {
+    appleButton.disabled = true;
+    return;
+  }
+
+  AppleID.auth.init({
+    clientId: appleClientId,
+    scope: "name email",
+    redirectURI: window.location.origin + "/admin/login",
+    usePopup: true,
+  });
+
+  appleButton.addEventListener("click", async () => {
+    try {
+      const response = await AppleID.auth.signIn();
+      await login(response.authorization.id_token, "APPLE");
+    } catch (error) {
+      setMessage("로그인이 취소되었습니다");
+    }
+  });
+});

--- a/backend/app/src/main/resources/static/admin/login.js
+++ b/backend/app/src/main/resources/static/admin/login.js
@@ -1,7 +1,6 @@
 const loginPanel = document.querySelector(".login-panel");
 const message = document.querySelector("#login-message");
 const googleClientId = loginPanel.dataset.googleClientId;
-const appleClientId = loginPanel.dataset.appleClientId;
 
 const setMessage = (text) => {
   message.textContent = text;
@@ -44,25 +43,4 @@ window.addEventListener("load", () => {
     });
   }
 
-  const appleButton = document.querySelector("#apple-login");
-  if (!appleClientId || !window.AppleID?.auth) {
-    appleButton.disabled = true;
-    return;
-  }
-
-  AppleID.auth.init({
-    clientId: appleClientId,
-    scope: "name email",
-    redirectURI: window.location.origin + "/admin/login",
-    usePopup: true,
-  });
-
-  appleButton.addEventListener("click", async () => {
-    try {
-      const response = await AppleID.auth.signIn();
-      await login(response.authorization.id_token, "APPLE");
-    } catch (error) {
-      setMessage("로그인이 취소되었습니다");
-    }
-  });
 });

--- a/backend/app/src/main/resources/templates/admin/dashboard.html
+++ b/backend/app/src/main/resources/templates/admin/dashboard.html
@@ -1,0 +1,43 @@
+<!doctype html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>야구보구 Admin</title>
+    <link rel="stylesheet" th:href="@{/admin/admin.css}">
+</head>
+<body class="admin-shell">
+<header class="topbar">
+    <div>
+        <p class="eyebrow">YAGU BOGU</p>
+        <h1>Admin</h1>
+    </div>
+    <button class="ghost-button" type="button" id="logout-button">로그아웃</button>
+</header>
+
+<main class="dashboard-grid">
+    <section class="admin-panel">
+        <div>
+            <p class="panel-kicker">Statistics</p>
+            <h2>승요 랭킹 동기화</h2>
+        </div>
+        <button class="primary-button" type="button" data-admin-action="/admin/victory-fairy-rankings/sync">
+            실행
+        </button>
+    </section>
+
+    <section class="admin-panel">
+        <div>
+            <p class="panel-kicker">Check-in</p>
+            <h2>위치별 직관 랭킹 재생성</h2>
+        </div>
+        <button class="primary-button" type="button" data-admin-action="/admin/location-check-in-rankings/sync">
+            실행
+        </button>
+    </section>
+</main>
+
+<aside class="toast" id="toast" role="status"></aside>
+<script th:src="@{/admin/dashboard.js}"></script>
+</body>
+</html>

--- a/backend/app/src/main/resources/templates/admin/login.html
+++ b/backend/app/src/main/resources/templates/admin/login.html
@@ -6,12 +6,10 @@
     <title>야구보구 Admin</title>
     <link rel="stylesheet" th:href="@{/admin/admin.css}">
     <script src="https://accounts.google.com/gsi/client" async defer></script>
-    <script src="https://appleid.cdn-apple.com/appleauth/static/jsapi/appleid/1/en_US/appleid.auth.js" async defer></script>
 </head>
 <body class="admin-shell login-shell">
 <main class="login-panel"
-      th:data-google-client-id="${googleClientId}"
-      th:data-apple-client-id="${appleClientId}">
+      th:data-google-client-id="${googleClientId}">
     <section class="brand-block">
         <p class="eyebrow">YAGU BOGU</p>
         <h1>Admin</h1>
@@ -19,9 +17,6 @@
 
     <section class="login-actions">
         <div id="google-login"></div>
-        <button class="oauth-button oauth-button-apple" type="button" id="apple-login">
-            Apple로 로그인
-        </button>
         <p class="login-message" id="login-message" role="status"></p>
     </section>
 </main>

--- a/backend/app/src/main/resources/templates/admin/login.html
+++ b/backend/app/src/main/resources/templates/admin/login.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>야구보구 Admin</title>
+    <link rel="stylesheet" th:href="@{/admin/admin.css}">
+    <script src="https://accounts.google.com/gsi/client" async defer></script>
+    <script src="https://appleid.cdn-apple.com/appleauth/static/jsapi/appleid/1/en_US/appleid.auth.js" async defer></script>
+</head>
+<body class="admin-shell login-shell">
+<main class="login-panel"
+      th:data-google-client-id="${googleClientId}"
+      th:data-apple-client-id="${appleClientId}">
+    <section class="brand-block">
+        <p class="eyebrow">YAGU BOGU</p>
+        <h1>Admin</h1>
+    </section>
+
+    <section class="login-actions">
+        <div id="google-login"></div>
+        <button class="oauth-button oauth-button-apple" type="button" id="apple-login">
+            Apple로 로그인
+        </button>
+        <p class="login-message" id="login-message" role="status"></p>
+    </section>
+</main>
+<script th:src="@{/admin/login.js}"></script>
+</body>
+</html>

--- a/backend/app/src/test/java/com/yagubogu/admin/controller/AdminWebControllerTest.java
+++ b/backend/app/src/test/java/com/yagubogu/admin/controller/AdminWebControllerTest.java
@@ -6,15 +6,14 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 
 import com.yagubogu.admin.dto.AdminLoginRequest;
-import com.yagubogu.auth.config.AppleAuthProperties;
-import com.yagubogu.auth.config.GoogleAuthProperties;
+import com.yagubogu.admin.config.AdminOAuthProperties;
+import com.yagubogu.admin.config.AdminOAuthProperties.OAuthClient;
 import com.yagubogu.auth.dto.v1.LoginResponse;
 import com.yagubogu.auth.service.AuthService;
 import com.yagubogu.auth.support.AuthTokenProvider;
 import com.yagubogu.global.exception.ForbiddenException;
 import com.yagubogu.member.domain.OAuthProvider;
 import com.yagubogu.member.domain.Role;
-import java.time.Duration;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
@@ -29,9 +28,7 @@ class AdminWebControllerTest {
     private final AdminWebController adminWebController = new AdminWebController(
             authService,
             authTokenProvider,
-            new GoogleAuthProperties("https://example.com", "/tokeninfo", "google-client-id", Duration.ofSeconds(1),
-                    Duration.ofSeconds(1)),
-            new AppleAuthProperties("https://appleid.apple.com", "apple-client-id", "https://appleid.apple.com/keys")
+            new AdminOAuthProperties(new OAuthClient("admin-google-client-id"), new OAuthClient("admin-apple-client-id"))
     );
 
     @DisplayName("어드민 토큰이 없으면 로그인 페이지로 이동한다")

--- a/backend/app/src/test/java/com/yagubogu/admin/controller/AdminWebControllerTest.java
+++ b/backend/app/src/test/java/com/yagubogu/admin/controller/AdminWebControllerTest.java
@@ -28,7 +28,7 @@ class AdminWebControllerTest {
     private final AdminWebController adminWebController = new AdminWebController(
             authService,
             authTokenProvider,
-            new AdminOAuthProperties(new OAuthClient("admin-google-client-id"), new OAuthClient("admin-apple-client-id"))
+            new AdminOAuthProperties(new OAuthClient("admin-google-client-id"))
     );
 
     @DisplayName("어드민 토큰이 없으면 로그인 페이지로 이동한다")

--- a/backend/app/src/test/java/com/yagubogu/admin/controller/AdminWebControllerTest.java
+++ b/backend/app/src/test/java/com/yagubogu/admin/controller/AdminWebControllerTest.java
@@ -1,0 +1,100 @@
+package com.yagubogu.admin.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+import com.yagubogu.admin.dto.AdminLoginRequest;
+import com.yagubogu.auth.config.AppleAuthProperties;
+import com.yagubogu.auth.config.GoogleAuthProperties;
+import com.yagubogu.auth.dto.v1.LoginResponse;
+import com.yagubogu.auth.service.AuthService;
+import com.yagubogu.auth.support.AuthTokenProvider;
+import com.yagubogu.global.exception.ForbiddenException;
+import com.yagubogu.member.domain.OAuthProvider;
+import com.yagubogu.member.domain.Role;
+import java.time.Duration;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+class AdminWebControllerTest {
+
+    private static final String ACCESS_TOKEN = "access.token";
+
+    private final AuthService authService = org.mockito.Mockito.mock(AuthService.class);
+    private final AuthTokenProvider authTokenProvider = org.mockito.Mockito.mock(AuthTokenProvider.class);
+    private final AdminWebController adminWebController = new AdminWebController(
+            authService,
+            authTokenProvider,
+            new GoogleAuthProperties("https://example.com", "/tokeninfo", "google-client-id", Duration.ofSeconds(1),
+                    Duration.ofSeconds(1)),
+            new AppleAuthProperties("https://appleid.apple.com", "apple-client-id", "https://appleid.apple.com/keys")
+    );
+
+    @DisplayName("어드민 토큰이 없으면 로그인 페이지로 이동한다")
+    @Test
+    void dashboard_redirect_login() {
+        // when
+        String viewName = adminWebController.dashboard(null);
+
+        // then
+        assertThat(viewName).isEqualTo("redirect:/admin/login");
+    }
+
+    @DisplayName("어드민 토큰이 있으면 대시보드를 보여준다")
+    @Test
+    void dashboard() {
+        // given
+        given(authTokenProvider.getRoleByAccessToken(ACCESS_TOKEN)).willReturn(Role.ADMIN);
+
+        // when
+        String viewName = adminWebController.dashboard(ACCESS_TOKEN);
+
+        // then
+        assertThat(viewName).isEqualTo("admin/dashboard");
+    }
+
+    @DisplayName("어드민 로그인 성공 시 접근 토큰 쿠키를 발급한다")
+    @Test
+    void login_admin() {
+        // given
+        given(authService.login(any())).willReturn(new LoginResponse(ACCESS_TOKEN, "refresh.token", false, null));
+        given(authTokenProvider.getRoleByAccessToken(ACCESS_TOKEN)).willReturn(Role.ADMIN);
+        MockHttpServletRequest servletRequest = new MockHttpServletRequest();
+        MockHttpServletResponse servletResponse = new MockHttpServletResponse();
+
+        // when
+        adminWebController.login(
+                new AdminLoginRequest("id-token", OAuthProvider.GOOGLE),
+                servletRequest,
+                servletResponse
+        );
+
+        // then
+        String cookie = servletResponse.getHeader("Set-Cookie");
+        assertThat(cookie).contains("admin_access_token=" + ACCESS_TOKEN);
+        assertThat(cookie).contains("HttpOnly");
+        assertThat(cookie).contains("SameSite=Strict");
+        assertThat(cookie).contains("Max-Age=900");
+    }
+
+    @DisplayName("어드민 권한이 아니면 로그인을 거부한다")
+    @Test
+    void login_user_forbidden() {
+        // given
+        given(authService.login(any())).willReturn(new LoginResponse(ACCESS_TOKEN, "refresh.token", false, null));
+        given(authTokenProvider.getRoleByAccessToken(ACCESS_TOKEN)).willReturn(Role.USER);
+        MockHttpServletRequest servletRequest = new MockHttpServletRequest();
+        MockHttpServletResponse servletResponse = new MockHttpServletResponse();
+
+        // when & then
+        assertThatThrownBy(() -> adminWebController.login(
+                new AdminLoginRequest("id-token", OAuthProvider.GOOGLE),
+                servletRequest,
+                servletResponse
+        )).isExactlyInstanceOf(ForbiddenException.class);
+    }
+}

--- a/backend/app/src/test/java/com/yagubogu/auth/support/AuthorizationExtractorTest.java
+++ b/backend/app/src/test/java/com/yagubogu/auth/support/AuthorizationExtractorTest.java
@@ -45,6 +45,22 @@ class AuthorizationExtractorTest {
         assertThat(extractedToken).isEmpty();
     }
 
+    @DisplayName("NativeWebRequest의 어드민 쿠키에서 토큰을 추출한다")
+    @Test
+    void extract_NativeWebRequest_cookie() {
+        // given
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        String token = "admin.token";
+        request.setCookies(new jakarta.servlet.http.Cookie(AuthorizationExtractor.ADMIN_ACCESS_TOKEN_COOKIE, token));
+        ServletWebRequest webRequest = new ServletWebRequest(request);
+
+        // when
+        Optional<String> extractedToken = authorizationExtractor.extract(webRequest);
+
+        // then
+        assertThat(extractedToken).contains(token);
+    }
+
     @DisplayName("NativeWebRequest가 Bearer 접두어가 아닌 경우 빈 객체를 반환한다")
     @Test
     void extract_NativeWebRequest_not_bearer() {
@@ -87,6 +103,21 @@ class AuthorizationExtractorTest {
 
         // then
         assertThat(extractedToken).isEmpty();
+    }
+
+    @DisplayName("HttpServletRequest의 어드민 쿠키에서 토큰을 추출한다")
+    @Test
+    void extract_HttpServletRequest_cookie() {
+        // given
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        String token = "admin.token";
+        request.setCookies(new jakarta.servlet.http.Cookie(AuthorizationExtractor.ADMIN_ACCESS_TOKEN_COOKIE, token));
+
+        // when
+        Optional<String> extractedToken = authorizationExtractor.extract(request);
+
+        // then
+        assertThat(extractedToken).contains(token);
     }
 
     @DisplayName("HttpServletRequest가 Bearer 접두어가 아닌 경우 빈 객체를 반환한다")

--- a/backend/app/src/test/resources/application.yml
+++ b/backend/app/src/test/resources/application.yml
@@ -20,8 +20,6 @@ admin:
   oauth:
     google:
       client-id: 'admin-google-client-id'
-    apple:
-      client-id: 'admin-apple-client-id'
 
 security:
   token:

--- a/backend/app/src/test/resources/application.yml
+++ b/backend/app/src/test/resources/application.yml
@@ -16,6 +16,13 @@ oauth:
     jwks-uri: 'https://appleid.apple.com/auth/keys'
     client-id: 'com.example.app'
 
+admin:
+  oauth:
+    google:
+      client-id: 'admin-google-client-id'
+    apple:
+      client-id: 'admin-apple-client-id'
+
 security:
   token:
     access-token:


### PR DESCRIPTION
## Summary
- Thymeleaf 기반 어드민 로그인/대시보드 화면을 추가했습니다.
- 기존 구글/애플 OAuth ID 토큰 로그인 흐름을 재사용해 어드민 전용 HttpOnly 쿠키를 발급합니다.
- `admin_access_token` 쿠키를 인증 추출기에 추가해 어드민 화면에서 기존 `AdminController` API를 호출할 수 있게 했습니다.
- 어드민 웹 컨트롤러 및 쿠키 토큰 추출 테스트를 추가했습니다.

## Verification
- `./gradlew :app:test --tests com.yagubogu.auth.support.AuthorizationExtractorTest --tests com.yagubogu.admin.controller.AdminWebControllerTest`
- `./gradlew :app:bootJar`
- `./gradlew :app:test`
- `jar tf backend/app/build/libs/app.jar | rg 'templates/admin|static/admin'`

## API Spec
### Added: `GET /admin/login`
- Query/path parameters: none
- Request body: none
- Response: Thymeleaf login HTML
- Status codes: `200`, or `302` to `/admin` when a valid admin cookie already exists
- Notes: renders Google/Apple OAuth client IDs from existing OAuth properties

### Added: `POST /admin/login`
- Query/path parameters: none
- Request body: `{ "idToken": string, "provider": "GOOGLE" | "APPLE" }`
- Response body: empty
- Status codes: `204` on admin login success, `401` for invalid token, `403` when the authenticated member role is not admin
- Side effects: sets HttpOnly `admin_access_token` cookie with SameSite=Strict and 15-minute max age

### Added: `POST /admin/logout`
- Query/path parameters: none
- Request body: none
- Response body: empty
- Status codes: `204`
- Side effects: expires `admin_access_token` cookie

### Changed: authenticated endpoints
- Existing `Authorization: Bearer` behavior is preserved.
- Requests may additionally authenticate with the `admin_access_token` cookie, allowing the web dashboard to call existing `/admin/**` APIs without exposing the token to JavaScript.

Resolves #1019