### PR TITLE
test: crawling 테스트 실패 수정

### DIFF
--- a/backend/crawling/src/test/java/yagubogu/crawling/game/service/crawler/KboGameCenterCrawlerTest.java
+++ b/backend/crawling/src/test/java/yagubogu/crawling/game/service/crawler/KboGameCenterCrawlerTest.java
@@ -196,6 +196,10 @@ class KboGameCenterCrawlerTest {
         lenient().when(yearLocator.selectOption(anyString())).thenReturn(List.of());
         lenient().when(monthLocator.selectOption(anyString())).thenReturn(List.of());
 
+        // Loading Overlay
+        Locator loadingLocator = mock(Locator.class);
+        lenient().when(mockPage.locator(".bx-loading")).thenReturn(loadingLocator);
+
         // Day Click
         Locator dayLocator = mock(Locator.class);
         lenient().when(mockPage.locator(contains("26"))).thenReturn(dayLocator);


### PR DESCRIPTION
## 작업 내용

- `KboGameCenterCrawlerTest`의 Playwright mock에 `.bx-loading` locator를 추가했습니다.
- `BaseKboPage`의 loading overlay 대기 흐름과 테스트 더블을 맞춰, 날짜 이동 중 mock locator 누락으로 발생하던 테스트 실패를 해결했습니다.

## 검증

- `./gradlew :crawling:test` 성공

Resolves #1024