### PR TITLE
feat: 인증 내역 응답 필드 제거

### DIFF
--- a/backend/app/src/main/java/com/yagubogu/checkin/dto/CheckInGameParam.java
+++ b/backend/app/src/main/java/com/yagubogu/checkin/dto/CheckInGameParam.java
@@ -3,7 +3,6 @@ package com.yagubogu.checkin.dto;
 import com.yagubogu.game.domain.GameState;
 import com.yagubogu.game.domain.ScoreBoard;
 import java.time.LocalDate;
-import java.util.List;
 import java.time.LocalTime;
 
 public record CheckInGameParam(
@@ -15,22 +14,6 @@ public record CheckInGameParam(
         LocalTime startAt,
         ScoreBoard homeScoreBoard,
         ScoreBoard awayScoreBoard,
-        GameState gameState,
-        String memo,
-        List<String> imageUrls
+        GameState gameState
 ) {
-    public CheckInGameParam(
-            Long checkInId,
-            String stadiumFullName,
-            CheckInGameTeamParam homeTeam,
-            CheckInGameTeamParam awayTeam,
-            LocalDate attendanceDate,
-            LocalTime startAt,
-            ScoreBoard homeScoreBoard,
-            ScoreBoard awayScoreBoard,
-            GameState gameState,
-            String memo
-    ) {
-        this(checkInId, stadiumFullName, homeTeam, awayTeam, attendanceDate, startAt, homeScoreBoard, awayScoreBoard, gameState, memo, List.of());
-    }
 }

--- a/backend/app/src/main/java/com/yagubogu/checkin/repository/CustomCheckInRepositoryImpl.java
+++ b/backend/app/src/main/java/com/yagubogu/checkin/repository/CustomCheckInRepositoryImpl.java
@@ -260,8 +260,7 @@ public class CustomCheckInRepositoryImpl implements CustomCheckInRepository {
                         GAME.startAt,
                         GAME.homeScoreBoard,
                         GAME.awayScoreBoard,
-                        GAME.gameState,
-                        CHECK_IN.memo
+                        GAME.gameState
                 )).from(CHECK_IN)
                 .join(CHECK_IN.game, GAME)
                 .join(GAME.stadium, STADIUM)

--- a/backend/app/src/main/java/com/yagubogu/checkin/service/CheckInService.java
+++ b/backend/app/src/main/java/com/yagubogu/checkin/service/CheckInService.java
@@ -38,8 +38,6 @@ import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -190,23 +188,7 @@ public class CheckInService {
                 orderFilter
         );
 
-        List<Long> checkInIds = checkIns.stream().map(CheckInGameParam::checkInId).toList();
-        Map<Long, List<String>> imageUrlsByCheckInId = checkInImageRepository.findByCheckInIdIn(checkInIds)
-                .stream()
-                .collect(Collectors.groupingBy(
-                        img -> img.getCheckIn().getId(),
-                        Collectors.mapping(CheckInImage::getImageUrl, Collectors.toList())
-                ));
-
-        List<CheckInGameParam> enriched = checkIns.stream()
-                .map(p -> new CheckInGameParam(
-                        p.checkInId(), p.stadiumFullName(), p.homeTeam(), p.awayTeam(),
-                        p.attendanceDate(), p.startAt(), p.homeScoreBoard(), p.awayScoreBoard(),
-                        p.gameState(), p.memo(), imageUrlsByCheckInId.getOrDefault(p.checkInId(), List.of())
-                ))
-                .toList();
-
-        return new CheckInHistoryResponse(enriched);
+        return new CheckInHistoryResponse(checkIns);
     }
 
     public CheckInReviewResponse findCheckInReview(final long memberId, final long checkInId) {

--- a/backend/app/src/test/java/com/yagubogu/checkin/CheckInE2eTest.java
+++ b/backend/app/src/test/java/com/yagubogu/checkin/CheckInE2eTest.java
@@ -40,6 +40,7 @@ import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -1015,9 +1016,9 @@ public class CheckInE2eTest extends E2eTestBase {
                 .statusCode(404);
     }
 
-    @DisplayName("직관 내역 조회 시 메모가 포함된다")
+    @DisplayName("직관 내역 조회 시 메모와 이미지 URL 목록이 포함되지 않는다")
     @Test
-    void findCheckInHistory_includesMemo() {
+    void findCheckInHistory_excludesMemoAndImageUrls() {
         // given
         Member fora = memberFactory.save(b -> b.team(kia));
         String accessToken = authFactory.getAccessTokenByMemberId(fora.getId(), Role.USER);
@@ -1035,7 +1036,7 @@ public class CheckInE2eTest extends E2eTestBase {
                 .when().put("/api/v1/check-ins/" + checkIn.getId() + "/memo");
 
         // when
-        CheckInHistoryResponse response = RestAssured.given().log().all()
+        ExtractableResponse<Response> response = RestAssured.given().log().all()
                 .contentType(ContentType.JSON)
                 .header(HttpHeaders.AUTHORIZATION, accessToken)
                 .queryParam("year", 2025)
@@ -1044,11 +1045,13 @@ public class CheckInE2eTest extends E2eTestBase {
                 .when().get("/api/v1/check-ins/members")
                 .then().log().all()
                 .statusCode(200)
-                .extract().as(CheckInHistoryResponse.class);
+                .extract();
 
         // then
-        assertThat(response.checkInHistory()).hasSize(1);
-        assertThat(response.checkInHistory().get(0).memo()).isEqualTo("기록에 남길 메모");
-        assertThat(response.checkInHistory().get(0).imageUrls()).isEmpty();
+        CheckInHistoryResponse historyResponse = response.as(CheckInHistoryResponse.class);
+        assertThat(historyResponse.checkInHistory()).hasSize(1);
+
+        Map<String, Object> historyItem = response.jsonPath().getMap("checkInHistory[0]");
+        assertThat(historyItem).doesNotContainKeys("memo", "imageUrls");
     }
 }

--- a/backend/app/src/test/java/com/yagubogu/checkin/service/CheckInServiceTest.java
+++ b/backend/app/src/test/java/com/yagubogu/checkin/service/CheckInServiceTest.java
@@ -1423,9 +1423,9 @@ class CheckInServiceTest {
                 .isExactlyInstanceOf(NotFoundException.class);
     }
 
-    @DisplayName("직관 내역 조회 시 메모와 이미지 URL 목록이 포함된다")
+    @DisplayName("직관 내역 조회 시 메모와 이미지 URL 목록이 포함되지 않는다")
     @Test
-    void findCheckInHistory_includesMemoAndImageUrls() {
+    void findCheckInHistory_excludesMemoAndImageUrls() {
         // given
         Member member = memberFactory.save(b -> b.team(kia));
         Game game = gameFactory.save(b -> b.stadium(stadiumJamsil)
@@ -1447,7 +1447,6 @@ class CheckInServiceTest {
         // then
         assertThat(history).hasSize(1);
         CheckInGameParam result = history.get(0);
-        assertThat(result.memo()).isEqualTo("역대급 직관");
-        assertThat(result.imageUrls()).hasSize(2);
+        assertThat(result.gameState()).isEqualTo(GameState.COMPLETED);
     }
 }


### PR DESCRIPTION
## 작업 내용
- `GET /check-ins/members` 인증 내역 응답 항목에서 `memo`, `imageUrls` 필드를 제거했습니다.
- 인증 내역 조회 시 이미지 목록을 추가 조회하던 enrichment 로직을 제거했습니다.
- 서비스/E2E 테스트를 제거된 필드 기대값에 맞게 갱신했습니다.

## 검증
- `./gradlew :app:test --tests com.yagubogu.checkin.service.CheckInServiceTest --tests com.yagubogu.checkin.CheckInE2eTest`

## API Spec
### Changed: `GET /api/v1/check-ins/members`
- Query parameters
  - `year`: optional integer
  - `month`: optional integer
  - `result`: optional enum, default `ALL`
  - `order`: optional enum, default `LATEST`
- Request body: none
- Response `200 OK`
  - `checkInHistory[]`
    - `checkInId`: number
    - `stadiumFullName`: string
    - `homeTeam`: object
    - `awayTeam`: object
    - `attendanceDate`: date string
    - `startAt`: time string
    - `homeScoreBoard`: object or null
    - `awayScoreBoard`: object or null
    - `gameState`: enum
  - Removed fields from each history item
    - `memo`
    - `imageUrls`
- Status codes
  - `200`: 인증 내역 조회 성공
  - `404`: 회원을 찾을 수 없음
- Compatibility note
  - 메모와 이미지는 각각 기존 `/check-ins/{checkInId}/memo`, `/check-ins/{checkInId}/images` API를 통해 조회해야 합니다.

Resolves #1036