### PR TITLE
feat: 체크인 랭킹 갱신 이벤트 분리

### DIFF
--- a/backend/app/src/main/java/com/yagubogu/checkin/dto/event/LocationCheckInCreatedEvent.java
+++ b/backend/app/src/main/java/com/yagubogu/checkin/dto/event/LocationCheckInCreatedEvent.java
@@ -1,0 +1,7 @@
+package com.yagubogu.checkin.dto.event;
+
+public record LocationCheckInCreatedEvent(
+        long memberId,
+        int gameYear
+) {
+}

--- a/backend/app/src/main/java/com/yagubogu/checkin/service/CheckInService.java
+++ b/backend/app/src/main/java/com/yagubogu/checkin/service/CheckInService.java
@@ -7,6 +7,7 @@ import com.yagubogu.checkin.domain.CheckInResultFilter;
 import com.yagubogu.checkin.domain.CheckInType;
 import com.yagubogu.checkin.dto.*;
 import com.yagubogu.checkin.dto.event.CheckInEvent;
+import com.yagubogu.checkin.dto.event.LocationCheckInCreatedEvent;
 import com.yagubogu.checkin.dto.event.StadiumVisitEvent;
 import com.yagubogu.checkin.dto.v1.*;
 import com.yagubogu.checkin.repository.CheckInImageRepository;
@@ -65,9 +66,11 @@ public class CheckInService {
 
         validateNotExistGameAndMember(game, member);
         saveCheckInSafely(game, member, team);
-        locationCheckInRankingRepository.upsertIncrement(member.getId(), game.getDate().getYear());
 
         applicationEventPublisher.publishEvent(new CheckInEvent(member));
+        applicationEventPublisher.publishEvent(
+                new LocationCheckInCreatedEvent(member.getId(), game.getDate().getYear())
+        );
         applicationEventPublisher.publishEvent(new StadiumVisitEvent(member, game.getStadium().getId()));
         applicationEventPublisher.publishEvent(new CheckInCreatedEvent());
     }

--- a/backend/app/src/main/java/com/yagubogu/stat/event/LocationCheckInRankingEventHandler.java
+++ b/backend/app/src/main/java/com/yagubogu/stat/event/LocationCheckInRankingEventHandler.java
@@ -1,0 +1,20 @@
+package com.yagubogu.stat.event;
+
+import com.yagubogu.checkin.dto.event.LocationCheckInCreatedEvent;
+import com.yagubogu.stat.repository.LocationCheckInRankingRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@RequiredArgsConstructor
+@Component
+public class LocationCheckInRankingEventHandler {
+
+    private final LocationCheckInRankingRepository locationCheckInRankingRepository;
+
+    @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
+    public void handleLocationCheckInCreated(final LocationCheckInCreatedEvent event) {
+        locationCheckInRankingRepository.upsertIncrement(event.memberId(), event.gameYear());
+    }
+}

--- a/backend/app/src/main/java/com/yagubogu/stat/event/LocationCheckInRankingEventHandler.java
+++ b/backend/app/src/main/java/com/yagubogu/stat/event/LocationCheckInRankingEventHandler.java
@@ -3,18 +3,28 @@ package com.yagubogu.stat.event;
 import com.yagubogu.checkin.dto.event.LocationCheckInCreatedEvent;
 import com.yagubogu.stat.repository.LocationCheckInRankingRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 
+@Slf4j
 @RequiredArgsConstructor
 @Component
 public class LocationCheckInRankingEventHandler {
 
     private final LocationCheckInRankingRepository locationCheckInRankingRepository;
 
-    @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleLocationCheckInCreated(final LocationCheckInCreatedEvent event) {
-        locationCheckInRankingRepository.upsertIncrement(event.memberId(), event.gameYear());
+        try {
+            locationCheckInRankingRepository.upsertIncrement(event.memberId(), event.gameYear());
+        } catch (RuntimeException e) {
+            log.error("[STAT] Failed to update location check-in ranking: memberId={}, gameYear={}",
+                    event.memberId(), event.gameYear(), e);
+        }
     }
 }

--- a/backend/app/src/main/java/com/yagubogu/stat/schedule/StatScheduler.java
+++ b/backend/app/src/main/java/com/yagubogu/stat/schedule/StatScheduler.java
@@ -1,6 +1,7 @@
 package com.yagubogu.stat.schedule;
 
 import com.yagubogu.game.event.GameFinalizedEvent;
+import com.yagubogu.stat.service.LocationCheckInRankingSyncService;
 import com.yagubogu.stat.service.StatSyncService;
 import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
@@ -17,11 +18,22 @@ import org.springframework.transaction.event.TransactionalEventListener;
 public class StatScheduler {
 
     private final StatSyncService statSyncService;
+    private final LocationCheckInRankingSyncService locationCheckInRankingSyncService;
 
     @Scheduled(cron = "0 0 3 * * *")
     public void updateVictoryRanking() {
         LocalDate yesterday = LocalDate.now().minusDays(1);
         triggerRankingUpdate(yesterday, "daily scheduler");
+    }
+
+    @Scheduled(cron = "0 0 4 * * *")
+    public void syncLocationCheckInRanking() {
+        try {
+            int syncedCount = locationCheckInRankingSyncService.rebuildAll();
+            log.info("[STAT] Sync location check-in ranking completed: count={}", syncedCount);
+        } catch (RuntimeException e) {
+            log.error("[STAT] Failed to sync location check-in ranking", e);
+        }
     }
 
     @Async

--- a/backend/app/src/test/java/com/yagubogu/stat/event/LocationCheckInRankingEventHandlerTest.java
+++ b/backend/app/src/test/java/com/yagubogu/stat/event/LocationCheckInRankingEventHandlerTest.java
@@ -1,0 +1,32 @@
+package com.yagubogu.stat.event;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import com.yagubogu.checkin.dto.event.LocationCheckInCreatedEvent;
+import com.yagubogu.stat.repository.LocationCheckInRankingRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class LocationCheckInRankingEventHandlerTest {
+
+    private final LocationCheckInRankingRepository locationCheckInRankingRepository =
+            mock(LocationCheckInRankingRepository.class);
+    private final LocationCheckInRankingEventHandler handler =
+            new LocationCheckInRankingEventHandler(locationCheckInRankingRepository);
+
+    @DisplayName("위치 기반 체크인 생성 이벤트를 받으면 직관 랭킹 카운트를 증가시킨다")
+    @Test
+    void handleLocationCheckInCreated() {
+        // given
+        long memberId = 1L;
+        int gameYear = 2025;
+        LocationCheckInCreatedEvent event = new LocationCheckInCreatedEvent(memberId, gameYear);
+
+        // when
+        handler.handleLocationCheckInCreated(event);
+
+        // then
+        verify(locationCheckInRankingRepository).upsertIncrement(memberId, gameYear);
+    }
+}

--- a/backend/app/src/test/java/com/yagubogu/stat/event/LocationCheckInRankingEventHandlerTest.java
+++ b/backend/app/src/test/java/com/yagubogu/stat/event/LocationCheckInRankingEventHandlerTest.java
@@ -1,5 +1,7 @@
 package com.yagubogu.stat.event;
 
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
@@ -28,5 +30,21 @@ class LocationCheckInRankingEventHandlerTest {
 
         // then
         verify(locationCheckInRankingRepository).upsertIncrement(memberId, gameYear);
+    }
+
+    @DisplayName("직관 랭킹 카운트 증가에 실패해도 예외를 전파하지 않는다")
+    @Test
+    void handleLocationCheckInCreated_updateFails() {
+        // given
+        long memberId = 1L;
+        int gameYear = 2025;
+        LocationCheckInCreatedEvent event = new LocationCheckInCreatedEvent(memberId, gameYear);
+        doThrow(new RuntimeException("ranking update failed"))
+                .when(locationCheckInRankingRepository)
+                .upsertIncrement(memberId, gameYear);
+
+        // when & then
+        assertThatCode(() -> handler.handleLocationCheckInCreated(event))
+                .doesNotThrowAnyException();
     }
 }

--- a/backend/app/src/test/java/com/yagubogu/stat/schedule/StatSchedulerTest.java
+++ b/backend/app/src/test/java/com/yagubogu/stat/schedule/StatSchedulerTest.java
@@ -1,0 +1,43 @@
+package com.yagubogu.stat.schedule;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import com.yagubogu.stat.service.LocationCheckInRankingSyncService;
+import com.yagubogu.stat.service.StatSyncService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class StatSchedulerTest {
+
+    private final StatSyncService statSyncService = mock(StatSyncService.class);
+    private final LocationCheckInRankingSyncService locationCheckInRankingSyncService =
+            mock(LocationCheckInRankingSyncService.class);
+    private final StatScheduler statScheduler =
+            new StatScheduler(statSyncService, locationCheckInRankingSyncService);
+
+    @DisplayName("위치 기반 직관 랭킹을 재집계한다")
+    @Test
+    void syncLocationCheckInRanking() {
+        // when
+        statScheduler.syncLocationCheckInRanking();
+
+        // then
+        verify(locationCheckInRankingSyncService).rebuildAll();
+    }
+
+    @DisplayName("위치 기반 직관 랭킹 재집계에 실패해도 예외를 전파하지 않는다")
+    @Test
+    void syncLocationCheckInRanking_fail() {
+        // given
+        doThrow(new RuntimeException("sync failed"))
+                .when(locationCheckInRankingSyncService)
+                .rebuildAll();
+
+        // when & then
+        assertThatCode(statScheduler::syncLocationCheckInRanking)
+                .doesNotThrowAnyException();
+    }
+}


### PR DESCRIPTION
## Summary
- 위치 기반 체크인 생성 시 직관 랭킹 카운트를 직접 증가시키던 책임을 이벤트 핸들러로 분리했습니다.
- `LocationCheckInCreatedEvent`를 추가하고, `LocationCheckInRankingEventHandler`에서 랭킹 projection을 갱신하도록 구성했습니다.
- 이벤트 핸들러 단위 테스트를 추가했습니다.

## Verification
- `./gradlew :app:test --tests com.yagubogu.stat.event.LocationCheckInRankingEventHandlerTest --tests com.yagubogu.checkin.service.CheckInServiceTest`
- `./gradlew :app:test --tests com.yagubogu.stat.service.StatServiceUsingMysqlTest.createLocationCheckInUpdatesLocationCheckInRanking`

## API Spec
- API endpoint, request, response, status code 변경 없음
- 기존 `POST /api/v1/check-ins` 호출 방식 유지

Resolves #1040