### PR TITLE
feat: dev workflow 멀티 아키텍처 빌드 지원

### DIFF
--- a/.github/workflows/backend-dev.yml
+++ b/.github/workflows/backend-dev.yml
@@ -56,7 +56,7 @@ jobs:
           username: ${{ secrets.DOCKERHUB_DEPLOY_USERNAME }}
           password: ${{ secrets.DOCKERHUB_DEPLOY_TOKEN }}
 
-      - name: Docker Image Build & Push (arm64-arch)
+      - name: Docker Image Build & Push (multi-arch)
         run: |
           TAG_LATEST="dev-latest"
           # 빌드 컨텍스트: backend/ (Gradle 루트), Dockerfile: app/Dockerfile
@@ -64,7 +64,7 @@ jobs:
           --cache-to=type=registry,ref=$IMAGE:build-cache,mode=max \
           --cache-from=type=registry,ref=$IMAGE:build-cache \
           -f app/Dockerfile \
-          --platform linux/arm64 \
+          --platform linux/amd64,linux/arm64 \
           -t $IMAGE:$TAG_LATEST \
           --push \
           .

--- a/.github/workflows/crawling-dev.yml
+++ b/.github/workflows/crawling-dev.yml
@@ -61,14 +61,14 @@ jobs:
           username: ${{ secrets.DOCKERHUB_DEPLOY_USERNAME }}
           password: ${{ secrets.DOCKERHUB_DEPLOY_TOKEN }}
 
-      - name: Docker Image Build & Push (arm64-arch)
+      - name: Docker Image Build & Push (multi-arch)
         run: |
           TAG_LATEST="dev-latest"
           docker buildx build \
           --cache-to=type=registry,ref=$IMAGE:build-cache,mode=max \
           --cache-from=type=registry,ref=$IMAGE:build-cache \
           -f crawling/Dockerfile.dev \
-          --platform linux/arm64 \
+          --platform linux/amd64,linux/arm64 \
           -t $IMAGE:$TAG_LATEST \
           --push \
           .

--- a/.github/workflows/crawling-main.yml
+++ b/.github/workflows/crawling-main.yml
@@ -42,7 +42,7 @@ jobs:
           username: ${{ secrets.DOCKERHUB_DEPLOY_USERNAME }}
           password: ${{ secrets.DOCKERHUB_DEPLOY_TOKEN }}
 
-      - name: Build & Push main-latest
+      - name: Build & Push main-latest (multi-arch)
         shell: bash
         run: |
           set -euo pipefail
@@ -50,7 +50,7 @@ jobs:
             --cache-to=type=registry,ref=$IMAGE:build-cache,mode=max \
             --cache-from=type=registry,ref=$IMAGE:build-cache \
             -f backend/crawling/Dockerfile.main \
-            --platform linux/arm64 \
+            --platform linux/amd64,linux/arm64 \
             -t $IMAGE:main-latest \
             --push \
             backend


### PR DESCRIPTION
## Summary
- backend dev Docker image build step을 `linux/amd64,linux/arm64` 멀티 아키텍처 빌드로 변경했습니다.
- crawling dev Docker image build step도 동일하게 멀티 아키텍처 빌드로 변경했습니다.
- build step 이름을 `multi-arch`로 갱신해 실제 빌드 대상과 맞췄습니다.

## Verification
- `ruby -ryaml -e 'ARGV.each { |f| YAML.load_file(f); puts "OK #{f}" }' .github/workflows/backend-dev.yml .github/workflows/crawling-dev.yml`
- `rg -n "Docker Image Build & Push|--platform" .github/workflows/backend-dev.yml .github/workflows/crawling-dev.yml`

## API Spec
- API 변경 없음

Resolves #1051