### PR TITLE
feat: R2 프로필 이미지 저장 구성

### DIFF
--- a/backend/app/src/main/java/com/yagubogu/checkin/controller/v1/CheckInControllerInterface.java
+++ b/backend/app/src/main/java/com/yagubogu/checkin/controller/v1/CheckInControllerInterface.java
@@ -168,7 +168,7 @@ public interface CheckInControllerInterface {
 
     // ── 이미지 CRUD ────────────────────────────────────────────────────────────
 
-    @Operation(summary = "직관 기록 이미지 업로드용 Presigned URL 발급", description = "직관 기록 이미지 업로드를 위한 S3 Presigned URL을 발급합니다.")
+    @Operation(summary = "직관 기록 이미지 업로드용 Presigned URL 발급", description = "직관 기록 이미지 업로드를 위한 R2 Presigned URL을 발급합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "Presigned URL 발급 성공")
     })

--- a/backend/app/src/main/java/com/yagubogu/checkin/service/CheckInService.java
+++ b/backend/app/src/main/java/com/yagubogu/checkin/service/CheckInService.java
@@ -294,7 +294,7 @@ public class CheckInService {
 
     private String resolveImageUrl(final String imageKey) {
         assertObjectExists(imageKey);
-        return s3Properties.endpoint() + "/" + s3Properties.bucket() + "/" + imageKey;
+        return s3Properties.objectUrl(imageKey);
     }
 
     private void assertObjectExists(final String key) {

--- a/backend/app/src/main/java/com/yagubogu/global/config/S3Properties.java
+++ b/backend/app/src/main/java/com/yagubogu/global/config/S3Properties.java
@@ -9,6 +9,44 @@ public record S3Properties(
         Duration presignExpiration,
         String endpoint,
         String region,
+        String publicBaseUrl,
         String defaultProfileImageUrl
 ) {
+
+    public String objectUrl(final String key) {
+        return trimTrailingSlash(resolvePublicBaseUrl()) + "/" + trimLeadingSlash(key);
+    }
+
+    private String resolvePublicBaseUrl() {
+        if (publicBaseUrl != null && !publicBaseUrl.isBlank()) {
+            return publicBaseUrl;
+        }
+        return trimTrailingSlash(endpoint) + "/" + trimSlashes(bucket);
+    }
+
+    private static String trimTrailingSlash(final String value) {
+        if (value == null || value.isBlank()) {
+            return value;
+        }
+        int end = value.length();
+        while (end > 0 && value.charAt(end - 1) == '/') {
+            end--;
+        }
+        return value.substring(0, end);
+    }
+
+    private static String trimLeadingSlash(final String value) {
+        if (value == null || value.isBlank()) {
+            return value;
+        }
+        int start = 0;
+        while (start < value.length() && value.charAt(start) == '/') {
+            start++;
+        }
+        return value.substring(start);
+    }
+
+    private static String trimSlashes(final String value) {
+        return trimTrailingSlash(trimLeadingSlash(value));
+    }
 }

--- a/backend/app/src/main/java/com/yagubogu/member/controller/v1/MemberControllerInterface.java
+++ b/backend/app/src/main/java/com/yagubogu/member/controller/v1/MemberControllerInterface.java
@@ -97,7 +97,7 @@ public interface MemberControllerInterface {
     @Operation(summary = "회원 프로필 이미지 수정", description = "프로필 사진 저장을 완료하고 회원의 프로필 사진으로 저장합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "회원 프로필 이미지 수정성공"),
-            @ApiResponse(responseCode = "404", description = "key로 s3에서 이미지를 찾을 수 없음")
+            @ApiResponse(responseCode = "404", description = "key로 R2에서 이미지를 찾을 수 없음")
     })
     @PostMapping("/me/profile-image/update")
     ResponseEntity<PreSignedUrlCompleteResponse> updateProfileImage(

--- a/backend/app/src/main/java/com/yagubogu/member/service/ProfileImageService.java
+++ b/backend/app/src/main/java/com/yagubogu/member/service/ProfileImageService.java
@@ -60,7 +60,7 @@ public class ProfileImageService {
         String key = request.key();
         assertObjectExists(key);
 
-        String objectUrl = s3Properties.endpoint() + "/" + s3Properties.bucket() + "/" + key;
+        String objectUrl = s3Properties.objectUrl(key);
 
         return updateProfileImage(memberId, objectUrl);
     }

--- a/backend/app/src/main/resources/application.yml
+++ b/backend/app/src/main/resources/application.yml
@@ -81,11 +81,12 @@ sse:
 
 app:
   s3:
-    bucket: ${OCI_S3_BUCKET}
+    bucket: ${R2_S3_BUCKET}
     presign-expiration: 5m
-    endpoint: ${OCI_S3_ENDPOINT}
-    region: ${OCI_REGION}
-    default-profile-image-url: ${DEFAULT_PROFILE_IMAGE_URL}
+    endpoint: ${R2_S3_ENDPOINT}
+    region: ${R2_REGION:auto}
+    public-base-url: ${R2_PUBLIC_BASE_URL:${app.s3.endpoint}/${app.s3.bucket}}
+    default-profile-image-url: ${R2_DEFAULT_PROFILE_IMAGE_URL:${app.s3.public-base-url}/images/defaults/profile.png}
 
 ---
 spring:

--- a/backend/app/src/test/java/com/yagubogu/checkin/service/CheckInImageServiceTest.java
+++ b/backend/app/src/test/java/com/yagubogu/checkin/service/CheckInImageServiceTest.java
@@ -43,6 +43,7 @@ class CheckInImageServiceTest {
                 Duration.ofMinutes(10),
                 TEST_ENDPOINT,
                 "ap-chuncheon-1",
+                TEST_ENDPOINT + "/" + TEST_BUCKET,
                 "http://default.img"
         );
         checkInImageService = new CheckInImageService(s3Properties, s3Presigner);

--- a/backend/app/src/test/java/com/yagubogu/checkin/service/CheckInServiceTest.java
+++ b/backend/app/src/test/java/com/yagubogu/checkin/service/CheckInServiceTest.java
@@ -120,6 +120,8 @@ class CheckInServiceTest {
         mockS3Properties = Mockito.mock(S3Properties.class);
         Mockito.when(mockS3Properties.endpoint()).thenReturn("http://s3.test");
         Mockito.when(mockS3Properties.bucket()).thenReturn("test-bucket");
+        Mockito.when(mockS3Properties.objectUrl(Mockito.anyString()))
+                .thenAnswer(invocation -> "http://s3.test/test-bucket/" + invocation.getArgument(0));
 
         locationCheckInRankingRepository = mock(LocationCheckInRankingRepository.class);
         checkInService = new CheckInService(

--- a/backend/app/src/test/java/com/yagubogu/global/config/S3PropertiesTest.java
+++ b/backend/app/src/test/java/com/yagubogu/global/config/S3PropertiesTest.java
@@ -1,0 +1,46 @@
+package com.yagubogu.global.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class S3PropertiesTest {
+
+    @DisplayName("publicBaseUrl 기준으로 객체 URL을 만든다")
+    @Test
+    void objectUrl_usesPublicBaseUrl() {
+        S3Properties properties = new S3Properties(
+                "yagubogu",
+                Duration.ofMinutes(5),
+                "https://test-account.r2.cloudflarestorage.com",
+                "auto",
+                "https://test-account.r2.cloudflarestorage.com/yagubogu/",
+                "https://test-account.r2.cloudflarestorage.com/yagubogu/images/defaults/profile.png"
+        );
+
+        String objectUrl = properties.objectUrl("/images/profiles/abc-123");
+
+        assertThat(objectUrl)
+                .isEqualTo("https://test-account.r2.cloudflarestorage.com/yagubogu/images/profiles/abc-123");
+    }
+
+    @DisplayName("publicBaseUrl이 없으면 endpoint와 bucket으로 객체 URL을 만든다")
+    @Test
+    void objectUrl_fallbackToEndpointAndBucket() {
+        S3Properties properties = new S3Properties(
+                "yagubogu",
+                Duration.ofMinutes(5),
+                "https://test-account.r2.cloudflarestorage.com/",
+                "auto",
+                null,
+                "https://test-account.r2.cloudflarestorage.com/yagubogu/images/defaults/profile.png"
+        );
+
+        String objectUrl = properties.objectUrl("images/profiles/abc-123");
+
+        assertThat(objectUrl)
+                .isEqualTo("https://test-account.r2.cloudflarestorage.com/yagubogu/images/profiles/abc-123");
+    }
+}

--- a/backend/app/src/test/java/com/yagubogu/member/ProfileImageE2eTest.java
+++ b/backend/app/src/test/java/com/yagubogu/member/ProfileImageE2eTest.java
@@ -96,7 +96,7 @@ public class ProfileImageE2eTest extends E2eTestBase {
         });
     }
 
-    @DisplayName("s3에 업로드된 이미지로 회원의 프로필 이미지 주소를 수정한다")
+    @DisplayName("R2에 업로드된 이미지로 회원의 프로필 이미지 주소를 수정한다")
     @Test
     void completeAndUpdate_success() {
         // given
@@ -104,7 +104,7 @@ public class ProfileImageE2eTest extends E2eTestBase {
         String accessToken = authFactory.getAccessTokenByMemberId(member.getId(), Role.USER);
         String key = "images/profiles/abc-123";
 
-        String expectedUrl = s3Properties.endpoint() + "/" + s3Properties.bucket() + "/" + key;
+        String expectedUrl = s3Properties.objectUrl(key);
 
         // when
         PreSignedUrlCompleteResponse response = RestAssured.given().log().all()

--- a/backend/app/src/test/java/com/yagubogu/member/service/ProfileImageServiceTest.java
+++ b/backend/app/src/test/java/com/yagubogu/member/service/ProfileImageServiceTest.java
@@ -51,9 +51,10 @@ class ProfileImageServiceTest {
 
     private static final String TEST_BUCKET = "test-bucket";
     private static final Duration TEST_PRESIGN_EXPIRATION = Duration.ofMinutes(10);
-    private static final String TEST_ENDPOINT = "https://test-namespace.compat.objectstorage.ap-chuncheon-1.oraclecloud.com";
-    private static final String TEST_REGION = "ap-chuncheon-1";
-    private static final String TEST_DEFAULT_PROFILE_IMAGE_URL = "https://test-namespace.compat.objectstorage.ap-chuncheon-1.oraclecloud.com/yagubogu/images/defaults/profile.png";
+    private static final String TEST_ENDPOINT = "https://test-account.r2.cloudflarestorage.com";
+    private static final String TEST_REGION = "auto";
+    private static final String TEST_PUBLIC_BASE_URL = TEST_ENDPOINT + "/" + TEST_BUCKET;
+    private static final String TEST_DEFAULT_PROFILE_IMAGE_URL = TEST_PUBLIC_BASE_URL + "/images/defaults/profile.png";
 
     @Mock
     private MemberService memberService;
@@ -73,7 +74,7 @@ class ProfileImageServiceTest {
     @BeforeEach
     void setUp() {
         s3Properties = new S3Properties(TEST_BUCKET, TEST_PRESIGN_EXPIRATION, TEST_ENDPOINT, TEST_REGION,
-                TEST_DEFAULT_PROFILE_IMAGE_URL);
+                TEST_PUBLIC_BASE_URL, TEST_DEFAULT_PROFILE_IMAGE_URL);
         profileImageService = new ProfileImageService(s3Presigner, s3Client, s3Properties, memberService);
     }
 
@@ -123,7 +124,7 @@ class ProfileImageServiceTest {
         verify(s3Presigner, never()).presignPutObject(any(java.util.function.Consumer.class));
     }
 
-    @DisplayName("s3에 업로드된 이미지로 회원의 프로필 이미지 주소를 수정한다")
+    @DisplayName("R2에 업로드된 이미지로 회원의 프로필 이미지 주소를 수정한다")
     @Test
     void completeUpload_success() {
         // given
@@ -131,7 +132,7 @@ class ProfileImageServiceTest {
         PreSignedUrlCompleteRequest request = new PreSignedUrlCompleteRequest(key);
         Member member = memberFactory.save(builder -> builder.build());
 
-        String expectedUrl = TEST_ENDPOINT + "/" + TEST_BUCKET + "/" + key;
+        String expectedUrl = TEST_PUBLIC_BASE_URL + "/" + key;
 
         // Mock 객체 행동 정의 (Stubbing)
         // 1. s3Client.headObject가 정상 응답을 반환하도록 설정

--- a/backend/app/src/test/resources/application.yml
+++ b/backend/app/src/test/resources/application.yml
@@ -66,11 +66,12 @@ sse:
 
 app:
   s3:
-    bucket: techcourse-project-2025
+    bucket: yagubogu
     presign-expiration: 10m
-    endpoint: https://test-namespace.compat.objectstorage.ap-chuncheon-1.oraclecloud.com
-    region: ap-chuncheon-1
-    default-profile-image-url: https://test.oraclecloud.com/test/defaults/profile.png
+    endpoint: https://test-account.r2.cloudflarestorage.com
+    region: auto
+    public-base-url: https://test-account.r2.cloudflarestorage.com/yagubogu
+    default-profile-image-url: https://test-account.r2.cloudflarestorage.com/yagubogu/images/defaults/profile.png
   clock:
     fixed-date: 2024-08-15
 


### PR DESCRIPTION
## Summary
- OCI S3 환경 변수 기반 설정을 Cloudflare R2 설정으로 전환했습니다.
- R2 presigned URL 발급에 쓰는 S3 API endpoint와 DB에 저장할 공개 객체 URL base를 분리했습니다.
- 프로필 이미지와 체크인 이미지 URL 저장 로직이 `S3Properties.objectUrl(key)`를 사용하도록 정리했습니다.
- R2 URL 조립 테스트와 관련 프로필/체크인 이미지 테스트를 갱신했습니다.

## Verification
- `./gradlew :app:test --tests com.yagubogu.global.config.S3PropertiesTest --tests com.yagubogu.member.service.ProfileImageServiceTest --tests com.yagubogu.checkin.service.CheckInImageServiceTest`
- `./gradlew :app:test --tests com.yagubogu.checkin.service.CheckInServiceTest --tests com.yagubogu.member.ProfileImageE2eTest`
- `./gradlew :app:test`
- `./gradlew :app:processResources`

## API Spec

### POST `/api/v1/members/me/profile-image/pre-signed`
- Purpose: 프로필 이미지 업로드용 R2 Presigned PUT URL 발급
- Auth: 로그인 사용자
- Request body:
  ```json
  {
    "contentType": "image/jpeg",
    "contentLength": 1000000
  }
  ```
- Validation:
  - `contentLength`는 5MB 이하
  - `contentType`은 `image/jpeg`
- Response 200:
  ```json
  {
    "key": "images/profiles/{uuid}",
    "url": "https://{r2-endpoint}/{bucket}/images/profiles/{uuid}?..."
  }
  ```
- Status codes: 200, 413, 415
- Compatibility notes: 응답 필드명은 유지되며, presigned URL 대상만 R2로 변경됩니다.

### POST `/api/v1/members/me/profile-image/update`
- Purpose: R2 업로드 완료 후 해당 객체 URL을 회원 프로필 이미지로 저장
- Auth: 로그인 사용자
- Request body:
  ```json
  {
    "key": "images/profiles/{uuid}"
  }
  ```
- Behavior:
  - R2 `HeadObject`로 key 존재 여부 확인
  - 저장 URL은 `app.s3.public-base-url + "/" + key` 형태로 생성
- Response 200:
  ```json
  {
    "url": "${R2_PUBLIC_BASE_URL}/images/profiles/{uuid}"
  }
  ```
- Status codes: 200, 404
- Compatibility notes: 엔드포인트와 요청/응답 스키마는 유지되며, 저장되는 객체 URL base가 R2 공개 base로 변경됩니다.

Resolves #1055