### PR TITLE
feat: 배포 워크플로 빌드 속도 최적화

### DIFF
--- a/.github/workflows/backend-dev.yml
+++ b/.github/workflows/backend-dev.yml
@@ -37,7 +37,7 @@ jobs:
 
   build:
     needs: ci
-    runs-on: ubuntu-22.04-arm
+    runs-on: ubuntu-latest
     defaults:
       run:
         shell: bash
@@ -56,7 +56,7 @@ jobs:
           username: ${{ secrets.DOCKERHUB_DEPLOY_USERNAME }}
           password: ${{ secrets.DOCKERHUB_DEPLOY_TOKEN }}
 
-      - name: Docker Image Build & Push (multi-arch)
+      - name: Docker Image Build & Push (amd64)
         run: |
           TAG_LATEST="dev-latest"
           # 빌드 컨텍스트: backend/ (Gradle 루트), Dockerfile: app/Dockerfile
@@ -64,7 +64,7 @@ jobs:
           --cache-to=type=registry,ref=$IMAGE:build-cache,mode=max \
           --cache-from=type=registry,ref=$IMAGE:build-cache \
           -f app/Dockerfile \
-          --platform linux/amd64,linux/arm64 \
+          --platform linux/amd64 \
           -t $IMAGE:$TAG_LATEST \
           --push \
           .

--- a/.github/workflows/crawling-dev.yml
+++ b/.github/workflows/crawling-dev.yml
@@ -42,7 +42,7 @@ jobs:
 
   build:
     needs: ci
-    runs-on: ubuntu-22.04-arm
+    runs-on: ubuntu-latest
     defaults:
       run:
         shell: bash
@@ -61,14 +61,14 @@ jobs:
           username: ${{ secrets.DOCKERHUB_DEPLOY_USERNAME }}
           password: ${{ secrets.DOCKERHUB_DEPLOY_TOKEN }}
 
-      - name: Docker Image Build & Push (multi-arch)
+      - name: Docker Image Build & Push (amd64)
         run: |
           TAG_LATEST="dev-latest"
           docker buildx build \
           --cache-to=type=registry,ref=$IMAGE:build-cache,mode=max \
           --cache-from=type=registry,ref=$IMAGE:build-cache \
           -f crawling/Dockerfile.dev \
-          --platform linux/amd64,linux/arm64 \
+          --platform linux/amd64 \
           -t $IMAGE:$TAG_LATEST \
           --push \
           .

--- a/.github/workflows/crawling-main.yml
+++ b/.github/workflows/crawling-main.yml
@@ -42,7 +42,7 @@ jobs:
           username: ${{ secrets.DOCKERHUB_DEPLOY_USERNAME }}
           password: ${{ secrets.DOCKERHUB_DEPLOY_TOKEN }}
 
-      - name: Build & Push main-latest (multi-arch)
+      - name: Build & Push main-latest (amd64)
         shell: bash
         run: |
           set -euo pipefail
@@ -50,7 +50,7 @@ jobs:
             --cache-to=type=registry,ref=$IMAGE:build-cache,mode=max \
             --cache-from=type=registry,ref=$IMAGE:build-cache \
             -f backend/crawling/Dockerfile.main \
-            --platform linux/amd64,linux/arm64 \
+            --platform linux/amd64 \
             -t $IMAGE:main-latest \
             --push \
             backend


### PR DESCRIPTION
## Summary
- 배포 서버가 x86_64 Intel N100 환경인 점에 맞춰 Docker 빌드 대상을 `linux/amd64` 단일 아키텍처로 변경했습니다.
- `backend-dev.yml`, `crawling-dev.yml`의 build job runner를 ARM runner에서 x64 `ubuntu-latest`로 변경했습니다.
- `crawling-main.yml`의 main-latest 빌드도 `linux/amd64` 단일 플랫폼으로 변경했습니다.
- Docker Hub push, registry cache, 기존 tag/deploy 흐름은 유지했습니다.

## Why
- 기존 dev 워크플로는 ARM runner에서 `linux/amd64,linux/arm64`를 함께 빌드해 cross-platform 빌드 비용이 컸습니다.
- 실제 실행 서버는 x86_64이므로 arm64 이미지를 매번 만들 필요가 없습니다.

## Verification
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "#{f}: ok" }' .github/workflows/backend-dev.yml .github/workflows/crawling-dev.yml .github/workflows/crawling-main.yml`
- `git diff --check`
- `rg -n "linux/arm64|ubuntu-22.04-arm|multi-arch" .github/workflows` 결과 없음

## API Spec
- API 변경 없음

Resolves #1058