### PR TITLE
feat: R2 배포 환경변수 추가

### DIFF
--- a/.github/workflows/backend-dev.yml
+++ b/.github/workflows/backend-dev.yml
@@ -128,6 +128,11 @@ jobs:
             -e OCI_REGION="${{ secrets.OCI_REGION }}" \
             -e OCI_S3_BUCKET="${{ secrets.OCI_S3_BUCKET }}" \
             -e DEFAULT_PROFILE_IMAGE_URL="${{ secrets.DEFAULT_PROFILE_IMAGE_URL }}" \
+            -e R2_S3_ENDPOINT="${{ secrets.R2_S3_ENDPOINT }}" \
+            -e R2_REGION="${{ secrets.R2_REGION }}" \
+            -e R2_S3_BUCKET="${{ secrets.R2_S3_BUCKET }}" \
+            -e R2_PUBLIC_BASE_URL="${{ secrets.R2_PUBLIC_BASE_URL }}" \
+            -e R2_DEFAULT_PROFILE_IMAGE_URL="${{ secrets.R2_DEFAULT_PROFILE_IMAGE_URL }}" \
             $IMAGE:$TAG
           
           echo "컨테이너 실행 완료."  

--- a/.github/workflows/backend-main.yml
+++ b/.github/workflows/backend-main.yml
@@ -179,6 +179,11 @@ jobs:
             -e OCI_REGION="${{ secrets.OCI_REGION }}" \
             -e OCI_S3_BUCKET="${{ secrets.OCI_S3_BUCKET }}" \
             -e DEFAULT_PROFILE_IMAGE_URL="${{ secrets.DEFAULT_PROFILE_IMAGE_URL }}" \
+            -e R2_S3_ENDPOINT="${{ secrets.R2_S3_ENDPOINT }}" \
+            -e R2_REGION="${{ secrets.R2_REGION }}" \
+            -e R2_S3_BUCKET="${{ secrets.R2_S3_BUCKET }}" \
+            -e R2_PUBLIC_BASE_URL="${{ secrets.R2_PUBLIC_BASE_URL }}" \
+            -e R2_DEFAULT_PROFILE_IMAGE_URL="${{ secrets.R2_DEFAULT_PROFILE_IMAGE_URL }}" \
             -l app=yagubogu-backend \
             -l release.version="${NEXT_VERSION_WITH_V}" \
             -l release.digest="${DIGEST}" \

--- a/.github/workflows/backend-rollback-main.yml
+++ b/.github/workflows/backend-rollback-main.yml
@@ -97,6 +97,13 @@ jobs:
             -e APPLE_CLIENT_ID="${{ secrets.APPLE_CLIENT_ID }}" \
             -e ACCESS_TOKEN_SECRET_KEY="${{ secrets.ACCESS_TOKEN_SECRET_KEY }}" \
             -e REFRESH_TOKEN_SECRET_KEY="${{ secrets.REFRESH_TOKEN_SECRET_KEY }}" \
+            -e AWS_ACCESS_KEY_ID="${{ secrets.AWS_ACCESS_KEY_ID }}" \
+            -e AWS_SECRET_ACCESS_KEY="${{ secrets.AWS_SECRET_ACCESS_KEY }}" \
+            -e R2_S3_ENDPOINT="${{ secrets.R2_S3_ENDPOINT }}" \
+            -e R2_REGION="${{ secrets.R2_REGION }}" \
+            -e R2_S3_BUCKET="${{ secrets.R2_S3_BUCKET }}" \
+            -e R2_PUBLIC_BASE_URL="${{ secrets.R2_PUBLIC_BASE_URL }}" \
+            -e R2_DEFAULT_PROFILE_IMAGE_URL="${{ secrets.R2_DEFAULT_PROFILE_IMAGE_URL }}" \
             -l app=yagubogu-backend \
             -l release.version="$VER" \
             -l release.digest="$DIGEST" \


### PR DESCRIPTION
## Summary
- 백엔드 dev 배포 컨테이너에 `R2_*` 환경변수를 추가했습니다.
- 백엔드 main 배포 컨테이너에 `R2_*` 환경변수를 추가했습니다.
- 백엔드 rollback 배포 컨테이너에도 R2 환경변수와 S3 SDK credential env를 추가했습니다.
- 기존 `OCI_*`, `DEFAULT_PROFILE_IMAGE_URL` 주입은 유지했습니다.

## Verification
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "#{f}: ok" }' .github/workflows/backend-dev.yml .github/workflows/backend-main.yml .github/workflows/backend-rollback-main.yml`
- `git diff --check`

## API Spec
- API 변경 없음

Resolves #1061