### PR TITLE
feat: R2 프로필 이미지 경로 수정

### DIFF
--- a/backend/app/src/main/java/com/yagubogu/global/config/S3Config.java
+++ b/backend/app/src/main/java/com/yagubogu/global/config/S3Config.java
@@ -20,7 +20,7 @@ public class S3Config {
     @Bean
     S3Client s3() {
         return S3Client.builder()
-                .endpointOverride(URI.create(s3Properties.endpoint()))
+                .endpointOverride(URI.create(s3Properties.apiEndpoint()))
                 .region(Region.of(s3Properties.region()))
                 .serviceConfiguration(S3Configuration.builder()
                         .pathStyleAccessEnabled(true)
@@ -31,7 +31,7 @@ public class S3Config {
     @Bean
     S3Presigner presigner() {
         return S3Presigner.builder()
-                .endpointOverride(URI.create(s3Properties.endpoint()))
+                .endpointOverride(URI.create(s3Properties.apiEndpoint()))
                 .region(Region.of(s3Properties.region()))
                 .serviceConfiguration(S3Configuration.builder()
                         .pathStyleAccessEnabled(true)

--- a/backend/app/src/main/java/com/yagubogu/global/config/S3Properties.java
+++ b/backend/app/src/main/java/com/yagubogu/global/config/S3Properties.java
@@ -13,15 +13,48 @@ public record S3Properties(
         String defaultProfileImageUrl
 ) {
 
+    public String apiEndpoint() {
+        return removeTrailingBucketPath(endpoint);
+    }
+
     public String objectUrl(final String key) {
         return trimTrailingSlash(resolvePublicBaseUrl()) + "/" + trimLeadingSlash(key);
     }
 
     private String resolvePublicBaseUrl() {
         if (publicBaseUrl != null && !publicBaseUrl.isBlank()) {
-            return publicBaseUrl;
+            return removeDuplicateTrailingBucketPath(publicBaseUrl);
         }
-        return trimTrailingSlash(endpoint) + "/" + trimSlashes(bucket);
+        String trimmedEndpoint = trimTrailingSlash(endpoint);
+        if (hasTrailingBucketPath(trimmedEndpoint)) {
+            return trimmedEndpoint;
+        }
+        return trimmedEndpoint + "/" + trimSlashes(bucket);
+    }
+
+    private String removeTrailingBucketPath(final String value) {
+        String trimmedValue = trimTrailingSlash(value);
+        if (!hasTrailingBucketPath(trimmedValue)) {
+            return trimmedValue;
+        }
+        return trimmedValue.substring(0, trimmedValue.length() - bucketPath().length());
+    }
+
+    private String removeDuplicateTrailingBucketPath(final String value) {
+        String trimmedValue = trimTrailingSlash(value);
+        String duplicateBucketPath = bucketPath() + bucketPath();
+        if (!trimmedValue.endsWith(duplicateBucketPath)) {
+            return trimmedValue;
+        }
+        return trimmedValue.substring(0, trimmedValue.length() - bucketPath().length());
+    }
+
+    private boolean hasTrailingBucketPath(final String value) {
+        return value != null && value.endsWith(bucketPath());
+    }
+
+    private String bucketPath() {
+        return "/" + trimSlashes(bucket);
     }
 
     private static String trimTrailingSlash(final String value) {

--- a/backend/app/src/main/java/com/yagubogu/member/service/ProfileImageService.java
+++ b/backend/app/src/main/java/com/yagubogu/member/service/ProfileImageService.java
@@ -25,7 +25,7 @@ public class ProfileImageService {
 
     private static final long MAX_FILE_SIZE_MB = 5;
     private static final long MAX_FILE_SIZE = MAX_FILE_SIZE_MB * 1024 * 1024;
-    private static final String IMAGES_PROFILES_PREFIX = "images/profiles/";
+    private static final String PROFILE_PREFIX = "profile/";
     private static final Set<String> ALLOWED_CONTENT_TYPES = Set.of("image/jpeg");
 
     private final S3Presigner s3Presigner;
@@ -38,7 +38,7 @@ public class ProfileImageService {
         validateContentType(preSignedUrlStartRequest.contentType());
 
         String uniqueFileName = UUID.randomUUID().toString();
-        String key = IMAGES_PROFILES_PREFIX + uniqueFileName;
+        String key = PROFILE_PREFIX + uniqueFileName;
 
         PutObjectRequest putReq = PutObjectRequest.builder()
                 .bucket(s3Properties.bucket())

--- a/backend/app/src/test/java/com/yagubogu/global/config/S3PropertiesTest.java
+++ b/backend/app/src/test/java/com/yagubogu/global/config/S3PropertiesTest.java
@@ -20,10 +20,10 @@ class S3PropertiesTest {
                 "https://test-account.r2.cloudflarestorage.com/yagubogu/images/defaults/profile.png"
         );
 
-        String objectUrl = properties.objectUrl("/images/profiles/abc-123");
+        String objectUrl = properties.objectUrl("/profile/abc-123");
 
         assertThat(objectUrl)
-                .isEqualTo("https://test-account.r2.cloudflarestorage.com/yagubogu/images/profiles/abc-123");
+                .isEqualTo("https://test-account.r2.cloudflarestorage.com/yagubogu/profile/abc-123");
     }
 
     @DisplayName("publicBaseUrl이 없으면 endpoint와 bucket으로 객체 URL을 만든다")
@@ -38,9 +38,43 @@ class S3PropertiesTest {
                 "https://test-account.r2.cloudflarestorage.com/yagubogu/images/defaults/profile.png"
         );
 
-        String objectUrl = properties.objectUrl("images/profiles/abc-123");
+        String objectUrl = properties.objectUrl("profile/abc-123");
 
         assertThat(objectUrl)
-                .isEqualTo("https://test-account.r2.cloudflarestorage.com/yagubogu/images/profiles/abc-123");
+                .isEqualTo("https://test-account.r2.cloudflarestorage.com/yagubogu/profile/abc-123");
+    }
+
+    @DisplayName("endpoint에 bucket 경로가 있어도 API endpoint에서는 bucket 경로를 제거한다")
+    @Test
+    void apiEndpoint_removesBucketPath() {
+        S3Properties properties = new S3Properties(
+                "yagubogu",
+                Duration.ofMinutes(5),
+                "https://test-account.r2.cloudflarestorage.com/yagubogu",
+                "auto",
+                null,
+                "https://test-account.r2.cloudflarestorage.com/yagubogu/images/defaults/profile.png"
+        );
+
+        assertThat(properties.apiEndpoint())
+                .isEqualTo("https://test-account.r2.cloudflarestorage.com");
+    }
+
+    @DisplayName("publicBaseUrl에 bucket 경로가 중복되어도 객체 URL에서는 한 번만 사용한다")
+    @Test
+    void objectUrl_removesDuplicatedBucketPath() {
+        S3Properties properties = new S3Properties(
+                "yagubogu",
+                Duration.ofMinutes(5),
+                "https://test-account.r2.cloudflarestorage.com/yagubogu",
+                "auto",
+                "https://test-account.r2.cloudflarestorage.com/yagubogu/yagubogu",
+                "https://test-account.r2.cloudflarestorage.com/yagubogu/images/defaults/profile.png"
+        );
+
+        String objectUrl = properties.objectUrl("profile/abc-123");
+
+        assertThat(objectUrl)
+                .isEqualTo("https://test-account.r2.cloudflarestorage.com/yagubogu/profile/abc-123");
     }
 }

--- a/backend/app/src/test/java/com/yagubogu/member/ProfileImageE2eTest.java
+++ b/backend/app/src/test/java/com/yagubogu/member/ProfileImageE2eTest.java
@@ -90,7 +90,7 @@ public class ProfileImageE2eTest extends E2eTestBase {
 
         // then
         assertSoftly(softAssertions -> {
-            softAssertions.assertThat(response.key()).startsWith("images/profiles/");
+            softAssertions.assertThat(response.key()).startsWith("profile/");
             softAssertions.assertThat(response.url()).contains(s3Properties.bucket());
             softAssertions.assertThat(response.url()).contains(response.key());
         });
@@ -102,7 +102,7 @@ public class ProfileImageE2eTest extends E2eTestBase {
         // given
         Member member = memberFactory.save(MemberBuilder::build);
         String accessToken = authFactory.getAccessTokenByMemberId(member.getId(), Role.USER);
-        String key = "images/profiles/abc-123";
+        String key = "profile/abc-123";
 
         String expectedUrl = s3Properties.objectUrl(key);
 

--- a/backend/app/src/test/java/com/yagubogu/member/service/ProfileImageServiceTest.java
+++ b/backend/app/src/test/java/com/yagubogu/member/service/ProfileImageServiceTest.java
@@ -83,7 +83,7 @@ class ProfileImageServiceTest {
     void issuePreSignedUrl_success() throws MalformedURLException {
         // given
         PreSignedUrlStartRequest request = new PreSignedUrlStartRequest("image/jpeg", 1_000_000L);
-        String fakeKeyPrefix = "images/profiles/";
+        String fakeKeyPrefix = "profile/";
         String fakeUrl = "https://test-bucket.s3.ap-northeast-2.amazonaws.com/" + fakeKeyPrefix + "some-uuid";
         when(presignedPutObjectRequest.url()).thenReturn(new URL(fakeUrl));
         when(s3Presigner.presignPutObject(any(Consumer.class))).thenReturn(
@@ -128,7 +128,7 @@ class ProfileImageServiceTest {
     @Test
     void completeUpload_success() {
         // given
-        String key = "images/profiles/abc-123";
+        String key = "profile/abc-123";
         PreSignedUrlCompleteRequest request = new PreSignedUrlCompleteRequest(key);
         Member member = memberFactory.save(builder -> builder.build());
 


### PR DESCRIPTION
## Summary
- 프로필 이미지 업로드 key prefix를 `images/profiles/`에서 `profile/`로 변경했습니다.
- R2 endpoint에 bucket path가 포함되어 들어와도 S3 SDK endpoint에서는 bucket path를 제거하도록 했습니다.
- `publicBaseUrl`에 bucket path가 중복되어 들어와도 저장 URL에서는 한 번만 사용하도록 정규화했습니다.
- 관련 프로필 이미지 테스트와 S3 properties 테스트를 갱신했습니다.

## Verification
- `./gradlew :app:test --tests com.yagubogu.global.config.S3PropertiesTest --tests com.yagubogu.member.service.ProfileImageServiceTest --tests com.yagubogu.member.ProfileImageE2eTest`
- `./gradlew :app:test --tests com.yagubogu.member.ProfileImageE2eTest`
- `git diff --check`

## Note
- `./gradlew :app:test` 전체 실행에서는 `ProfileImageE2eTest`가 403으로 실패했지만, 동일 테스트 단독 실행은 성공했습니다. 실패는 응답 URL assertion이 아니라 인증 계층 403으로, 전체 테스트 순서/상태 영향으로 보입니다.

## API Spec

### POST `/api/v1/members/me/profile-image/pre-signed`
- 변경 전 key: `images/profiles/{uuid}`
- 변경 후 key: `profile/{uuid}`
- Response 200:
  ```json
  {
    "key": "profile/{uuid}",
    "url": "https://{r2-endpoint}/{bucket}/profile/{uuid}?..."
  }
  ```
- Compatibility notes: 클라이언트가 반환된 `key`를 그대로 완료 API에 넘기면 되며, key prefix만 변경됩니다.

### POST `/api/v1/members/me/profile-image/update`
- Request body:
  ```json
  {
    "key": "profile/{uuid}"
  }
  ```
- Response 200:
  ```json
  {
    "url": "https://{public-base-url}/profile/{uuid}"
  }
  ```
- Compatibility notes: 저장 URL에서 bucket path가 중복되지 않도록 정규화됩니다.

Resolves #1063