### PR TITLE
feat: 이미지 저장 도메인 변경

### DIFF
--- a/.github/workflows/backend-dev.yml
+++ b/.github/workflows/backend-dev.yml
@@ -131,8 +131,8 @@ jobs:
             -e R2_S3_ENDPOINT="${{ secrets.R2_S3_ENDPOINT }}" \
             -e R2_REGION="${{ secrets.R2_REGION }}" \
             -e R2_S3_BUCKET="${{ secrets.R2_S3_BUCKET }}" \
-            -e R2_PUBLIC_BASE_URL="${{ secrets.R2_PUBLIC_BASE_URL }}" \
-            -e R2_DEFAULT_PROFILE_IMAGE_URL="${{ secrets.R2_DEFAULT_PROFILE_IMAGE_URL }}" \
+            -e R2_PUBLIC_BASE_URL="${{ secrets.R2_PUBLIC_BASE_URL || 'https://images.yagubogu.com' }}" \
+            -e R2_DEFAULT_PROFILE_IMAGE_URL="${{ secrets.R2_DEFAULT_PROFILE_IMAGE_URL || 'https://images.yagubogu.com/images/defaults/profile.png' }}" \
             $IMAGE:$TAG
           
           echo "컨테이너 실행 완료."  

--- a/.github/workflows/backend-main.yml
+++ b/.github/workflows/backend-main.yml
@@ -182,8 +182,8 @@ jobs:
             -e R2_S3_ENDPOINT="${{ secrets.R2_S3_ENDPOINT }}" \
             -e R2_REGION="${{ secrets.R2_REGION }}" \
             -e R2_S3_BUCKET="${{ secrets.R2_S3_BUCKET }}" \
-            -e R2_PUBLIC_BASE_URL="${{ secrets.R2_PUBLIC_BASE_URL }}" \
-            -e R2_DEFAULT_PROFILE_IMAGE_URL="${{ secrets.R2_DEFAULT_PROFILE_IMAGE_URL }}" \
+            -e R2_PUBLIC_BASE_URL="${{ secrets.R2_PUBLIC_BASE_URL || 'https://images.yagubogu.com' }}" \
+            -e R2_DEFAULT_PROFILE_IMAGE_URL="${{ secrets.R2_DEFAULT_PROFILE_IMAGE_URL || 'https://images.yagubogu.com/images/defaults/profile.png' }}" \
             -l app=yagubogu-backend \
             -l release.version="${NEXT_VERSION_WITH_V}" \
             -l release.digest="${DIGEST}" \

--- a/.github/workflows/backend-rollback-main.yml
+++ b/.github/workflows/backend-rollback-main.yml
@@ -102,8 +102,8 @@ jobs:
             -e R2_S3_ENDPOINT="${{ secrets.R2_S3_ENDPOINT }}" \
             -e R2_REGION="${{ secrets.R2_REGION }}" \
             -e R2_S3_BUCKET="${{ secrets.R2_S3_BUCKET }}" \
-            -e R2_PUBLIC_BASE_URL="${{ secrets.R2_PUBLIC_BASE_URL }}" \
-            -e R2_DEFAULT_PROFILE_IMAGE_URL="${{ secrets.R2_DEFAULT_PROFILE_IMAGE_URL }}" \
+            -e R2_PUBLIC_BASE_URL="${{ secrets.R2_PUBLIC_BASE_URL || 'https://images.yagubogu.com' }}" \
+            -e R2_DEFAULT_PROFILE_IMAGE_URL="${{ secrets.R2_DEFAULT_PROFILE_IMAGE_URL || 'https://images.yagubogu.com/images/defaults/profile.png' }}" \
             -l app=yagubogu-backend \
             -l release.version="$VER" \
             -l release.digest="$DIGEST" \

--- a/backend/app/src/main/resources/application.yml
+++ b/backend/app/src/main/resources/application.yml
@@ -85,7 +85,7 @@ app:
     presign-expiration: 5m
     endpoint: ${R2_S3_ENDPOINT}
     region: ${R2_REGION:auto}
-    public-base-url: ${R2_PUBLIC_BASE_URL:${app.s3.endpoint}/${app.s3.bucket}}
+    public-base-url: ${R2_PUBLIC_BASE_URL:https://images.yagubogu.com}
     default-profile-image-url: ${R2_DEFAULT_PROFILE_IMAGE_URL:${app.s3.public-base-url}/images/defaults/profile.png}
 
 ---

--- a/backend/app/src/test/java/com/yagubogu/global/config/S3PropertiesTest.java
+++ b/backend/app/src/test/java/com/yagubogu/global/config/S3PropertiesTest.java
@@ -16,14 +16,14 @@ class S3PropertiesTest {
                 Duration.ofMinutes(5),
                 "https://test-account.r2.cloudflarestorage.com",
                 "auto",
-                "https://test-account.r2.cloudflarestorage.com/yagubogu/",
-                "https://test-account.r2.cloudflarestorage.com/yagubogu/images/defaults/profile.png"
+                "https://images.yagubogu.com/",
+                "https://images.yagubogu.com/images/defaults/profile.png"
         );
 
         String objectUrl = properties.objectUrl("/profile/abc-123");
 
         assertThat(objectUrl)
-                .isEqualTo("https://test-account.r2.cloudflarestorage.com/yagubogu/profile/abc-123");
+                .isEqualTo("https://images.yagubogu.com/profile/abc-123");
     }
 
     @DisplayName("publicBaseUrl이 없으면 endpoint와 bucket으로 객체 URL을 만든다")

--- a/backend/app/src/test/java/com/yagubogu/member/service/ProfileImageServiceTest.java
+++ b/backend/app/src/test/java/com/yagubogu/member/service/ProfileImageServiceTest.java
@@ -53,7 +53,7 @@ class ProfileImageServiceTest {
     private static final Duration TEST_PRESIGN_EXPIRATION = Duration.ofMinutes(10);
     private static final String TEST_ENDPOINT = "https://test-account.r2.cloudflarestorage.com";
     private static final String TEST_REGION = "auto";
-    private static final String TEST_PUBLIC_BASE_URL = TEST_ENDPOINT + "/" + TEST_BUCKET;
+    private static final String TEST_PUBLIC_BASE_URL = "https://images.yagubogu.com";
     private static final String TEST_DEFAULT_PROFILE_IMAGE_URL = TEST_PUBLIC_BASE_URL + "/images/defaults/profile.png";
 
     @Mock

--- a/backend/app/src/test/resources/application.yml
+++ b/backend/app/src/test/resources/application.yml
@@ -70,8 +70,8 @@ app:
     presign-expiration: 10m
     endpoint: https://test-account.r2.cloudflarestorage.com
     region: auto
-    public-base-url: https://test-account.r2.cloudflarestorage.com/yagubogu
-    default-profile-image-url: https://test-account.r2.cloudflarestorage.com/yagubogu/images/defaults/profile.png
+    public-base-url: https://images.yagubogu.com
+    default-profile-image-url: https://images.yagubogu.com/images/defaults/profile.png
   clock:
     fixed-date: 2024-08-15
 


### PR DESCRIPTION
## Summary
- `app.s3.public-base-url` 기본값을 `https://images.yagubogu.com`으로 변경했습니다.
- 테스트 설정과 URL 조립 테스트도 `images.yagubogu.com` 기준으로 갱신했습니다.
- dev/main/rollback 배포 워크플로에서 `R2_PUBLIC_BASE_URL` secret이 없을 때 `https://images.yagubogu.com`을 전달하도록 했습니다.
- `R2_DEFAULT_PROFILE_IMAGE_URL`도 기본값을 `https://images.yagubogu.com/images/defaults/profile.png`로 맞췄습니다.

## Verification
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "#{f}: ok" }' .github/workflows/backend-dev.yml .github/workflows/backend-main.yml .github/workflows/backend-rollback-main.yml`
- `git diff --check`
- `./gradlew :app:test --tests com.yagubogu.global.config.S3PropertiesTest --tests com.yagubogu.member.service.ProfileImageServiceTest --tests com.yagubogu.member.ProfileImageE2eTest --tests com.yagubogu.checkin.service.CheckInServiceTest`

## API Spec

### POST `/api/v1/members/me/profile-image/update`
- 변경: 업로드 완료 후 응답 및 DB 저장 URL의 host가 기본적으로 `images.yagubogu.com`을 사용합니다.
- Response 200:
  ```json
  {
    "url": "https://images.yagubogu.com/profile/{uuid}"
  }
  ```

### 체크인 이미지 저장
- 변경: 체크인 이미지 key 완료/저장 시에도 `S3Properties.objectUrl(key)`를 통해 기본적으로 `https://images.yagubogu.com/{key}` 형태를 저장합니다.

Resolves #1065