### PR TITLE
fix: iOS 직관 기록 버그 수정

### DIFF
--- a/mobile/composeApp/src/commonMain/kotlin/com/yagubogu/ui/attendance/detail/AttendanceDetailDiaryScreen.kt
+++ b/mobile/composeApp/src/commonMain/kotlin/com/yagubogu/ui/attendance/detail/AttendanceDetailDiaryScreen.kt
@@ -175,6 +175,7 @@ private fun WritingDiaryPage(
             ImagePicker(
                 allowMultiple = true,
                 selectionLimit = uiState.emptyImageCount,
+                enableCrop = false,
                 onPhotosSelected = { uris: List<String> ->
                     isGalleryOpen = false
                     onImagesSelected(uris)

--- a/mobile/composeApp/src/commonMain/kotlin/com/yagubogu/ui/attendance/detail/AttendanceDetailDiaryScreen.kt
+++ b/mobile/composeApp/src/commonMain/kotlin/com/yagubogu/ui/attendance/detail/AttendanceDetailDiaryScreen.kt
@@ -8,9 +8,12 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.ime
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -27,6 +30,8 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -69,8 +74,14 @@ fun AttendanceDetailDiaryScreen(
     onImagePickerError: (message: StringResource) -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    val focusManager = LocalFocusManager.current
     Column(
-        modifier = modifier.fillMaxSize().padding(horizontal = 20.dp).padding(bottom = 20.dp),
+        modifier =
+            modifier
+                .fillMaxSize()
+                .pointerInput(Unit) { detectTapGestures { focusManager.clearFocus() } }
+                .padding(horizontal = 20.dp)
+                .padding(bottom = 20.dp),
     ) {
         AttendanceDetailDiaryTitle(
             showEditButton = uiState.mode == DiaryMode.READ,
@@ -138,11 +149,13 @@ private fun WritingDiaryPage(
 ) {
     var isGalleryOpen by remember { mutableStateOf(false) }
     var comment by remember(uiState.comment) { mutableStateOf(uiState.comment) }
+    val isKeyboardVisible = WindowInsets.ime.getBottom(LocalDensity.current) > 0
 
     Column(
         modifier =
             modifier
                 .fillMaxSize()
+                .imePadding()
                 .background(White, RoundedCornerShape(12.dp))
                 .padding(20.dp),
         verticalArrangement = Arrangement.spacedBy(20.dp),
@@ -160,7 +173,9 @@ private fun WritingDiaryPage(
             },
             modifier = Modifier.fillMaxWidth().weight(1f),
         )
-        DiarySaveButton(onClick = { onSaveClick(comment) })
+        if (!isKeyboardVisible) {
+            DiarySaveButton(onClick = { onSaveClick(comment) })
+        }
     }
 
     if (isGalleryOpen) {

--- a/mobile/composeApp/src/commonMain/kotlin/com/yagubogu/ui/attendance/detail/AttendanceDetailScreen.kt
+++ b/mobile/composeApp/src/commonMain/kotlin/com/yagubogu/ui/attendance/detail/AttendanceDetailScreen.kt
@@ -3,7 +3,9 @@ package com.yagubogu.ui.attendance.detail
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.ime
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.PagerState
 import androidx.compose.foundation.pager.rememberPagerState
@@ -18,6 +20,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.yagubogu.ui.attendance.detail.component.AttendanceDetailTabRow
@@ -127,6 +130,8 @@ private fun AttendanceDetailScreen(
     onImagePickerError: (message: StringResource) -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    val isKeyboardVisible = WindowInsets.ime.getBottom(LocalDensity.current) > 0
+
     Box(modifier = modifier.fillMaxSize()) {
         Column(
             modifier =
@@ -139,7 +144,9 @@ private fun AttendanceDetailScreen(
                 onBackClick = onBackClick,
                 onDeleteClick = onDeleteClick,
             )
-            AttendanceDetailTabRow(pagerState)
+            if (!isKeyboardVisible) {
+                AttendanceDetailTabRow(pagerState)
+            }
             HorizontalPager(
                 state = pagerState,
                 modifier = Modifier.fillMaxSize(),

--- a/mobile/composeApp/src/commonMain/kotlin/com/yagubogu/ui/attendance/detail/AttendanceDetailScreen.kt
+++ b/mobile/composeApp/src/commonMain/kotlin/com/yagubogu/ui/attendance/detail/AttendanceDetailScreen.kt
@@ -149,6 +149,7 @@ private fun AttendanceDetailScreen(
             }
             HorizontalPager(
                 state = pagerState,
+                beyondViewportPageCount = AttendanceDetailTab.entries.size,
                 modifier = Modifier.fillMaxSize(),
             ) { page ->
                 when (page) {

--- a/mobile/composeApp/src/commonMain/kotlin/com/yagubogu/ui/common/component/image/ImagePicker.kt
+++ b/mobile/composeApp/src/commonMain/kotlin/com/yagubogu/ui/common/component/image/ImagePicker.kt
@@ -19,6 +19,7 @@ fun ImagePicker(
     onClosePicker: () -> Unit,
     allowMultiple: Boolean = false,
     selectionLimit: Long = 1,
+    enableCrop: Boolean = true,
 ) {
     val logger: Logger = Logger.withTag("ImagePicker")
     logger.d { "ImagePicker 열림" }
@@ -44,7 +45,7 @@ fun ImagePicker(
             logger.d { "GalleryPicker 닫힘" }
             onClosePicker()
         },
-        enableCrop = true,
+        enableCrop = enableCrop,
         cameraCaptureConfig =
             CameraCaptureConfig(
                 compressionLevel = CompressionLevel.HIGH,


### PR DESCRIPTION
## 📌 관련 이슈
- close #1078 

## ✨ 변경 내용
- 직관 기록에 단일 이미지 업로드 안되는 버그 수정
- 직관 기록 작성 시 키보드를 고려한 화면 위치 수정
  - 키보드가 화면에 보일 시 `TabRow`, `DiarySaveButton` 가림
  - `TextField` 바깥 터치 시 focus 해제

## 🎸 iOS 테스트 영상

https://github.com/user-attachments/assets/b881113c-5e39-4298-b593-4b6b136aef26

