### PR TITLE
fix: 직관 내역 달력 스크롤 및 광고 개선

### DIFF
--- a/mobile/composeApp/src/commonMain/kotlin/com/yagubogu/ui/attendance/AttendanceHistoryScreen.kt
+++ b/mobile/composeApp/src/commonMain/kotlin/com/yagubogu/ui/attendance/AttendanceHistoryScreen.kt
@@ -93,6 +93,7 @@ fun AttendanceHistoryScreen(
     val selectedDate: LocalDate by viewModel.selectedDate.collectAsStateWithLifecycle()
     val filterState: AttendanceFilterState by viewModel.filterState.collectAsStateWithLifecycle()
     val sort: AttendanceHistorySort by viewModel.sort.collectAsStateWithLifecycle()
+    val isGameDatesLoading: Boolean by viewModel.isGameDatesLoading.collectAsStateWithLifecycle()
     val pastGameUiState: PastGameUiState by viewModel.pastGameUiState.collectAsStateWithLifecycle()
 
     val startMonth: YearMonth = AttendanceHistoryViewModel.START_MONTH
@@ -168,6 +169,7 @@ fun AttendanceHistoryScreen(
         onYearlyFilterToggle = viewModel::toggleYearlyFilter,
         sort = sort,
         updateSort = viewModel::updateSort,
+        isGameDatesLoading = isGameDatesLoading,
         pastGameUiState = pastGameUiState,
         onPastGamesRequest = viewModel::fetchPastGames,
         onPastCheckIn = viewModel::addPastCheckIn,
@@ -194,6 +196,7 @@ private fun AttendanceHistoryScreen(
     onYearlyFilterToggle: () -> Unit,
     sort: AttendanceHistorySort,
     updateSort: (AttendanceHistorySort) -> Unit,
+    isGameDatesLoading: Boolean,
     pastGameUiState: PastGameUiState,
     onPastGamesRequest: (LocalDate) -> Unit,
     onPastCheckIn: (Long) -> Unit,
@@ -229,6 +232,7 @@ private fun AttendanceHistoryScreen(
                     onMonthChange = onMonthChange,
                     selectedDate = selectedDate,
                     onDateChange = onDateChange,
+                    isGameDatesLoading = isGameDatesLoading,
                     pastGameUiState = pastGameUiState,
                     onPastGamesRequest = onPastGamesRequest,
                     onPastCheckIn = onPastCheckIn,
@@ -416,6 +420,7 @@ private fun AttendanceCalenderScreenPreview() {
         onYearlyFilterToggle = {},
         sort = AttendanceHistorySort.LATEST,
         updateSort = {},
+        isGameDatesLoading = false,
         pastGameUiState = PastGameUiState.Loading,
         onPastGamesRequest = {},
         onPastCheckIn = {},
@@ -442,6 +447,7 @@ private fun AttendanceListScreenPreview() {
         onYearlyFilterToggle = {},
         sort = AttendanceHistorySort.LATEST,
         updateSort = {},
+        isGameDatesLoading = false,
         pastGameUiState = PastGameUiState.Loading,
         onPastGamesRequest = {},
         onPastCheckIn = {},

--- a/mobile/composeApp/src/commonMain/kotlin/com/yagubogu/ui/attendance/AttendanceHistoryViewModel.kt
+++ b/mobile/composeApp/src/commonMain/kotlin/com/yagubogu/ui/attendance/AttendanceHistoryViewModel.kt
@@ -55,6 +55,9 @@ class AttendanceHistoryViewModel(
     private val _sort = MutableStateFlow(AttendanceHistorySort.LATEST)
     val sort: StateFlow<AttendanceHistorySort> = _sort.asStateFlow()
 
+    private val _isGameDatesLoading = MutableStateFlow(true)
+    val isGameDatesLoading: StateFlow<Boolean> = _isGameDatesLoading.asStateFlow()
+
     private val _pastGameUiState = MutableStateFlow<PastGameUiState>(PastGameUiState.Loading)
     val pastGameUiState: StateFlow<PastGameUiState> = _pastGameUiState.asStateFlow()
 
@@ -105,6 +108,7 @@ class AttendanceHistoryViewModel(
 
     fun fetchGameDates() {
         viewModelScope.launch {
+            _isGameDatesLoading.value = true
             val yearMonth: YearMonth = selectedMonth.value
             gameRepository
                 .getGameDates(yearMonth)
@@ -113,6 +117,7 @@ class AttendanceHistoryViewModel(
                 }.onFailure { exception: Throwable ->
                     logger.w(exception) { "API 호출 실패" }
                 }
+            _isGameDatesLoading.value = false
         }
     }
 

--- a/mobile/composeApp/src/commonMain/kotlin/com/yagubogu/ui/attendance/component/AttendanceCalendar.kt
+++ b/mobile/composeApp/src/commonMain/kotlin/com/yagubogu/ui/attendance/component/AttendanceCalendar.kt
@@ -18,6 +18,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -44,6 +45,7 @@ import com.yagubogu.ui.util.getDisplayNameResId
 import com.yagubogu.ui.util.minusMonths
 import com.yagubogu.ui.util.noRippleClickable
 import com.yagubogu.ui.util.now
+import kotlinx.coroutines.flow.filter
 import kotlinx.datetime.DayOfWeek
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.YearMonth
@@ -77,10 +79,14 @@ fun AttendanceCalendar(
         }
     }
 
-    LaunchedEffect(state.firstVisibleMonth) {
-        if (state.firstVisibleMonth.yearMonth != selectedMonth) {
-            onMonthChange(state.firstVisibleMonth.yearMonth)
-        }
+    LaunchedEffect(state) {
+        snapshotFlow { state.isScrollInProgress }
+            .filter { isScrolling -> !isScrolling }
+            .collect {
+                if (state.firstVisibleMonth.yearMonth != selectedMonth) {
+                    onMonthChange(state.firstVisibleMonth.yearMonth)
+                }
+            }
     }
 
     Column(

--- a/mobile/composeApp/src/commonMain/kotlin/com/yagubogu/ui/attendance/component/AttendanceCalendarContent.kt
+++ b/mobile/composeApp/src/commonMain/kotlin/com/yagubogu/ui/attendance/component/AttendanceCalendarContent.kt
@@ -130,27 +130,20 @@ fun AttendanceCalendarContent(
                         AttendanceItem(item = item, onItemClick = onItemClick)
                     }
                 }
-
-                // 오늘인 경우
-                isToday ->
-                    BannerAd(
-                        adUnitId = AdUnitIds.attendanceCalendarBanner,
-                        bannerAdType = BannerAdType.BANNER,
-                    )
-
                 // 경기가 없는 날인 경우
                 selectedDate !in gameDates -> NoGameDayView()
 
                 // 직관 내역이 없는 경우
                 else -> {
-                    AttendanceAdditionButton(
-                        onClick = {
-                            onPastGamesRequest(selectedDate)
-                            showBottomSheet = true
-                        },
-                        modifier = Modifier.padding(vertical = 10.dp),
-                    )
-
+                    if (!isToday) {
+                        AttendanceAdditionButton(
+                            onClick = {
+                                onPastGamesRequest(selectedDate)
+                                showBottomSheet = true
+                            },
+                            modifier = Modifier.padding(vertical = 10.dp),
+                        )
+                    }
                     BannerAd(
                         adUnitId = AdUnitIds.attendanceCalendarBanner,
                         bannerAdType = BannerAdType.BANNER,

--- a/mobile/composeApp/src/commonMain/kotlin/com/yagubogu/ui/attendance/component/AttendanceCalendarContent.kt
+++ b/mobile/composeApp/src/commonMain/kotlin/com/yagubogu/ui/attendance/component/AttendanceCalendarContent.kt
@@ -191,10 +191,11 @@ private fun AttendanceAdditionButton(
             AnalyticsLogger.logEvent("past_attendance_addition")
         },
         shape = CircleShape,
-        colors = ButtonDefaults.buttonColors(
-            containerColor = Primary500,
-            contentColor = White,
-        ),
+        colors =
+            ButtonDefaults.buttonColors(
+                containerColor = Primary500,
+                contentColor = White,
+            ),
         elevation = ButtonDefaults.buttonElevation(defaultElevation = 4.dp),
         contentPadding = PaddingValues(horizontal = 36.dp, vertical = 12.dp),
         modifier = modifier,

--- a/mobile/composeApp/src/commonMain/kotlin/com/yagubogu/ui/attendance/component/AttendanceCalendarContent.kt
+++ b/mobile/composeApp/src/commonMain/kotlin/com/yagubogu/ui/attendance/component/AttendanceCalendarContent.kt
@@ -18,6 +18,7 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.SmallFloatingActionButton
@@ -38,6 +39,7 @@ import com.yagubogu.ui.attendance.model.PastGameUiState
 import com.yagubogu.ui.common.AdUnitIds
 import com.yagubogu.ui.common.component.BannerAd
 import com.yagubogu.ui.common.component.BannerAdType
+import com.yagubogu.ui.theme.Gray300
 import com.yagubogu.ui.theme.Gray400
 import com.yagubogu.ui.theme.PretendardBold16
 import com.yagubogu.ui.theme.PretendardMedium16
@@ -70,6 +72,7 @@ fun AttendanceCalendarContent(
     onMonthChange: (YearMonth) -> Unit,
     selectedDate: LocalDate,
     onDateChange: (LocalDate) -> Unit,
+    isGameDatesLoading: Boolean,
     pastGameUiState: PastGameUiState,
     onPastGamesRequest: (LocalDate) -> Unit,
     onPastCheckIn: (Long) -> Unit,
@@ -123,12 +126,24 @@ fun AttendanceCalendarContent(
                 gameDates = gameDates,
             )
 
+            BannerAd(
+                adUnitId = AdUnitIds.attendanceCalendarBanner,
+                bannerAdType = BannerAdType.BANNER,
+            )
+
             when {
                 // 직관 내역이 있는 경우
                 currentItems != null -> {
                     currentItems.forEach { item: AttendanceHistoryItem ->
                         AttendanceItem(item = item, onItemClick = onItemClick)
                     }
+                }
+                // 경기 일정 로딩 중인 경우
+                isGameDatesLoading -> {
+                    CircularProgressIndicator(
+                        color = Gray300,
+                        modifier = Modifier.size(24.dp),
+                    )
                 }
                 // 경기가 없는 날인 경우
                 selectedDate !in gameDates -> NoGameDayView()
@@ -144,10 +159,6 @@ fun AttendanceCalendarContent(
                             modifier = Modifier.padding(vertical = 10.dp),
                         )
                     }
-                    BannerAd(
-                        adUnitId = AdUnitIds.attendanceCalendarBanner,
-                        bannerAdType = BannerAdType.BANNER,
-                    )
                 }
             }
         }
@@ -161,10 +172,7 @@ fun AttendanceCalendarContent(
                 containerColor = Primary500,
                 contentColor = White,
                 shape = CircleShape,
-                modifier =
-                    Modifier
-                        .align(Alignment.BottomEnd)
-                        .padding(20.dp),
+                modifier = Modifier.align(Alignment.BottomEnd).padding(20.dp),
             ) {
                 Icon(painter = painterResource(Res.drawable.ic_add), contentDescription = null)
             }
@@ -183,11 +191,10 @@ private fun AttendanceAdditionButton(
             AnalyticsLogger.logEvent("past_attendance_addition")
         },
         shape = CircleShape,
-        colors =
-            ButtonDefaults.buttonColors(
-                containerColor = Primary500,
-                contentColor = White,
-            ),
+        colors = ButtonDefaults.buttonColors(
+            containerColor = Primary500,
+            contentColor = White,
+        ),
         elevation = ButtonDefaults.buttonElevation(defaultElevation = 4.dp),
         contentPadding = PaddingValues(horizontal = 36.dp, vertical = 12.dp),
         modifier = modifier,
@@ -219,10 +226,7 @@ private fun NoGameDayView(modifier: Modifier = Modifier) {
         Image(
             painter = painterResource(Res.drawable.img_baseball_fly_error),
             contentDescription = null,
-            modifier =
-                Modifier
-                    .height(180.dp)
-                    .fillMaxWidth(),
+            modifier = Modifier.height(180.dp).fillMaxWidth(),
         )
     }
 }
@@ -239,6 +243,7 @@ private fun AttendanceCalendarContentPreview() {
         onMonthChange = {},
         selectedDate = LocalDate.now().minusDays(3),
         onDateChange = {},
+        isGameDatesLoading = false,
         pastGameUiState = PastGameUiState.Loading,
         onPastGamesRequest = {},
         onPastCheckIn = {},
@@ -258,6 +263,7 @@ private fun AttendanceCalendarContentHasAttendancePreview() {
         onMonthChange = {},
         selectedDate = LocalDate.now(),
         onDateChange = {},
+        isGameDatesLoading = false,
         pastGameUiState = PastGameUiState.Loading,
         onPastGamesRequest = {},
         onPastCheckIn = {},
@@ -277,6 +283,7 @@ private fun AttendanceCalendarContentNoGamePreview() {
         onMonthChange = {},
         selectedDate = LocalDate.now().minusDays(1),
         onDateChange = {},
+        isGameDatesLoading = false,
         pastGameUiState = PastGameUiState.Loading,
         onPastGamesRequest = {},
         onPastCheckIn = {},


### PR DESCRIPTION
## 📌 관련 이슈
- close #1084 

## ✨ 변경 내용

### 기존 UI
- `BannerAd` 컴포저블이 조건 분기에 따라 새로 그려져요
- 달력 왼쪽(이전 달)으로 스크롤 시 전환 애니메이션이 끊기는 현상이 있어요

[Screen_recording_20260522_235419.webm](https://github.com/user-attachments/assets/7d4a4fb9-f74c-48d6-b46a-ff8feb4b2b1d)

### 변경된 UI
- `BannerAd`를 항시 띄우고 위치를 상단으로 옮겼어요
- 스크롤이 완료된 후에 게임 데이터를 요청하도록 시점을 변경했어요

[Screen_recording_20260522_235308.webm](https://github.com/user-attachments/assets/46e48085-3a04-4663-b473-2768d0e1b630)
