### PR TITLE
feat: 체크인 이미지 private bucket 분리

### DIFF
--- a/.github/workflows/backend-dev.yml
+++ b/.github/workflows/backend-dev.yml
@@ -132,6 +132,9 @@ jobs:
             -e R2_S3_ENDPOINT="${{ secrets.R2_S3_ENDPOINT }}" \
             -e R2_REGION="${{ secrets.R2_REGION }}" \
             -e R2_S3_BUCKET="${{ secrets.R2_S3_BUCKET }}" \
+            -e R2_CHECK_IN_PRIVATE_BUCKET="${{ secrets.R2_CHECK_IN_PRIVATE_BUCKET || 'yagubogu-check-in-image-private' }}" \
+            -e R2_CHECK_IN_ACCESS_KEY_ID="${{ secrets.R2_CHECK_IN_ACCESS_KEY_ID }}" \
+            -e R2_CHECK_IN_SECRET_ACCESS_KEY="${{ secrets.R2_CHECK_IN_SECRET_ACCESS_KEY }}" \
             -e R2_PUBLIC_BASE_URL="${{ secrets.R2_PUBLIC_BASE_URL || 'https://images.yagubogu.com' }}" \
             -e R2_DEFAULT_PROFILE_IMAGE_URL="${{ secrets.R2_DEFAULT_PROFILE_IMAGE_URL || 'https://images.yagubogu.com/images/defaults/profile.png' }}" \
             $IMAGE:$TAG

--- a/.github/workflows/backend-main.yml
+++ b/.github/workflows/backend-main.yml
@@ -183,6 +183,9 @@ jobs:
             -e R2_S3_ENDPOINT="${{ secrets.R2_S3_ENDPOINT }}" \
             -e R2_REGION="${{ secrets.R2_REGION }}" \
             -e R2_S3_BUCKET="${{ secrets.R2_S3_BUCKET }}" \
+            -e R2_CHECK_IN_PRIVATE_BUCKET="${{ secrets.R2_CHECK_IN_PRIVATE_BUCKET || 'yagubogu-check-in-image-private' }}" \
+            -e R2_CHECK_IN_ACCESS_KEY_ID="${{ secrets.R2_CHECK_IN_ACCESS_KEY_ID }}" \
+            -e R2_CHECK_IN_SECRET_ACCESS_KEY="${{ secrets.R2_CHECK_IN_SECRET_ACCESS_KEY }}" \
             -e R2_PUBLIC_BASE_URL="${{ secrets.R2_PUBLIC_BASE_URL || 'https://images.yagubogu.com' }}" \
             -e R2_DEFAULT_PROFILE_IMAGE_URL="${{ secrets.R2_DEFAULT_PROFILE_IMAGE_URL || 'https://images.yagubogu.com/images/defaults/profile.png' }}" \
             -l app=yagubogu-backend \

--- a/.github/workflows/backend-rollback-main.yml
+++ b/.github/workflows/backend-rollback-main.yml
@@ -102,6 +102,9 @@ jobs:
             -e R2_S3_ENDPOINT="${{ secrets.R2_S3_ENDPOINT }}" \
             -e R2_REGION="${{ secrets.R2_REGION }}" \
             -e R2_S3_BUCKET="${{ secrets.R2_S3_BUCKET }}" \
+            -e R2_CHECK_IN_PRIVATE_BUCKET="${{ secrets.R2_CHECK_IN_PRIVATE_BUCKET || 'yagubogu-check-in-image-private' }}" \
+            -e R2_CHECK_IN_ACCESS_KEY_ID="${{ secrets.R2_CHECK_IN_ACCESS_KEY_ID }}" \
+            -e R2_CHECK_IN_SECRET_ACCESS_KEY="${{ secrets.R2_CHECK_IN_SECRET_ACCESS_KEY }}" \
             -e R2_PUBLIC_BASE_URL="${{ secrets.R2_PUBLIC_BASE_URL || 'https://images.yagubogu.com' }}" \
             -e R2_DEFAULT_PROFILE_IMAGE_URL="${{ secrets.R2_DEFAULT_PROFILE_IMAGE_URL || 'https://images.yagubogu.com/images/defaults/profile.png' }}" \
             -l app=yagubogu-backend \

--- a/backend/app/src/main/java/com/yagubogu/checkin/domain/CheckInImage.java
+++ b/backend/app/src/main/java/com/yagubogu/checkin/domain/CheckInImage.java
@@ -29,11 +29,28 @@ public class CheckInImage extends BaseEntity {
     @JoinColumn(name = "check_in_id", nullable = false)
     private CheckIn checkIn;
 
-    @Column(name = "image_url", nullable = false, length = 500)
+    @Column(name = "image_url", length = 500)
     private String imageUrl;
+
+    @Column(name = "image_key", length = 500)
+    private String imageKey;
 
     public CheckInImage(final CheckIn checkIn, final String imageUrl) {
         this.checkIn = checkIn;
         this.imageUrl = imageUrl;
+    }
+
+    private CheckInImage(final CheckIn checkIn, final String imageUrl, final String imageKey) {
+        this.checkIn = checkIn;
+        this.imageUrl = imageUrl;
+        this.imageKey = imageKey;
+    }
+
+    public static CheckInImage privateImage(final CheckIn checkIn, final String imageKey) {
+        return new CheckInImage(checkIn, null, imageKey);
+    }
+
+    public boolean hasImageKey() {
+        return imageKey != null && !imageKey.isBlank();
     }
 }

--- a/backend/app/src/main/java/com/yagubogu/checkin/service/CheckInImageService.java
+++ b/backend/app/src/main/java/com/yagubogu/checkin/service/CheckInImageService.java
@@ -5,7 +5,7 @@ import com.yagubogu.global.exception.PayloadTooLargeException;
 import com.yagubogu.global.exception.UnsupportedMediaTypeException;
 import com.yagubogu.member.dto.v1.PreSignedUrlStartRequest;
 import com.yagubogu.member.dto.v1.PresignedUrlStartResponse;
-import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
@@ -15,7 +15,6 @@ import java.util.Set;
 import java.util.UUID;
 
 @Service
-@RequiredArgsConstructor
 public class CheckInImageService {
 
     private static final long MAX_FILE_SIZE = 5 * 1024 * 1024;
@@ -23,6 +22,14 @@ public class CheckInImageService {
     private static final Set<String> ALLOWED_CONTENT_TYPES = Set.of("image/jpeg", "image/jpg", "image/png");
     private final S3Properties s3Properties;
     private final S3Presigner s3Presigner;
+
+    public CheckInImageService(
+            final S3Properties s3Properties,
+            @Qualifier("checkInPresigner") final S3Presigner s3Presigner
+    ) {
+        this.s3Properties = s3Properties;
+        this.s3Presigner = s3Presigner;
+    }
 
     public PresignedUrlStartResponse issuePresignedUrl(PreSignedUrlStartRequest request) {
         if (request.contentLength() > MAX_FILE_SIZE) {
@@ -35,7 +42,7 @@ public class CheckInImageService {
         String key = PATH_PREFIX + UUID.randomUUID();
 
         PutObjectRequest putObjectRequest = PutObjectRequest.builder()
-                .bucket(s3Properties.bucket())
+                .bucket(s3Properties.checkInPrivateBucket())
                 .key(key)
                 .contentType(request.contentType())
                 .contentLength(request.contentLength())

--- a/backend/app/src/main/java/com/yagubogu/checkin/service/CheckInService.java
+++ b/backend/app/src/main/java/com/yagubogu/checkin/service/CheckInService.java
@@ -27,19 +27,21 @@ import com.yagubogu.sse.dto.GameWithFanRateParam;
 import com.yagubogu.sse.dto.event.CheckInCreatedEvent;
 import com.yagubogu.stat.repository.LocationCheckInRankingRepository;
 import com.yagubogu.team.domain.Team;
-import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
 import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 
-@RequiredArgsConstructor
 @Transactional(readOnly = true)
 @Service
 public class CheckInService {
@@ -55,7 +57,34 @@ public class CheckInService {
     private final LocationCheckInRankingRepository locationCheckInRankingRepository;
     private final ApplicationEventPublisher applicationEventPublisher;
     private final S3Client s3Client;
+    private final S3Presigner s3Presigner;
     private final S3Properties s3Properties;
+
+    public CheckInService(
+            final CheckInRepository checkInRepository,
+            final CheckInImageRepository checkInImageRepository,
+            final MemberRepository memberRepository,
+            final GameRepository gameRepository,
+            final GameHitterRecordRepository hitterRecordRepository,
+            final GamePitcherRecordRepository pitcherRecordRepository,
+            final LocationCheckInRankingRepository locationCheckInRankingRepository,
+            final ApplicationEventPublisher applicationEventPublisher,
+            @Qualifier("checkInS3") final S3Client s3Client,
+            @Qualifier("checkInPresigner") final S3Presigner s3Presigner,
+            final S3Properties s3Properties
+    ) {
+        this.checkInRepository = checkInRepository;
+        this.checkInImageRepository = checkInImageRepository;
+        this.memberRepository = memberRepository;
+        this.gameRepository = gameRepository;
+        this.hitterRecordRepository = hitterRecordRepository;
+        this.pitcherRecordRepository = pitcherRecordRepository;
+        this.locationCheckInRankingRepository = locationCheckInRankingRepository;
+        this.applicationEventPublisher = applicationEventPublisher;
+        this.s3Client = s3Client;
+        this.s3Presigner = s3Presigner;
+        this.s3Properties = s3Properties;
+    }
 
     @Transactional
     public void createCheckIn(final Long memberId, final CreateCheckInRequest request) {
@@ -117,9 +146,9 @@ public class CheckInService {
     public CheckInImageParam addImage(final Long memberId, final Long checkInId, final String imageKey) {
         Member member = getMember(memberId);
         CheckIn checkIn = getCheckInByIdAndMember(checkInId, member);
-        String imageUrl = resolveImageUrl(imageKey);
-        CheckInImage image = checkInImageRepository.save(new CheckInImage(checkIn, imageUrl));
-        return new CheckInImageParam(image.getId(), image.getImageUrl());
+        assertObjectExists(imageKey);
+        CheckInImage image = checkInImageRepository.save(CheckInImage.privateImage(checkIn, imageKey));
+        return new CheckInImageParam(image.getId(), resolveImageUrl(image));
     }
 
     @Transactional
@@ -136,7 +165,7 @@ public class CheckInService {
         Member member = getMember(memberId);
         getCheckInByIdAndMember(checkInId, member);
         List<CheckInImageParam> images = checkInImageRepository.findByCheckInId(checkInId).stream()
-                .map(img -> new CheckInImageParam(img.getId(), img.getImageUrl()))
+                .map(img -> new CheckInImageParam(img.getId(), resolveImageUrl(img)))
                 .toList();
         return new CheckInImagesResponse(images);
     }
@@ -292,14 +321,31 @@ public class CheckInService {
         return Math.round(((double) checkInCounts / total) * 1000) / ROUND_FACTOR;
     }
 
-    private String resolveImageUrl(final String imageKey) {
-        assertObjectExists(imageKey);
-        return s3Properties.objectUrl(imageKey);
+    private String resolveImageUrl(final CheckInImage image) {
+        if (image.hasImageKey()) {
+            return createSignedImageUrl(image.getImageKey());
+        }
+        return image.getImageUrl();
+    }
+
+    private String createSignedImageUrl(final String imageKey) {
+        GetObjectRequest getObjectRequest = GetObjectRequest.builder()
+                .bucket(s3Properties.checkInPrivateBucket())
+                .key(imageKey)
+                .build();
+
+        return s3Presigner.presignGetObject(b -> b
+                .signatureDuration(s3Properties.presignExpiration())
+                .getObjectRequest(getObjectRequest)).url().toString();
     }
 
     private void assertObjectExists(final String key) {
         try {
-            s3Client.headObject(r -> r.bucket(s3Properties.bucket()).key(key));
+            HeadObjectRequest headObjectRequest = HeadObjectRequest.builder()
+                    .bucket(s3Properties.checkInPrivateBucket())
+                    .key(key)
+                    .build();
+            s3Client.headObject(headObjectRequest);
         } catch (NoSuchKeyException e) {
             throw new NotFoundException("File does not exist in S3: " + key);
         }

--- a/backend/app/src/main/java/com/yagubogu/global/config/S3Config.java
+++ b/backend/app/src/main/java/com/yagubogu/global/config/S3Config.java
@@ -2,11 +2,16 @@ package com.yagubogu.global.config;
 
 import java.net.URI;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3ClientBuilder;
 import software.amazon.awssdk.services.s3.S3Configuration;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 
@@ -18,24 +23,56 @@ public class S3Config {
     private final S3Properties s3Properties;
 
     @Bean
+    @Primary
     S3Client s3() {
+        return defaultS3ClientBuilder().build();
+    }
+
+    @Bean
+    @Qualifier("checkInS3")
+    S3Client checkInS3() {
+        return defaultS3ClientBuilder()
+                .credentialsProvider(checkInCredentialsProvider())
+                .build();
+    }
+
+    @Bean
+    @Primary
+    S3Presigner presigner() {
+        return defaultS3PresignerBuilder().build();
+    }
+
+    @Bean
+    @Qualifier("checkInPresigner")
+    S3Presigner checkInPresigner() {
+        return defaultS3PresignerBuilder()
+                .credentialsProvider(checkInCredentialsProvider())
+                .build();
+    }
+
+    private S3ClientBuilder defaultS3ClientBuilder() {
         return S3Client.builder()
                 .endpointOverride(URI.create(s3Properties.apiEndpoint()))
                 .region(Region.of(s3Properties.region()))
                 .serviceConfiguration(S3Configuration.builder()
                         .pathStyleAccessEnabled(true)
-                        .build())
-                .build();
+                        .build());
     }
 
-    @Bean
-    S3Presigner presigner() {
+    private S3Presigner.Builder defaultS3PresignerBuilder() {
         return S3Presigner.builder()
                 .endpointOverride(URI.create(s3Properties.apiEndpoint()))
                 .region(Region.of(s3Properties.region()))
                 .serviceConfiguration(S3Configuration.builder()
                         .pathStyleAccessEnabled(true)
-                        .build())
-                .build();
+                        .build());
+    }
+
+    private StaticCredentialsProvider checkInCredentialsProvider() {
+        AwsBasicCredentials credentials = AwsBasicCredentials.create(
+                s3Properties.checkInAccessKeyId(),
+                s3Properties.checkInSecretAccessKey()
+        );
+        return StaticCredentialsProvider.create(credentials);
     }
 }

--- a/backend/app/src/main/java/com/yagubogu/global/config/S3Properties.java
+++ b/backend/app/src/main/java/com/yagubogu/global/config/S3Properties.java
@@ -10,11 +10,14 @@ public record S3Properties(
         String endpoint,
         String region,
         String publicBaseUrl,
-        String defaultProfileImageUrl
+        String defaultProfileImageUrl,
+        String checkInPrivateBucket,
+        String checkInAccessKeyId,
+        String checkInSecretAccessKey
 ) {
 
     public String apiEndpoint() {
-        return removeTrailingBucketPath(endpoint);
+        return removeTrailingKnownBucketPath(endpoint);
     }
 
     public String objectUrl(final String key) {
@@ -26,35 +29,39 @@ public record S3Properties(
             return removeDuplicateTrailingBucketPath(publicBaseUrl);
         }
         String trimmedEndpoint = trimTrailingSlash(endpoint);
-        if (hasTrailingBucketPath(trimmedEndpoint)) {
+        if (hasTrailingBucketPath(trimmedEndpoint, bucket)) {
             return trimmedEndpoint;
         }
         return trimmedEndpoint + "/" + trimSlashes(bucket);
     }
 
-    private String removeTrailingBucketPath(final String value) {
+    private String removeTrailingKnownBucketPath(final String value) {
         String trimmedValue = trimTrailingSlash(value);
-        if (!hasTrailingBucketPath(trimmedValue)) {
-            return trimmedValue;
+        if (hasTrailingBucketPath(trimmedValue, bucket)) {
+            return trimmedValue.substring(0, trimmedValue.length() - bucketPath(bucket).length());
         }
-        return trimmedValue.substring(0, trimmedValue.length() - bucketPath().length());
+        if (hasTrailingBucketPath(trimmedValue, checkInPrivateBucket)) {
+            return trimmedValue.substring(0, trimmedValue.length() - bucketPath(checkInPrivateBucket).length());
+        }
+        return trimmedValue;
     }
 
     private String removeDuplicateTrailingBucketPath(final String value) {
         String trimmedValue = trimTrailingSlash(value);
-        String duplicateBucketPath = bucketPath() + bucketPath();
+        String bucketPath = bucketPath(bucket);
+        String duplicateBucketPath = bucketPath + bucketPath;
         if (!trimmedValue.endsWith(duplicateBucketPath)) {
             return trimmedValue;
         }
-        return trimmedValue.substring(0, trimmedValue.length() - bucketPath().length());
+        return trimmedValue.substring(0, trimmedValue.length() - bucketPath.length());
     }
 
-    private boolean hasTrailingBucketPath(final String value) {
-        return value != null && value.endsWith(bucketPath());
+    private boolean hasTrailingBucketPath(final String value, final String bucketName) {
+        return value != null && bucketName != null && !bucketName.isBlank() && value.endsWith(bucketPath(bucketName));
     }
 
-    private String bucketPath() {
-        return "/" + trimSlashes(bucket);
+    private String bucketPath(final String bucketName) {
+        return "/" + trimSlashes(bucketName);
     }
 
     private static String trimTrailingSlash(final String value) {

--- a/backend/app/src/main/resources/application.yml
+++ b/backend/app/src/main/resources/application.yml
@@ -86,11 +86,14 @@ sse:
 app:
   s3:
     bucket: ${R2_S3_BUCKET}
+    check-in-private-bucket: ${R2_CHECK_IN_PRIVATE_BUCKET:yagubogu-check-in-image-private}
     presign-expiration: 5m
     endpoint: ${R2_S3_ENDPOINT}
     region: ${R2_REGION:auto}
     public-base-url: ${R2_PUBLIC_BASE_URL:https://images.yagubogu.com}
     default-profile-image-url: ${R2_DEFAULT_PROFILE_IMAGE_URL:${app.s3.public-base-url}/images/defaults/profile.png}
+    check-in-access-key-id: ${R2_CHECK_IN_ACCESS_KEY_ID}
+    check-in-secret-access-key: ${R2_CHECK_IN_SECRET_ACCESS_KEY}
 
 ---
 spring:

--- a/backend/app/src/main/resources/db/migration/mysql/V17__add_image_key_to_check_in_images.sql
+++ b/backend/app/src/main/resources/db/migration/mysql/V17__add_image_key_to_check_in_images.sql
@@ -1,0 +1,5 @@
+ALTER TABLE check_in_images
+    ADD COLUMN image_key VARCHAR(500) NULL AFTER image_url;
+
+ALTER TABLE check_in_images
+    MODIFY COLUMN image_url VARCHAR(500) NULL;

--- a/backend/app/src/test/java/com/yagubogu/checkin/service/CheckInImageServiceTest.java
+++ b/backend/app/src/test/java/com/yagubogu/checkin/service/CheckInImageServiceTest.java
@@ -3,6 +3,7 @@ package com.yagubogu.checkin.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.yagubogu.global.config.S3Properties;
@@ -18,15 +19,19 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
 
 @ExtendWith(MockitoExtension.class)
 class CheckInImageServiceTest {
 
     private static final String TEST_BUCKET = "test-bucket";
+    private static final String TEST_CHECK_IN_PRIVATE_BUCKET = "test-check-in-private-bucket";
     private static final String TEST_ENDPOINT = "https://test-endpoint.com";
 
     @Mock
@@ -44,7 +49,10 @@ class CheckInImageServiceTest {
                 TEST_ENDPOINT,
                 "ap-chuncheon-1",
                 TEST_ENDPOINT + "/" + TEST_BUCKET,
-                "http://default.img"
+                "http://default.img",
+                TEST_CHECK_IN_PRIVATE_BUCKET,
+                "test-check-in-access-key",
+                "test-check-in-secret-key"
         );
         checkInImageService = new CheckInImageService(s3Properties, s3Presigner);
     }
@@ -62,8 +70,16 @@ class CheckInImageServiceTest {
         PresignedUrlStartResponse response = checkInImageService.issuePresignedUrl(request);
 
         // then
+        ArgumentCaptor<Consumer<PutObjectPresignRequest.Builder>> captor = ArgumentCaptor.forClass(Consumer.class);
+        verify(s3Presigner).presignPutObject(captor.capture());
+
+        PutObjectPresignRequest.Builder builder = PutObjectPresignRequest.builder();
+        captor.getValue().accept(builder);
+        PutObjectRequest capturedRequest = builder.build().putObjectRequest();
+
         assertThat(response.key()).startsWith("images/check-ins/");
         assertThat(response.url()).isEqualTo(fakeUrl);
+        assertThat(capturedRequest.bucket()).isEqualTo(TEST_CHECK_IN_PRIVATE_BUCKET);
     }
 
     @DisplayName("예외: contentLength가 최대 길이를 초과하면 예외를 던진다")

--- a/backend/app/src/test/java/com/yagubogu/checkin/service/CheckInServiceTest.java
+++ b/backend/app/src/test/java/com/yagubogu/checkin/service/CheckInServiceTest.java
@@ -51,6 +51,8 @@ import com.yagubogu.support.member.MemberBuilder;
 import com.yagubogu.support.member.MemberFactory;
 import com.yagubogu.team.domain.Team;
 import com.yagubogu.team.repository.TeamRepository;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.ArrayList;
@@ -64,6 +66,10 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.Import;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
+import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedGetObjectRequest;
 
 @Import({AuthTestConfig.class, JpaAuditingConfig.class})
 @DataJpaTest
@@ -71,6 +77,7 @@ class CheckInServiceTest {
 
     private CheckInService checkInService;
     private S3Client mockS3Client;
+    private S3Presigner mockS3Presigner;
     private S3Properties mockS3Properties;
 
     @Autowired
@@ -115,11 +122,20 @@ class CheckInServiceTest {
     private Stadium stadiumJamsil, stadiumGocheok, stadiumIncheon;
 
     @BeforeEach
-    void setUp() {
+    void setUp() throws MalformedURLException {
         mockS3Client = Mockito.mock(S3Client.class);
+        mockS3Presigner = Mockito.mock(S3Presigner.class);
+        PresignedGetObjectRequest mockPresignedGetObjectRequest = Mockito.mock(PresignedGetObjectRequest.class);
         mockS3Properties = Mockito.mock(S3Properties.class);
+        Mockito.when(mockS3Client.headObject(Mockito.any(HeadObjectRequest.class)))
+                .thenReturn(HeadObjectResponse.builder().build());
+        Mockito.when(mockS3Presigner.presignGetObject(Mockito.any(java.util.function.Consumer.class)))
+                .thenReturn(mockPresignedGetObjectRequest);
+        Mockito.when(mockPresignedGetObjectRequest.url())
+                .thenReturn(new URL("http://private.signed.test/images/check-ins/test-key"));
         Mockito.when(mockS3Properties.endpoint()).thenReturn("http://s3.test");
         Mockito.when(mockS3Properties.bucket()).thenReturn("test-bucket");
+        Mockito.when(mockS3Properties.checkInPrivateBucket()).thenReturn("test-check-in-private-bucket");
         Mockito.when(mockS3Properties.objectUrl(Mockito.anyString()))
                 .thenAnswer(invocation -> "http://s3.test/test-bucket/" + invocation.getArgument(0));
 
@@ -134,6 +150,7 @@ class CheckInServiceTest {
                 locationCheckInRankingRepository,
                 applicationEventPublisher,
                 mockS3Client,
+                mockS3Presigner,
                 mockS3Properties
         );
 
@@ -1261,7 +1278,7 @@ class CheckInServiceTest {
         assertThat(response.images()).isEmpty();
     }
 
-    @DisplayName("이미지 목록을 조회한다 - 이미지 있는 경우")
+    @DisplayName("이미지 목록을 조회한다 - 기존 public 이미지인 경우 저장된 URL을 반환한다")
     @Test
     void getImages_returnsImages() {
         // given
@@ -1281,6 +1298,24 @@ class CheckInServiceTest {
                         "http://s3.test/test-bucket/img1",
                         "http://s3.test/test-bucket/img2"
                 );
+    }
+
+    @DisplayName("이미지 목록을 조회한다 - private 이미지인 경우 signed URL을 반환한다")
+    @Test
+    void getImages_returnsSignedUrl_whenImageKeyExists() {
+        // given
+        Member member = memberFactory.save(b -> b.team(kia));
+        Game game = gameFactory.save(b -> b.stadium(stadiumJamsil).homeTeam(kia).awayTeam(kt).date(LocalDate.now()));
+        CheckIn checkIn = checkInFactory.save(b -> b.member(member).team(kia).game(game));
+        checkInImageRepository.save(CheckInImage.privateImage(checkIn, "images/check-ins/img1"));
+
+        // when
+        CheckInImagesResponse response = checkInService.getImages(member.getId(), checkIn.getId());
+
+        // then
+        assertThat(response.images()).hasSize(1);
+        assertThat(response.images().get(0).imageUrl())
+                .isEqualTo("http://private.signed.test/images/check-ins/test-key");
     }
 
     @DisplayName("예외: 다른 회원의 직관 기록 이미지는 조회할 수 없다")
@@ -1310,8 +1345,16 @@ class CheckInServiceTest {
 
         // then
         assertThat(result.imageId()).isNotNull();
-        assertThat(result.imageUrl()).isEqualTo("http://s3.test/test-bucket/images/check-ins/test-key");
+        assertThat(result.imageUrl()).isEqualTo("http://private.signed.test/images/check-ins/test-key");
         assertThat(checkInService.getImages(member.getId(), checkIn.getId()).images()).hasSize(1);
+
+        CheckInImage savedImage = checkInImageRepository.findByCheckInId(checkIn.getId()).get(0);
+        assertThat(savedImage.getImageKey()).isEqualTo("images/check-ins/test-key");
+        assertThat(savedImage.getImageUrl()).isNull();
+        Mockito.verify(mockS3Client).headObject(Mockito.argThat((HeadObjectRequest request) ->
+                request.bucket().equals("test-check-in-private-bucket")
+                        && request.key().equals("images/check-ins/test-key")
+        ));
     }
 
     @DisplayName("이미지를 여러 장 추가한다")

--- a/backend/app/src/test/java/com/yagubogu/global/config/S3PropertiesTest.java
+++ b/backend/app/src/test/java/com/yagubogu/global/config/S3PropertiesTest.java
@@ -17,7 +17,10 @@ class S3PropertiesTest {
                 "https://test-account.r2.cloudflarestorage.com",
                 "auto",
                 "https://images.yagubogu.com/",
-                "https://images.yagubogu.com/images/defaults/profile.png"
+                "https://images.yagubogu.com/images/defaults/profile.png",
+                "yagubogu-check-in-image-private",
+                "test-check-in-access-key",
+                "test-check-in-secret-key"
         );
 
         String objectUrl = properties.objectUrl("/profile/abc-123");
@@ -35,7 +38,10 @@ class S3PropertiesTest {
                 "https://test-account.r2.cloudflarestorage.com/",
                 "auto",
                 null,
-                "https://test-account.r2.cloudflarestorage.com/yagubogu/images/defaults/profile.png"
+                "https://test-account.r2.cloudflarestorage.com/yagubogu/images/defaults/profile.png",
+                "yagubogu-check-in-image-private",
+                "test-check-in-access-key",
+                "test-check-in-secret-key"
         );
 
         String objectUrl = properties.objectUrl("profile/abc-123");
@@ -53,7 +59,10 @@ class S3PropertiesTest {
                 "https://test-account.r2.cloudflarestorage.com/yagubogu",
                 "auto",
                 null,
-                "https://test-account.r2.cloudflarestorage.com/yagubogu/images/defaults/profile.png"
+                "https://test-account.r2.cloudflarestorage.com/yagubogu/images/defaults/profile.png",
+                "yagubogu-check-in-image-private",
+                "test-check-in-access-key",
+                "test-check-in-secret-key"
         );
 
         assertThat(properties.apiEndpoint())
@@ -69,12 +78,34 @@ class S3PropertiesTest {
                 "https://test-account.r2.cloudflarestorage.com/yagubogu",
                 "auto",
                 "https://test-account.r2.cloudflarestorage.com/yagubogu/yagubogu",
-                "https://test-account.r2.cloudflarestorage.com/yagubogu/images/defaults/profile.png"
+                "https://test-account.r2.cloudflarestorage.com/yagubogu/images/defaults/profile.png",
+                "yagubogu-check-in-image-private",
+                "test-check-in-access-key",
+                "test-check-in-secret-key"
         );
 
         String objectUrl = properties.objectUrl("profile/abc-123");
 
         assertThat(objectUrl)
                 .isEqualTo("https://test-account.r2.cloudflarestorage.com/yagubogu/profile/abc-123");
+    }
+
+    @DisplayName("endpoint에 check-in private bucket 경로가 있어도 API endpoint에서는 bucket 경로를 제거한다")
+    @Test
+    void apiEndpoint_removesCheckInPrivateBucketPath() {
+        S3Properties properties = new S3Properties(
+                "yagubogu",
+                Duration.ofMinutes(5),
+                "https://test-account.r2.cloudflarestorage.com/yagubogu-check-in-image-private",
+                "auto",
+                null,
+                "https://test-account.r2.cloudflarestorage.com/yagubogu/images/defaults/profile.png",
+                "yagubogu-check-in-image-private",
+                "test-check-in-access-key",
+                "test-check-in-secret-key"
+        );
+
+        assertThat(properties.apiEndpoint())
+                .isEqualTo("https://test-account.r2.cloudflarestorage.com");
     }
 }

--- a/backend/app/src/test/java/com/yagubogu/member/service/ProfileImageServiceTest.java
+++ b/backend/app/src/test/java/com/yagubogu/member/service/ProfileImageServiceTest.java
@@ -55,6 +55,7 @@ class ProfileImageServiceTest {
     private static final String TEST_REGION = "auto";
     private static final String TEST_PUBLIC_BASE_URL = "https://images.yagubogu.com";
     private static final String TEST_DEFAULT_PROFILE_IMAGE_URL = TEST_PUBLIC_BASE_URL + "/images/defaults/profile.png";
+    private static final String TEST_CHECK_IN_PRIVATE_BUCKET = "test-check-in-private-bucket";
 
     @Mock
     private MemberService memberService;
@@ -73,8 +74,17 @@ class ProfileImageServiceTest {
 
     @BeforeEach
     void setUp() {
-        s3Properties = new S3Properties(TEST_BUCKET, TEST_PRESIGN_EXPIRATION, TEST_ENDPOINT, TEST_REGION,
-                TEST_PUBLIC_BASE_URL, TEST_DEFAULT_PROFILE_IMAGE_URL);
+        s3Properties = new S3Properties(
+                TEST_BUCKET,
+                TEST_PRESIGN_EXPIRATION,
+                TEST_ENDPOINT,
+                TEST_REGION,
+                TEST_PUBLIC_BASE_URL,
+                TEST_DEFAULT_PROFILE_IMAGE_URL,
+                TEST_CHECK_IN_PRIVATE_BUCKET,
+                "test-check-in-access-key",
+                "test-check-in-secret-key"
+        );
         profileImageService = new ProfileImageService(s3Presigner, s3Client, s3Properties, memberService);
     }
 

--- a/backend/app/src/test/resources/application.yml
+++ b/backend/app/src/test/resources/application.yml
@@ -67,11 +67,14 @@ sse:
 app:
   s3:
     bucket: yagubogu
+    check-in-private-bucket: yagubogu-check-in-image-private
     presign-expiration: 10m
     endpoint: https://test-account.r2.cloudflarestorage.com
     region: auto
     public-base-url: https://images.yagubogu.com
     default-profile-image-url: https://images.yagubogu.com/images/defaults/profile.png
+    check-in-access-key-id: test-check-in-access-key
+    check-in-secret-access-key: test-check-in-secret-key
   clock:
     fixed-date: 2024-08-15
 


### PR DESCRIPTION
## 작업 내용
- 신규 check-in 이미지 업로드 presigned URL을 private bucket 기준으로 발급하도록 변경했습니다.
- `check_in_images.image_key` 컬럼을 추가하고, 신규 check-in 이미지는 URL 대신 object key를 저장하도록 변경했습니다.
- 이미지 조회 시 `image_key`가 있으면 private bucket signed GET URL을 반환하고, `image_key`가 없으면 기존 public `image_url`을 반환해 하위호환을 유지했습니다.
- check-in 이미지용 S3 client/presigner를 별도 credential로 분리했습니다.
- backend dev/main/rollback workflow에 check-in private bucket 환경변수를 추가했습니다.

## 검증
- `./gradlew :app:test --rerun-tasks --tests com.yagubogu.checkin.service.CheckInImageServiceTest --tests com.yagubogu.checkin.service.CheckInServiceTest --tests com.yagubogu.global.config.S3PropertiesTest --tests com.yagubogu.member.service.ProfileImageServiceTest`
- `./gradlew :app:test --tests com.yagubogu.checkin.CheckInE2eTest.getImages_returnsEmptyList`

## API Spec
### POST `/api/v1/check-ins/image/presigned-url`
- 변경: 요청/응답 body shape는 기존과 동일합니다.
- 변경: 발급되는 presigned PUT URL의 대상 bucket이 check-in private bucket으로 변경됩니다.
- Request body: `contentType`, `contentLength`
- Response body: `key`, `url`
- Validation: 최대 5MB, `image/jpeg`, `image/jpg`, `image/png`만 허용
- Compatibility: 기존 client 수정 없이 동일 endpoint를 사용할 수 있습니다.

### POST `/api/v1/check-ins/{checkInId}/images`
- 변경: 요청/응답 body shape는 기존과 동일합니다.
- 변경: 신규 이미지는 DB에 public URL 대신 `image_key`로 저장합니다.
- Request body: `imageKey`
- Response body: `imageId`, `imageUrl`
- Compatibility: `imageUrl` 필드는 유지되지만 신규 private 이미지는 signed GET URL입니다.

### GET `/api/v1/check-ins/{checkInId}/images`
- 변경: 응답 body shape는 기존과 동일합니다.
- Response body: `{ images: [{ imageId, imageUrl }] }`
- Compatibility: `image_key`가 없는 기존 데이터는 legacy public `image_url`을 그대로 반환합니다. `image_key`가 있는 신규 데이터는 private bucket signed GET URL을 반환합니다.

## 운영 설정
GitHub Secrets에 다음 값을 추가해야 합니다.
- `R2_CHECK_IN_PRIVATE_BUCKET`
- `R2_CHECK_IN_ACCESS_KEY_ID`
- `R2_CHECK_IN_SECRET_ACCESS_KEY`

Resolves #1093