### PR TITLE
feat: 직관 티켓 조회 API 추가

### DIFF
--- a/backend/app/src/main/java/com/yagubogu/checkin/repository/CustomCheckInRepository.java
+++ b/backend/app/src/main/java/com/yagubogu/checkin/repository/CustomCheckInRepository.java
@@ -23,6 +23,8 @@ public interface CustomCheckInRepository {
 
     StatCountsParam findStatCountsByMemberAndTeam(Member member, Team team, Integer year);
 
+    int countByMemberAndYearUntilCheckIn(Member member, int year, LocalDate gameDate, Long checkInId);
+
     int findWinCounts(Member member, Integer year);
 
     int findLoseCounts(Member member, Integer year);

--- a/backend/app/src/main/java/com/yagubogu/checkin/repository/CustomCheckInRepository.java
+++ b/backend/app/src/main/java/com/yagubogu/checkin/repository/CustomCheckInRepository.java
@@ -21,6 +21,8 @@ public interface CustomCheckInRepository {
 
     StatCountsParam findStatCounts(Member member, Integer year);
 
+    StatCountsParam findStatCountsByMemberAndTeam(Member member, Team team, Integer year);
+
     int findWinCounts(Member member, Integer year);
 
     int findLoseCounts(Member member, Integer year);

--- a/backend/app/src/main/java/com/yagubogu/checkin/repository/CustomCheckInRepositoryImpl.java
+++ b/backend/app/src/main/java/com/yagubogu/checkin/repository/CustomCheckInRepositoryImpl.java
@@ -107,6 +107,28 @@ public class CustomCheckInRepositoryImpl implements CustomCheckInRepository {
     }
 
     @Override
+    public int countByMemberAndYearUntilCheckIn(
+            final Member member,
+            final int year,
+            final LocalDate gameDate,
+            final Long checkInId
+    ) {
+        Long result = jpaQueryFactory
+                .select(CHECK_IN.id.count())
+                .from(CHECK_IN)
+                .join(CHECK_IN.game, GAME)
+                .where(
+                        CHECK_IN.member.eq(member),
+                        isBetweenYear(GAME, year),
+                        GAME.date.lt(gameDate)
+                                .or(GAME.date.eq(gameDate).and(CHECK_IN.id.loe(checkInId)))
+                )
+                .fetchOne();
+
+        return result == null ? 0 : result.intValue();
+    }
+
+    @Override
     public int findWinCounts(final Member member, final Integer year) {
         return conditionCount(member, year, winCondition(QCheckIn.checkIn, QGame.game));
     }

--- a/backend/app/src/main/java/com/yagubogu/checkin/repository/CustomCheckInRepositoryImpl.java
+++ b/backend/app/src/main/java/com/yagubogu/checkin/repository/CustomCheckInRepositoryImpl.java
@@ -82,6 +82,31 @@ public class CustomCheckInRepositoryImpl implements CustomCheckInRepository {
     }
 
     @Override
+    public StatCountsParam findStatCountsByMemberAndTeam(
+            final Member member,
+            final Team team,
+            final Integer year
+    ) {
+        NumberExpression<Integer> winExpr = new CaseBuilder().when(winCondition(CHECK_IN, GAME)).then(1).otherwise(0);
+        NumberExpression<Integer> drawExpr = new CaseBuilder().when(drawCondition(CHECK_IN, GAME)).then(1).otherwise(0);
+        NumberExpression<Integer> loseExpr = new CaseBuilder().when(loseCondition(CHECK_IN, GAME)).then(1).otherwise(0);
+
+        return jpaQueryFactory.select(
+                        Projections.constructor(
+                                StatCountsParam.class,
+                                winExpr.sum().coalesce(0),
+                                drawExpr.sum().coalesce(0),
+                                loseExpr.sum().coalesce(0)
+                        )).from(CHECK_IN)
+                .join(CHECK_IN.game, CustomCheckInRepositoryImpl.GAME).on(isComplete())
+                .where(
+                        CHECK_IN.member.eq(member),
+                        CHECK_IN.team.eq(team),
+                        isBetweenYear(year)
+                ).fetchOne();
+    }
+
+    @Override
     public int findWinCounts(final Member member, final Integer year) {
         return conditionCount(member, year, winCondition(QCheckIn.checkIn, QGame.game));
     }

--- a/backend/app/src/main/java/com/yagubogu/ticket/controller/v1/TicketController.java
+++ b/backend/app/src/main/java/com/yagubogu/ticket/controller/v1/TicketController.java
@@ -1,0 +1,27 @@
+package com.yagubogu.ticket.controller.v1;
+
+import com.yagubogu.auth.annotation.RequireRole;
+import com.yagubogu.auth.dto.MemberClaims;
+import com.yagubogu.ticket.dto.v1.TicketResponse;
+import com.yagubogu.ticket.service.TicketService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RequireRole
+@RestController
+public class TicketController implements TicketControllerInterface {
+
+    private final TicketService ticketService;
+
+    @Override
+    public ResponseEntity<TicketResponse> findTicket(
+            final MemberClaims memberClaims,
+            final long checkInId
+    ) {
+        TicketResponse response = ticketService.findTicket(memberClaims.id(), checkInId);
+
+        return ResponseEntity.ok(response);
+    }
+}

--- a/backend/app/src/main/java/com/yagubogu/ticket/controller/v1/TicketControllerInterface.java
+++ b/backend/app/src/main/java/com/yagubogu/ticket/controller/v1/TicketControllerInterface.java
@@ -1,0 +1,29 @@
+package com.yagubogu.ticket.controller.v1;
+
+import com.yagubogu.auth.dto.MemberClaims;
+import com.yagubogu.ticket.dto.v1.TicketResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Tag(name = "Ticket", description = "직관 티켓 관련 API")
+@RequestMapping("/tickets")
+public interface TicketControllerInterface {
+
+    @Operation(summary = "직관 티켓 조회", description = "checkInId에 해당하는 직관 티켓 화면 정보를 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "직관 티켓 조회 성공"),
+            @ApiResponse(responseCode = "404", description = "해당 직관 내역을 찾을 수 없음")
+    })
+    @GetMapping("/{checkInId}")
+    ResponseEntity<TicketResponse> findTicket(
+            @Parameter(hidden = true) MemberClaims memberClaims,
+            @PathVariable long checkInId
+    );
+}

--- a/backend/app/src/main/java/com/yagubogu/ticket/dto/v1/TicketResponse.java
+++ b/backend/app/src/main/java/com/yagubogu/ticket/dto/v1/TicketResponse.java
@@ -20,7 +20,8 @@ public record TicketResponse(
             final CheckIn checkIn,
             final int recordYear,
             final StatCountsParam statCounts,
-            final double winRate
+            final double winRate,
+            final int checkInCounts
     ) {
         Game game = checkIn.getGame();
 
@@ -30,7 +31,7 @@ public record TicketResponse(
                 game.getHomeScore(),
                 game.getAwayScore(),
                 checkIn.getTeam().getTeamCode(),
-                TicketRecordResponse.from(recordYear, statCounts, winRate),
+                TicketRecordResponse.from(recordYear, statCounts, winRate, checkInCounts),
                 game.getStadium().getFullName(),
                 game.getDate()
         );
@@ -48,10 +49,9 @@ public record TicketResponse(
         private static TicketRecordResponse from(
                 final int year,
                 final StatCountsParam statCounts,
-                final double winRate
+                final double winRate,
+                final int checkInCounts
         ) {
-            int checkInCounts = statCounts.winCounts() + statCounts.drawCounts() + statCounts.loseCounts();
-
             return new TicketRecordResponse(
                     year,
                     statCounts.winCounts(),

--- a/backend/app/src/main/java/com/yagubogu/ticket/dto/v1/TicketResponse.java
+++ b/backend/app/src/main/java/com/yagubogu/ticket/dto/v1/TicketResponse.java
@@ -1,0 +1,65 @@
+package com.yagubogu.ticket.dto.v1;
+
+import com.yagubogu.checkin.domain.CheckIn;
+import com.yagubogu.checkin.dto.StatCountsParam;
+import com.yagubogu.game.domain.Game;
+import java.time.LocalDate;
+
+public record TicketResponse(
+        String homeTeamCode,
+        String awayTeamCode,
+        Integer homeScore,
+        Integer awayScore,
+        String myTeamCode,
+        TicketRecordResponse record,
+        String stadiumName,
+        LocalDate attendanceDate
+) {
+
+    public static TicketResponse from(
+            final CheckIn checkIn,
+            final int recordYear,
+            final StatCountsParam statCounts,
+            final double winRate
+    ) {
+        Game game = checkIn.getGame();
+
+        return new TicketResponse(
+                game.getHomeTeam().getTeamCode(),
+                game.getAwayTeam().getTeamCode(),
+                game.getHomeScore(),
+                game.getAwayScore(),
+                checkIn.getTeam().getTeamCode(),
+                TicketRecordResponse.from(recordYear, statCounts, winRate),
+                game.getStadium().getFullName(),
+                game.getDate()
+        );
+    }
+
+    public record TicketRecordResponse(
+            int year,
+            int winCounts,
+            int drawCounts,
+            int loseCounts,
+            double winRate,
+            int checkInCounts
+    ) {
+
+        private static TicketRecordResponse from(
+                final int year,
+                final StatCountsParam statCounts,
+                final double winRate
+        ) {
+            int checkInCounts = statCounts.winCounts() + statCounts.drawCounts() + statCounts.loseCounts();
+
+            return new TicketRecordResponse(
+                    year,
+                    statCounts.winCounts(),
+                    statCounts.drawCounts(),
+                    statCounts.loseCounts(),
+                    winRate,
+                    checkInCounts
+            );
+        }
+    }
+}

--- a/backend/app/src/main/java/com/yagubogu/ticket/service/TicketService.java
+++ b/backend/app/src/main/java/com/yagubogu/ticket/service/TicketService.java
@@ -27,8 +27,14 @@ public class TicketService {
                 recordYear
         );
         double winRate = calculateWinRate(statCounts.winCounts(), statCounts.winCounts() + statCounts.loseCounts());
+        int checkInCounts = checkInRepository.countByMemberAndYearUntilCheckIn(
+                checkIn.getMember(),
+                recordYear,
+                checkIn.getGame().getDate(),
+                checkIn.getId()
+        );
 
-        return TicketResponse.from(checkIn, recordYear, statCounts, winRate);
+        return TicketResponse.from(checkIn, recordYear, statCounts, winRate, checkInCounts);
     }
 
     private double calculateWinRate(final long winCounts, final long totalCountsWithoutDraw) {

--- a/backend/app/src/main/java/com/yagubogu/ticket/service/TicketService.java
+++ b/backend/app/src/main/java/com/yagubogu/ticket/service/TicketService.java
@@ -1,0 +1,42 @@
+package com.yagubogu.ticket.service;
+
+import com.yagubogu.checkin.domain.CheckIn;
+import com.yagubogu.checkin.dto.StatCountsParam;
+import com.yagubogu.checkin.repository.CheckInRepository;
+import com.yagubogu.global.exception.NotFoundException;
+import com.yagubogu.ticket.dto.v1.TicketResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Service
+public class TicketService {
+
+    private final CheckInRepository checkInRepository;
+
+    public TicketResponse findTicket(final long memberId, final long checkInId) {
+        CheckIn checkIn = checkInRepository.findByIdAndMemberId(checkInId, memberId)
+                .orElseThrow(() -> new NotFoundException("CheckIn is not found"));
+
+        int recordYear = checkIn.getGame().getDate().getYear();
+        StatCountsParam statCounts = checkInRepository.findStatCountsByMemberAndTeam(
+                checkIn.getMember(),
+                checkIn.getTeam(),
+                recordYear
+        );
+        double winRate = calculateWinRate(statCounts.winCounts(), statCounts.winCounts() + statCounts.loseCounts());
+
+        return TicketResponse.from(checkIn, recordYear, statCounts, winRate);
+    }
+
+    private double calculateWinRate(final long winCounts, final long totalCountsWithoutDraw) {
+        if (totalCountsWithoutDraw == 0) {
+            return 0;
+        }
+        double rate = (double) winCounts / totalCountsWithoutDraw * 100;
+
+        return Math.round(rate * 10) / 10.0;
+    }
+}

--- a/backend/app/src/test/java/com/yagubogu/ticket/TicketE2eTest.java
+++ b/backend/app/src/test/java/com/yagubogu/ticket/TicketE2eTest.java
@@ -1,0 +1,145 @@
+package com.yagubogu.ticket;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.yagubogu.auth.config.AuthTestConfig;
+import com.yagubogu.checkin.domain.CheckIn;
+import com.yagubogu.game.domain.Game;
+import com.yagubogu.game.domain.GameState;
+import com.yagubogu.global.config.JpaAuditingConfig;
+import com.yagubogu.member.domain.Member;
+import com.yagubogu.member.domain.Role;
+import com.yagubogu.stadium.domain.Stadium;
+import com.yagubogu.stadium.repository.StadiumRepository;
+import com.yagubogu.support.TestFixture;
+import com.yagubogu.support.auth.AuthFactory;
+import com.yagubogu.support.base.E2eTestBase;
+import com.yagubogu.support.checkin.CheckInFactory;
+import com.yagubogu.support.game.GameFactory;
+import com.yagubogu.support.member.MemberFactory;
+import com.yagubogu.team.domain.Team;
+import com.yagubogu.team.repository.TeamRepository;
+import com.yagubogu.ticket.dto.v1.TicketResponse;
+import io.restassured.RestAssured;
+import java.time.LocalDate;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpHeaders;
+
+@Import({AuthTestConfig.class, JpaAuditingConfig.class})
+class TicketE2eTest extends E2eTestBase {
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private AuthFactory authFactory;
+
+    @Autowired
+    private MemberFactory memberFactory;
+
+    @Autowired
+    private GameFactory gameFactory;
+
+    @Autowired
+    private CheckInFactory checkInFactory;
+
+    @Autowired
+    private TeamRepository teamRepository;
+
+    @Autowired
+    private StadiumRepository stadiumRepository;
+
+    private Team lg, doosan;
+    private Stadium stadiumJamsil;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+
+        lg = teamRepository.findByTeamCode("LG").orElseThrow();
+        doosan = teamRepository.findByTeamCode("OB").orElseThrow();
+        stadiumJamsil = stadiumRepository.findById(2L).orElseThrow();
+    }
+
+    @DisplayName("직관 티켓 화면 정보를 조회한다")
+    @Test
+    void findTicket() {
+        // given
+        Member member = memberFactory.save(builder -> builder.team(lg));
+        String accessToken = authFactory.getAccessTokenByMemberId(member.getId(), Role.USER);
+
+        saveCheckIn(member, lg, 5, doosan, 1, LocalDate.of(2026, 4, 1));
+        saveCheckIn(member, doosan, 2, lg, 4, LocalDate.of(2026, 4, 15));
+        Game targetGame = saveGame(lg, 2, doosan, 3, LocalDate.of(2026, 5, 7));
+        CheckIn targetCheckIn = checkInFactory.save(builder -> builder
+                .member(member)
+                .team(lg)
+                .game(targetGame)
+        );
+
+        // when
+        TicketResponse actual = RestAssured.given().log().all()
+                .header(HttpHeaders.AUTHORIZATION, accessToken)
+                .when().get("/api/v1/tickets/{checkInId}", targetCheckIn.getId())
+                .then().log().all()
+                .statusCode(200)
+                .extract()
+                .as(TicketResponse.class);
+
+        // then
+        assertThat(actual.homeTeamCode()).isEqualTo("LG");
+        assertThat(actual.awayTeamCode()).isEqualTo("OB");
+        assertThat(actual.homeScore()).isEqualTo(2);
+        assertThat(actual.awayScore()).isEqualTo(3);
+        assertThat(actual.myTeamCode()).isEqualTo("LG");
+        assertThat(actual.stadiumName()).isEqualTo("잠실 야구장");
+        assertThat(actual.attendanceDate()).isEqualTo(LocalDate.of(2026, 5, 7));
+        assertThat(actual.record().year()).isEqualTo(2026);
+        assertThat(actual.record().winCounts()).isEqualTo(2);
+        assertThat(actual.record().drawCounts()).isZero();
+        assertThat(actual.record().loseCounts()).isEqualTo(1);
+        assertThat(actual.record().winRate()).isEqualTo(66.7);
+        assertThat(actual.record().checkInCounts()).isEqualTo(3);
+    }
+
+    private void saveCheckIn(
+            final Member member,
+            final Team homeTeam,
+            final int homeScore,
+            final Team awayTeam,
+            final int awayScore,
+            final LocalDate date
+    ) {
+        Game game = saveGame(homeTeam, homeScore, awayTeam, awayScore, date);
+        checkInFactory.save(builder -> builder
+                .member(member)
+                .team(lg)
+                .game(game)
+        );
+    }
+
+    private Game saveGame(
+            final Team homeTeam,
+            final int homeScore,
+            final Team awayTeam,
+            final int awayScore,
+            final LocalDate date
+    ) {
+        return gameFactory.save(builder -> builder
+                .stadium(stadiumJamsil)
+                .homeTeam(homeTeam)
+                .awayTeam(awayTeam)
+                .homeScore(homeScore)
+                .awayScore(awayScore)
+                .homeScoreBoard(TestFixture.getHomeScoreBoardAbout(homeScore))
+                .awayScoreBoard(TestFixture.getAwayScoreBoardAbout(awayScore))
+                .date(date)
+                .gameState(GameState.COMPLETED)
+        );
+    }
+}

--- a/backend/app/src/test/java/com/yagubogu/ticket/TicketE2eTest.java
+++ b/backend/app/src/test/java/com/yagubogu/ticket/TicketE2eTest.java
@@ -81,6 +81,7 @@ class TicketE2eTest extends E2eTestBase {
                 .team(lg)
                 .game(targetGame)
         );
+        saveCheckIn(member, lg, 7, doosan, 2, LocalDate.of(2026, 6, 1));
 
         // when
         TicketResponse actual = RestAssured.given().log().all()
@@ -100,10 +101,10 @@ class TicketE2eTest extends E2eTestBase {
         assertThat(actual.stadiumName()).isEqualTo("잠실 야구장");
         assertThat(actual.attendanceDate()).isEqualTo(LocalDate.of(2026, 5, 7));
         assertThat(actual.record().year()).isEqualTo(2026);
-        assertThat(actual.record().winCounts()).isEqualTo(2);
+        assertThat(actual.record().winCounts()).isEqualTo(3);
         assertThat(actual.record().drawCounts()).isZero();
         assertThat(actual.record().loseCounts()).isEqualTo(1);
-        assertThat(actual.record().winRate()).isEqualTo(66.7);
+        assertThat(actual.record().winRate()).isEqualTo(75.0);
         assertThat(actual.record().checkInCounts()).isEqualTo(3);
     }
 

--- a/backend/app/src/test/java/com/yagubogu/ticket/service/TicketServiceTest.java
+++ b/backend/app/src/test/java/com/yagubogu/ticket/service/TicketServiceTest.java
@@ -77,6 +77,7 @@ class TicketServiceTest {
                 .team(lg)
                 .game(targetGame)
         );
+        saveCheckIn(member, lg, 7, doosan, 2, LocalDate.of(2026, 6, 1));
         saveCheckIn(member, lg, 8, doosan, 0, LocalDate.of(2025, 5, 7));
 
         // when
@@ -91,10 +92,10 @@ class TicketServiceTest {
         assertThat(actual.stadiumName()).isEqualTo("잠실 야구장");
         assertThat(actual.attendanceDate()).isEqualTo(LocalDate.of(2026, 5, 7));
         assertThat(actual.record().year()).isEqualTo(2026);
-        assertThat(actual.record().winCounts()).isEqualTo(2);
+        assertThat(actual.record().winCounts()).isEqualTo(3);
         assertThat(actual.record().drawCounts()).isZero();
         assertThat(actual.record().loseCounts()).isEqualTo(1);
-        assertThat(actual.record().winRate()).isEqualTo(66.7);
+        assertThat(actual.record().winRate()).isEqualTo(75.0);
         assertThat(actual.record().checkInCounts()).isEqualTo(3);
     }
 

--- a/backend/app/src/test/java/com/yagubogu/ticket/service/TicketServiceTest.java
+++ b/backend/app/src/test/java/com/yagubogu/ticket/service/TicketServiceTest.java
@@ -1,0 +1,155 @@
+package com.yagubogu.ticket.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+
+import com.yagubogu.auth.config.AuthTestConfig;
+import com.yagubogu.checkin.domain.CheckIn;
+import com.yagubogu.checkin.repository.CheckInRepository;
+import com.yagubogu.game.domain.Game;
+import com.yagubogu.game.domain.GameState;
+import com.yagubogu.global.config.JpaAuditingConfig;
+import com.yagubogu.global.exception.NotFoundException;
+import com.yagubogu.member.domain.Member;
+import com.yagubogu.stadium.domain.Stadium;
+import com.yagubogu.stadium.repository.StadiumRepository;
+import com.yagubogu.support.TestFixture;
+import com.yagubogu.support.checkin.CheckInFactory;
+import com.yagubogu.support.game.GameFactory;
+import com.yagubogu.support.member.MemberFactory;
+import com.yagubogu.team.domain.Team;
+import com.yagubogu.team.repository.TeamRepository;
+import com.yagubogu.ticket.dto.v1.TicketResponse;
+import java.time.LocalDate;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+@Import({AuthTestConfig.class, JpaAuditingConfig.class})
+@DataJpaTest
+class TicketServiceTest {
+
+    private TicketService ticketService;
+
+    @Autowired
+    private MemberFactory memberFactory;
+
+    @Autowired
+    private GameFactory gameFactory;
+
+    @Autowired
+    private CheckInFactory checkInFactory;
+
+    @Autowired
+    private CheckInRepository checkInRepository;
+
+    @Autowired
+    private TeamRepository teamRepository;
+
+    @Autowired
+    private StadiumRepository stadiumRepository;
+
+    private Team lg, doosan;
+    private Stadium stadiumJamsil;
+
+    @BeforeEach
+    void setUp() {
+        ticketService = new TicketService(checkInRepository);
+
+        lg = teamRepository.findByTeamCode("LG").orElseThrow();
+        doosan = teamRepository.findByTeamCode("OB").orElseThrow();
+        stadiumJamsil = stadiumRepository.findById(2L).orElseThrow();
+    }
+
+    @DisplayName("직관 티켓 화면에 필요한 경기 정보와 연도별 직관 기록을 조회한다")
+    @Test
+    void findTicket() {
+        // given
+        Member member = memberFactory.save(builder -> builder.team(lg));
+        saveCheckIn(member, lg, 5, doosan, 1, LocalDate.of(2026, 4, 1));
+        saveCheckIn(member, doosan, 2, lg, 4, LocalDate.of(2026, 4, 15));
+        Game targetGame = saveGame(lg, 2, doosan, 3, LocalDate.of(2026, 5, 7));
+        CheckIn targetCheckIn = checkInFactory.save(builder -> builder
+                .member(member)
+                .team(lg)
+                .game(targetGame)
+        );
+        saveCheckIn(member, lg, 8, doosan, 0, LocalDate.of(2025, 5, 7));
+
+        // when
+        TicketResponse actual = ticketService.findTicket(member.getId(), targetCheckIn.getId());
+
+        // then
+        assertThat(actual.homeTeamCode()).isEqualTo("LG");
+        assertThat(actual.awayTeamCode()).isEqualTo("OB");
+        assertThat(actual.homeScore()).isEqualTo(2);
+        assertThat(actual.awayScore()).isEqualTo(3);
+        assertThat(actual.myTeamCode()).isEqualTo("LG");
+        assertThat(actual.stadiumName()).isEqualTo("잠실 야구장");
+        assertThat(actual.attendanceDate()).isEqualTo(LocalDate.of(2026, 5, 7));
+        assertThat(actual.record().year()).isEqualTo(2026);
+        assertThat(actual.record().winCounts()).isEqualTo(2);
+        assertThat(actual.record().drawCounts()).isZero();
+        assertThat(actual.record().loseCounts()).isEqualTo(1);
+        assertThat(actual.record().winRate()).isEqualTo(66.7);
+        assertThat(actual.record().checkInCounts()).isEqualTo(3);
+    }
+
+    @DisplayName("예외: 본인의 직관 기록이 아니면 티켓을 조회할 수 없다")
+    @Test
+    void findTicket_notFoundWhenNotOwner() {
+        // given
+        Member member = memberFactory.save(builder -> builder.team(lg));
+        Member other = memberFactory.save(builder -> builder.team(doosan));
+        Game game = saveGame(lg, 2, doosan, 3, LocalDate.of(2026, 5, 7));
+        CheckIn checkIn = checkInFactory.save(builder -> builder
+                .member(member)
+                .team(lg)
+                .game(game)
+        );
+
+        // when & then
+        assertThatThrownBy(() -> ticketService.findTicket(other.getId(), checkIn.getId()))
+                .isExactlyInstanceOf(NotFoundException.class)
+                .hasMessage("CheckIn is not found");
+    }
+
+    private void saveCheckIn(
+            final Member member,
+            final Team homeTeam,
+            final int homeScore,
+            final Team awayTeam,
+            final int awayScore,
+            final LocalDate date
+    ) {
+        Game game = saveGame(homeTeam, homeScore, awayTeam, awayScore, date);
+        checkInFactory.save(builder -> builder
+                .member(member)
+                .team(lg)
+                .game(game)
+        );
+    }
+
+    private Game saveGame(
+            final Team homeTeam,
+            final int homeScore,
+            final Team awayTeam,
+            final int awayScore,
+            final LocalDate date
+    ) {
+        return gameFactory.save(builder -> builder
+                .stadium(stadiumJamsil)
+                .homeTeam(homeTeam)
+                .awayTeam(awayTeam)
+                .homeScore(homeScore)
+                .awayScore(awayScore)
+                .homeScoreBoard(TestFixture.getHomeScoreBoardAbout(homeScore))
+                .awayScoreBoard(TestFixture.getAwayScoreBoardAbout(awayScore))
+                .date(date)
+                .gameState(GameState.COMPLETED)
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- `GET /tickets/{checkInId}` 직관 티켓 조회 API를 추가했습니다.
- 티켓 화면에 필요한 경기 팀/스코어, 내 팀 코드, 경기장명, 관람일, 해당 연도 직관 기록을 한 번에 반환합니다.
- 체크인 소유자만 조회되도록 `checkInId + memberId` 기준으로 조회합니다.
- 회원+응원팀+연도 기준 승/무/패 집계 QueryDSL 메서드를 추가했습니다.

## Verification
- `./gradlew :app:test --tests com.yagubogu.ticket.service.TicketServiceTest --tests com.yagubogu.ticket.TicketE2eTest`

## API Spec
### GET /api/v1/tickets/{checkInId}
직관 티켓 화면 정보를 조회합니다.

**Path Parameters**
- `checkInId` (long, required): 조회할 직관 기록 ID

**Request Body**
- 없음

**Authentication**
- `Authorization: Bearer <accessToken>` 필요
- `@RequireRole` 적용

**Response Body**
```json
{
  "homeTeamCode": "LG",
  "awayTeamCode": "OB",
  "homeScore": 2,
  "awayScore": 3,
  "myTeamCode": "LG",
  "record": {
    "year": 2026,
    "winCounts": 2,
    "drawCounts": 0,
    "loseCounts": 1,
    "winRate": 66.7,
    "checkInCounts": 3
  },
  "stadiumName": "잠실 야구장",
  "attendanceDate": "2026-05-07"
}
```

**Validation / Business Rules**
- `checkInId`는 인증된 회원 본인의 체크인 ID여야 합니다.
- 기록 연도는 해당 체크인의 경기 일자 연도를 기준으로 계산합니다.
- `record`는 체크인 당시 응원팀(`checkIn.team`) 기준으로 집계합니다.
- 승률은 기존 통계 API와 동일하게 `승 / (승 + 패) * 100`이며 무승부는 분모에서 제외하고 소수 1자리로 반올림합니다.
- `checkInCounts`는 `winCounts + drawCounts + loseCounts`입니다.

**Status Codes**
- `200 OK`: 조회 성공
- `401 Unauthorized`: 인증 토큰 없음 또는 유효하지 않음
- `404 Not Found`: 체크인을 찾을 수 없거나 본인의 체크인이 아님

**Compatibility / Migration Notes**
- 신규 API 추가이며 기존 API 동작 변경은 없습니다.

Resolves #1095