### PR TITLE
design: 현장톡 아이템 UI 레이아웃 수정

### DIFF
--- a/mobile/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/mobile/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -65,7 +65,7 @@
     <string name="home_double_header_message">어떤 경기를 인증할까요?</string>
     <string name="home_double_header_game">%1$d차전</string>
     <string name="home_my_team">우리 팀</string>
-    <string name="home_attendance_count">인증 횟수</string>
+    <string name="home_attendance_count">직관 횟수</string>
     <string name="home_winning_percentage">직관 승률</string>
     <string name="home_location_permission_denied_message">위치 권한이 거부되었습니다.</string>
     <string name="home_location_settings_disabled">디바이스 위치 설정이 비활성화 상태입니다.</string>

--- a/mobile/composeApp/src/commonMain/kotlin/com/yagubogu/ui/livetalk/component/LivetalkStadiumItem.kt
+++ b/mobile/composeApp/src/commonMain/kotlin/com/yagubogu/ui/livetalk/component/LivetalkStadiumItem.kt
@@ -12,7 +12,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
@@ -20,6 +19,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -33,6 +33,7 @@ import com.yagubogu.ui.theme.Gray100
 import com.yagubogu.ui.theme.Gray500
 import com.yagubogu.ui.theme.PretendardBold
 import com.yagubogu.ui.theme.PretendardMedium
+import com.yagubogu.ui.theme.PretendardMedium12
 import com.yagubogu.ui.theme.Primary500
 import com.yagubogu.ui.theme.White
 import com.yagubogu.ui.theme.dpToSp
@@ -69,38 +70,46 @@ fun LivetalkStadiumItem(
                 .padding(20.dp),
     ) {
         Row(
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
-            Text(
-                text = item.stadiumName,
-                style = PretendardBold.copy(fontSize = 18.dpToSp),
-            )
-            Spacer(modifier = Modifier.width(10.dp))
-
             Row(
-                modifier = Modifier.weight(1.0f),
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                horizontalArrangement = Arrangement.spacedBy(10.dp),
                 verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier.weight(1.0f),
             ) {
-                if (item.weatherUiModel != null) {
-                    val weatherStatusText =
-                        stringResource(item.weatherUiModel.condition.toStringResource())
+                Text(
+                    text = item.stadiumName,
+                    style = PretendardBold.copy(fontSize = 18.sp),
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.weight(1f, fill = false),
+                )
+
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    if (item.weatherUiModel != null) {
+                        val weatherStatusText =
+                            stringResource(item.weatherUiModel.condition.toStringResource())
+                        IconWithText(
+                            icon = item.weatherUiModel.condition.toResource(),
+                            iconDescription =
+                                stringResource(
+                                    Res.string.livetalk_weather_icon_description,
+                                    weatherStatusText,
+                                ),
+                            text = item.weatherUiModel.temperatureText,
+                        )
+                    }
+
                     IconWithText(
-                        icon = item.weatherUiModel.condition.toResource(),
-                        iconDescription =
-                            stringResource(
-                                Res.string.livetalk_weather_icon_description,
-                                weatherStatusText,
-                            ),
-                        text = item.weatherUiModel.temperatureText,
+                        icon = Res.drawable.ic_users,
+                        iconDescription = stringResource(Res.string.livetalk_user_icon_description),
+                        text = item.userCount.toString(),
                     )
                 }
-
-                IconWithText(
-                    icon = Res.drawable.ic_users,
-                    iconDescription = stringResource(Res.string.livetalk_user_icon_description),
-                    text = item.userCount.toString(),
-                )
             }
 
             Icon(
@@ -166,7 +175,7 @@ private fun IconWithText(
         )
         Text(
             text = text,
-            style = PretendardMedium.copy(fontSize = 12.dpToSp, color = Gray500),
+            style = PretendardMedium12.copy(color = Gray500),
         )
     }
 }

--- a/mobile/composeApp/src/commonMain/kotlin/com/yagubogu/ui/livetalk/component/LivetalkStadiumItem.kt
+++ b/mobile/composeApp/src/commonMain/kotlin/com/yagubogu/ui/livetalk/component/LivetalkStadiumItem.kt
@@ -31,9 +31,8 @@ import com.yagubogu.ui.livetalk.model.toStringResource
 import com.yagubogu.ui.theme.EsamanruMedium
 import com.yagubogu.ui.theme.Gray100
 import com.yagubogu.ui.theme.Gray500
-import com.yagubogu.ui.theme.PretendardBold20
+import com.yagubogu.ui.theme.PretendardBold
 import com.yagubogu.ui.theme.PretendardMedium
-import com.yagubogu.ui.theme.PretendardMedium12
 import com.yagubogu.ui.theme.Primary500
 import com.yagubogu.ui.theme.White
 import com.yagubogu.ui.theme.dpToSp
@@ -67,36 +66,41 @@ fun LivetalkStadiumItem(
                     if (item.isVerified) Primary500 else Gray100,
                     RoundedCornerShape(12.dp),
                 ).noRippleClickable { onClick(item) }
-                .padding(horizontal = 24.dp, vertical = 20.dp),
+                .padding(20.dp),
     ) {
         Row(
             verticalAlignment = Alignment.CenterVertically,
         ) {
             Text(
                 text = item.stadiumName,
-                style = PretendardBold20,
+                style = PretendardBold.copy(fontSize = 18.dpToSp),
             )
-            Spacer(modifier = Modifier.width(8.dp))
+            Spacer(modifier = Modifier.width(10.dp))
 
             Row(
                 modifier = Modifier.weight(1.0f),
                 horizontalArrangement = Arrangement.spacedBy(8.dp),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
+                if (item.weatherUiModel != null) {
+                    val weatherStatusText =
+                        stringResource(item.weatherUiModel.condition.toStringResource())
+                    IconWithText(
+                        icon = item.weatherUiModel.condition.toResource(),
+                        iconDescription =
+                            stringResource(
+                                Res.string.livetalk_weather_icon_description,
+                                weatherStatusText,
+                            ),
+                        text = item.weatherUiModel.temperatureText,
+                    )
+                }
+
                 IconWithText(
                     icon = Res.drawable.ic_users,
                     iconDescription = stringResource(Res.string.livetalk_user_icon_description),
                     text = item.userCount.toString(),
                 )
-                if (item.weatherUiModel != null) {
-                    val weatherStatusText = stringResource(item.weatherUiModel.condition.toStringResource())
-
-                    IconWithText(
-                        icon = item.weatherUiModel.condition.toResource(),
-                        iconDescription = stringResource(Res.string.livetalk_weather_icon_description, weatherStatusText),
-                        text = item.weatherUiModel.temperatureText,
-                    )
-                }
             }
 
             Icon(
@@ -149,7 +153,11 @@ private fun IconWithText(
     text: String,
     modifier: Modifier = Modifier,
 ) {
-    Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+    Row(
+        horizontalArrangement = Arrangement.spacedBy(4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = modifier,
+    ) {
         Icon(
             painter = painterResource(icon),
             contentDescription = iconDescription,
@@ -158,7 +166,7 @@ private fun IconWithText(
         )
         Text(
             text = text,
-            style = PretendardMedium12.copy(color = Gray500),
+            style = PretendardMedium.copy(fontSize = 12.dpToSp, color = Gray500),
         )
     }
 }
@@ -200,7 +208,15 @@ private fun LivetalkStadiumItemVerifiedPreview() {
 @Composable
 private fun LivetalkStadiumItemUnVerifiedPreview() {
     LivetalkStadiumItem(
-        item = LIVETALK_STADIUM_ITEM_UNVERIFIED.copy(weatherUiModel = WeatherUiModel(1, Condition.Clear, "12.3°C")),
+        item =
+            LIVETALK_STADIUM_ITEM_UNVERIFIED.copy(
+                weatherUiModel =
+                    WeatherUiModel(
+                        1,
+                        Condition.Clear,
+                        "12.3°C",
+                    ),
+            ),
         onClick = {},
     )
 }

--- a/mobile/composeApp/src/commonMain/kotlin/com/yagubogu/ui/onboarding/favorite/FavoriteTeamScreen.kt
+++ b/mobile/composeApp/src/commonMain/kotlin/com/yagubogu/ui/onboarding/favorite/FavoriteTeamScreen.kt
@@ -202,6 +202,7 @@ private fun FavoriteTeamDialog(
             text = teamName,
             style = PretendardSemiBold16,
         )
+        Spacer(modifier = Modifier.height(20.dp))
     }
 }
 


### PR DESCRIPTION
## 📌 관련 이슈
- close #1102 

## ✨ 변경 내용
- 날씨가 추가되면서 UI가 깨진다고 해서 레이아웃을 조정했습니다.
- 구장명에 `TextOverflow.Ellipsis`를 적용했습니다.

## 🎸 기타 참고 사항
- 스크린샷, 참고 링크, 추가 설명 등 (없으면 생략 가능)
<img width="450" alt="Screenshot_20260616_214731" src="https://github.com/user-attachments/assets/11754551-ce47-4053-90d9-2a1d0e1dad48" />

