### PR TITLE
refactor: 경기기록 상세 화면 Scaffold 적용

### DIFF
--- a/mobile/composeApp/src/commonMain/kotlin/com/yagubogu/ui/attendance/detail/AttendanceDetailScreen.kt
+++ b/mobile/composeApp/src/commonMain/kotlin/com/yagubogu/ui/attendance/detail/AttendanceDetailScreen.kt
@@ -1,6 +1,5 @@
 package com.yagubogu.ui.attendance.detail
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -160,8 +159,7 @@ private fun AttendanceDetailScreen(
                 modifier =
                     Modifier
                         .fillMaxSize()
-                        .padding(innerPadding)
-                        .background(Gray050),
+                        .padding(innerPadding),
             ) {
                 if (!isKeyboardVisible) {
                     AttendanceDetailTabRow(pagerState)

--- a/mobile/composeApp/src/commonMain/kotlin/com/yagubogu/ui/attendance/detail/AttendanceDetailScreen.kt
+++ b/mobile/composeApp/src/commonMain/kotlin/com/yagubogu/ui/attendance/detail/AttendanceDetailScreen.kt
@@ -217,6 +217,25 @@ private fun AttendanceDetailToolbar(
 
 @Preview
 @Composable
+private fun AttendanceDetailScreenGameRecordTabPreview() {
+    AttendanceDetailScreen(
+        item = ATTENDANCE_HISTORY_ITEM_PLAYED,
+        playerRecordUiModel = PLAYER_RECORD,
+        attendanceDetailDiaryUiState = AttendanceDetailDiaryUiState(),
+        pagerState = rememberPagerState(AttendanceDetailTab.GAME_RECORD.ordinal) { AttendanceDetailTab.entries.size },
+        date = "2025.08.14 (목)",
+        onBackClick = {},
+        onDeleteClick = {},
+        onImagesSelected = {},
+        onImageDeleted = {},
+        onEditClick = {},
+        onSaveClick = { _ -> },
+        onImagePickerError = {},
+    )
+}
+
+@Preview
+@Composable
 private fun AttendanceDetailScreenDiaryTabPreview() {
     AttendanceDetailScreen(
         item = ATTENDANCE_HISTORY_ITEM_PLAYED,

--- a/mobile/composeApp/src/commonMain/kotlin/com/yagubogu/ui/attendance/detail/AttendanceDetailScreen.kt
+++ b/mobile/composeApp/src/commonMain/kotlin/com/yagubogu/ui/attendance/detail/AttendanceDetailScreen.kt
@@ -3,14 +3,17 @@ package com.yagubogu.ui.attendance.detail
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.ime
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.PagerState
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -143,41 +146,48 @@ private fun AttendanceDetailScreen(
     val isKeyboardVisible = WindowInsets.ime.getBottom(LocalDensity.current) > 0
 
     Box(modifier = modifier.fillMaxSize()) {
-        Column(
-            modifier =
-                Modifier
-                    .fillMaxSize()
-                    .background(Gray050),
-        ) {
-            AttendanceDetailToolbar(
-                date = date,
-                onBackClick = onBackClick,
-                onDeleteClick = onDeleteClick,
-            )
-            if (!isKeyboardVisible) {
-                AttendanceDetailTabRow(pagerState)
-            }
-            HorizontalPager(
-                state = pagerState,
-                beyondViewportPageCount = AttendanceDetailTab.entries.size,
-                modifier = Modifier.fillMaxSize(),
-            ) { page ->
-                when (page) {
-                    AttendanceDetailTab.GAME_RECORD.ordinal ->
-                        AttendanceDetailGameRecordScreen(
-                            item = item,
-                            playerRecord = playerRecordUiModel,
-                        )
+        Scaffold(
+            containerColor = Gray050,
+            topBar = {
+                AttendanceDetailToolbar(
+                    date = date,
+                    onBackClick = onBackClick,
+                    onDeleteClick = onDeleteClick,
+                )
+            },
+        ) { innerPadding: PaddingValues ->
+            Column(
+                modifier =
+                    Modifier
+                        .fillMaxSize()
+                        .padding(innerPadding)
+                        .background(Gray050),
+            ) {
+                if (!isKeyboardVisible) {
+                    AttendanceDetailTabRow(pagerState)
+                }
+                HorizontalPager(
+                    state = pagerState,
+                    beyondViewportPageCount = AttendanceDetailTab.entries.size,
+                    modifier = Modifier.fillMaxSize(),
+                ) { page ->
+                    when (page) {
+                        AttendanceDetailTab.GAME_RECORD.ordinal ->
+                            AttendanceDetailGameRecordScreen(
+                                item = item,
+                                playerRecord = playerRecordUiModel,
+                            )
 
-                    AttendanceDetailTab.DIARY.ordinal ->
-                        AttendanceDetailDiaryScreen(
-                            uiState = attendanceDetailDiaryUiState,
-                            onImagesSelected = onImagesSelected,
-                            onImageDeleted = onImageDeleted,
-                            onEditClick = onEditClick,
-                            onSaveClick = onSaveClick,
-                            onImagePickerError = onImagePickerError,
-                        )
+                        AttendanceDetailTab.DIARY.ordinal ->
+                            AttendanceDetailDiaryScreen(
+                                uiState = attendanceDetailDiaryUiState,
+                                onImagesSelected = onImagesSelected,
+                                onImageDeleted = onImageDeleted,
+                                onEditClick = onEditClick,
+                                onSaveClick = onSaveClick,
+                                onImagePickerError = onImagePickerError,
+                            )
+                    }
                 }
             }
         }


### PR DESCRIPTION
## 📌 관련 이슈
- close #1104 

## ✨ 변경 내용
- 경기기록 상세 화면에 Scaffold를 적용하여 안드로이드에서 네비게이션바에 가리지 않도록 수정했습니다.

## 🎸 기타 참고 사항
- 스크린샷, 참고 링크, 추가 설명 등 (없으면 생략 가능)