### PR TITLE
feat: 경기 라이브 상태(타자/투수/진루/카운트) 조회 API 구현

### DIFF
--- a/backend/app/src/main/java/com/yagubogu/game/controller/v1/GameController.java
+++ b/backend/app/src/main/java/com/yagubogu/game/controller/v1/GameController.java
@@ -2,6 +2,7 @@ package com.yagubogu.game.controller.v1;
 
 import com.yagubogu.auth.annotation.RequireRole;
 import com.yagubogu.auth.dto.MemberClaims;
+import com.yagubogu.game.dto.GameResultParam;
 import com.yagubogu.game.dto.v1.GameDatesResponse;
 import com.yagubogu.game.dto.v1.GameResponse;
 import com.yagubogu.game.service.GameService;
@@ -10,6 +11,7 @@ import java.time.YearMonth;
 import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -35,6 +37,16 @@ public class GameController implements GameControllerInterface {
             @RequestParam @DateTimeFormat(pattern = "yyyy-MM") final YearMonth yearMonth
     ) {
         GameDatesResponse response = gameService.findGameDatesByYearMonth(yearMonth);
+
+        return ResponseEntity.ok(response);
+    }
+
+    @RequireRole
+    public ResponseEntity<GameResultParam> findScoreBoard(
+            final MemberClaims memberClaims,
+            @PathVariable final long gameId
+    ) {
+        GameResultParam response = gameService.findScoreBoard(gameId);
 
         return ResponseEntity.ok(response);
     }

--- a/backend/app/src/main/java/com/yagubogu/game/controller/v1/GameControllerInterface.java
+++ b/backend/app/src/main/java/com/yagubogu/game/controller/v1/GameControllerInterface.java
@@ -1,6 +1,7 @@
 package com.yagubogu.game.controller.v1;
 
 import com.yagubogu.auth.dto.MemberClaims;
+import com.yagubogu.game.dto.GameResultParam;
 import com.yagubogu.game.dto.v1.GameDatesResponse;
 import com.yagubogu.game.dto.v1.GameResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -13,6 +14,7 @@ import java.time.YearMonth;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
@@ -41,5 +43,16 @@ public interface GameControllerInterface {
     ResponseEntity<GameDatesResponse> findGameDatesByYearMonth(
             @Parameter(hidden = true) MemberClaims memberClaims,
             @RequestParam @DateTimeFormat(pattern = "yyyy-MM") YearMonth yearMonth
+    );
+
+    @Operation(summary = "경기 스코어보드 조회", description = "경기의 스코어보드와 경기중 실시간 상태(현재 타자/투수, 진루정보, 카운트)를 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "스코어보드 조회 성공"),
+            @ApiResponse(responseCode = "404", description = "경기를 찾을 수 없거나 스코어보드가 아직 없음")
+    })
+    @GetMapping("/{gameId}/score-board")
+    ResponseEntity<GameResultParam> findScoreBoard(
+            @Parameter(hidden = true) MemberClaims memberClaims,
+            @PathVariable long gameId
     );
 }

--- a/backend/app/src/main/java/com/yagubogu/game/domain/Game.java
+++ b/backend/app/src/main/java/com/yagubogu/game/domain/Game.java
@@ -79,6 +79,37 @@ public class Game {
     @Column(name = "game_state")
     private GameState gameState;
 
+    // 경기중 실시간 상태 (경기중이 아니면 모두 null)
+    @Column(name = "current_batter_team", nullable = true)
+    private String currentBatterTeam;
+
+    @Column(name = "current_batter_name", nullable = true)
+    private String currentBatterName;
+
+    @Column(name = "current_pitcher_team", nullable = true)
+    private String currentPitcherTeam;
+
+    @Column(name = "current_pitcher_name", nullable = true)
+    private String currentPitcherName;
+
+    @Column(name = "first_base_occupied", nullable = true)
+    private Boolean firstBaseOccupied;
+
+    @Column(name = "second_base_occupied", nullable = true)
+    private Boolean secondBaseOccupied;
+
+    @Column(name = "third_base_occupied", nullable = true)
+    private Boolean thirdBaseOccupied;
+
+    @Column(name = "balls", nullable = true)
+    private Integer balls;
+
+    @Column(name = "strikes", nullable = true)
+    private Integer strikes;
+
+    @Column(name = "outs", nullable = true)
+    private Integer outs;
+
     public Game(final Stadium stadium, final Team homeTeam, final Team awayTeam, final LocalDate date,
                 final LocalTime startAt, final String gameCode,
                 final Integer homeScore, final Integer awayScore, final ScoreBoard homeScoreBoard,
@@ -139,5 +170,41 @@ public class Game {
 
     public boolean hasTeam(final Team team) {
         return homeTeam.equals(team) || awayTeam.equals(team);
+    }
+
+    /**
+     * 스코어보드 크롤링 결과로 진루정보/볼·스트라이크·아웃 카운트를 갱신한다.
+     * 게임센터가 출처인 현재 타자/투수 값은 건드리지 않는다.
+     */
+    public void updateLiveBaseState(
+            final Boolean firstBaseOccupied,
+            final Boolean secondBaseOccupied,
+            final Boolean thirdBaseOccupied,
+            final Integer balls,
+            final Integer strikes,
+            final Integer outs
+    ) {
+        this.firstBaseOccupied = firstBaseOccupied;
+        this.secondBaseOccupied = secondBaseOccupied;
+        this.thirdBaseOccupied = thirdBaseOccupied;
+        this.balls = balls;
+        this.strikes = strikes;
+        this.outs = outs;
+    }
+
+    /**
+     * 게임센터 크롤링 결과로 현재 타자/투수를 갱신한다.
+     * 스코어보드가 출처인 진루정보/카운트 값은 건드리지 않는다.
+     */
+    public void updateLiveBatterAndPitcher(
+            final String currentBatterTeam,
+            final String currentBatterName,
+            final String currentPitcherTeam,
+            final String currentPitcherName
+    ) {
+        this.currentBatterTeam = currentBatterTeam;
+        this.currentBatterName = currentBatterName;
+        this.currentPitcherTeam = currentPitcherTeam;
+        this.currentPitcherName = currentPitcherName;
     }
 }

--- a/backend/app/src/main/java/com/yagubogu/game/dto/GameResultParam.java
+++ b/backend/app/src/main/java/com/yagubogu/game/dto/GameResultParam.java
@@ -8,7 +8,8 @@ public record GameResultParam(
         ScoreBoardParam homeTeamScoreBoard,
         ScoreBoardParam awayTeamScoreBoard,
         String homePitcher,
-        String awayPitcher
+        String awayPitcher,
+        LiveStateParam liveState
 ) {
 
     public static GameResultParam from(Game game) {
@@ -16,8 +17,38 @@ public record GameResultParam(
                 ScoreBoardParam.from(game.getHomeScoreBoard()),
                 ScoreBoardParam.from(game.getAwayScoreBoard()),
                 game.getHomePitcher(),
-                game.getAwayPitcher()
+                game.getAwayPitcher(),
+                LiveStateParam.from(game)
         );
+    }
+
+    public record LiveStateParam(
+            String currentBatterTeam,
+            String currentBatterName,
+            String currentPitcherTeam,
+            String currentPitcherName,
+            Boolean firstBaseOccupied,
+            Boolean secondBaseOccupied,
+            Boolean thirdBaseOccupied,
+            Integer balls,
+            Integer strikes,
+            Integer outs
+    ) {
+
+        public static LiveStateParam from(Game game) {
+            return new LiveStateParam(
+                    game.getCurrentBatterTeam(),
+                    game.getCurrentBatterName(),
+                    game.getCurrentPitcherTeam(),
+                    game.getCurrentPitcherName(),
+                    game.getFirstBaseOccupied(),
+                    game.getSecondBaseOccupied(),
+                    game.getThirdBaseOccupied(),
+                    game.getBalls(),
+                    game.getStrikes(),
+                    game.getOuts()
+            );
+        }
     }
 
     public record ScoreBoardParam(

--- a/backend/app/src/main/resources/db/migration/mysql/V17__add_game_live_state.sql
+++ b/backend/app/src/main/resources/db/migration/mysql/V17__add_game_live_state.sql
@@ -1,0 +1,13 @@
+-- 경기중 실시간 상태(현재 타자/투수, 진루정보, 볼/스트라이크/아웃)
+-- 경기 진행에 따라 계속 덮어써지는 값이라 Bronze 재처리 대상이 아니라 games 테이블에 직접 반영함
+ALTER TABLE games
+    ADD COLUMN current_batter_team    VARCHAR(10) NULL,
+    ADD COLUMN current_batter_name    VARCHAR(50) NULL,
+    ADD COLUMN current_pitcher_team   VARCHAR(10) NULL,
+    ADD COLUMN current_pitcher_name   VARCHAR(50) NULL,
+    ADD COLUMN first_base_occupied    BOOLEAN     NULL,
+    ADD COLUMN second_base_occupied   BOOLEAN     NULL,
+    ADD COLUMN third_base_occupied    BOOLEAN     NULL,
+    ADD COLUMN balls                  TINYINT     NULL,
+    ADD COLUMN strikes                TINYINT     NULL,
+    ADD COLUMN outs                   TINYINT     NULL;

--- a/backend/app/src/test/java/com/yagubogu/game/GameE2eTest.java
+++ b/backend/app/src/test/java/com/yagubogu/game/GameE2eTest.java
@@ -4,11 +4,13 @@ import com.yagubogu.auth.config.AuthTestConfig;
 import com.yagubogu.checkin.domain.CheckIn;
 import com.yagubogu.game.domain.Game;
 import com.yagubogu.game.domain.GameState;
+import com.yagubogu.game.dto.GameResultParam;
 import com.yagubogu.game.dto.GameWithCheckInParam;
 import com.yagubogu.game.dto.StadiumByGameParam;
 import com.yagubogu.game.dto.TeamByGameParam;
 import com.yagubogu.game.dto.v1.GameDatesResponse;
 import com.yagubogu.game.dto.v1.GameResponse;
+import com.yagubogu.game.repository.GameRepository;
 import com.yagubogu.global.config.JpaAuditingConfig;
 import com.yagubogu.member.domain.Member;
 import com.yagubogu.member.domain.Role;
@@ -52,6 +54,9 @@ public class GameE2eTest extends E2eTestBase {
 
     @Autowired
     private GameFactory gameFactory;
+
+    @Autowired
+    private GameRepository gameRepository;
 
     @Autowired
     private CheckInFactory checkInFactory;
@@ -156,6 +161,35 @@ public class GameE2eTest extends E2eTestBase {
 
         // then
         assertThat(actual.dates()).containsExactlyInAnyOrder(date1, date2);
+    }
+
+    @DisplayName("경기중인 경기의 스코어보드를 조회하면 라이브 상태가 포함된다")
+    @Test
+    void findScoreBoard_WithLiveState() {
+        // given
+        LocalDate date = TestFixture.getToday();
+        Game game = makeGame(date, "HT", "LT", "잠실구장");
+        game.updateLiveBatterAndPitcher("away", "최지훈", "home", "김태경");
+        game.updateLiveBaseState(true, false, true, 1, 2, 0);
+        gameRepository.save(game);
+
+        Member member = makeMember(getTeamByCode("SS"));
+        String accessToken = authFactory.getAccessTokenByMemberId(member.getId(), Role.USER);
+
+        // when
+        GameResultParam actual = RestAssured.given().log().all()
+                .contentType(ContentType.JSON)
+                .header(HttpHeaders.AUTHORIZATION, accessToken)
+                .when().get("/api/v1/games/" + game.getId() + "/score-board")
+                .then().log().all()
+                .statusCode(200)
+                .extract()
+                .as(GameResultParam.class);
+
+        // then
+        assertThat(actual.liveState()).isEqualTo(new GameResultParam.LiveStateParam(
+                "away", "최지훈", "home", "김태경", true, false, true, 1, 2, 0
+        ));
     }
 
     @DisplayName("취소된 경기만 있는 날짜는 결과에서 제외된다")

--- a/backend/app/src/test/java/com/yagubogu/game/domain/GameTest.java
+++ b/backend/app/src/test/java/com/yagubogu/game/domain/GameTest.java
@@ -1,0 +1,73 @@
+package com.yagubogu.game.domain;
+
+import com.yagubogu.stadium.domain.Stadium;
+import com.yagubogu.stadium.domain.StadiumLevel;
+import com.yagubogu.team.domain.Team;
+import com.yagubogu.team.domain.TeamStatus;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class GameTest {
+
+    @DisplayName("진루정보/카운트를 갱신해도 현재 타자/투수는 영향받지 않는다")
+    @Test
+    void updateLiveBaseState_DoesNotAffectBatterAndPitcher() {
+        // given
+        Game game = makeGame();
+        game.updateLiveBatterAndPitcher("away", "최지훈", "home", "김태경");
+
+        // when
+        game.updateLiveBaseState(true, false, true, 1, 2, 0);
+
+        // then
+        assertThat(game.getFirstBaseOccupied()).isTrue();
+        assertThat(game.getSecondBaseOccupied()).isFalse();
+        assertThat(game.getThirdBaseOccupied()).isTrue();
+        assertThat(game.getBalls()).isEqualTo(1);
+        assertThat(game.getStrikes()).isEqualTo(2);
+        assertThat(game.getOuts()).isEqualTo(0);
+        assertThat(game.getCurrentBatterTeam()).isEqualTo("away");
+        assertThat(game.getCurrentBatterName()).isEqualTo("최지훈");
+        assertThat(game.getCurrentPitcherTeam()).isEqualTo("home");
+        assertThat(game.getCurrentPitcherName()).isEqualTo("김태경");
+    }
+
+    @DisplayName("현재 타자/투수를 갱신해도 진루정보/카운트는 영향받지 않는다")
+    @Test
+    void updateLiveBatterAndPitcher_DoesNotAffectBaseState() {
+        // given
+        Game game = makeGame();
+        game.updateLiveBaseState(true, false, true, 1, 2, 0);
+
+        // when
+        game.updateLiveBatterAndPitcher("away", "최지훈", "home", "김태경");
+
+        // then
+        assertThat(game.getCurrentBatterTeam()).isEqualTo("away");
+        assertThat(game.getCurrentBatterName()).isEqualTo("최지훈");
+        assertThat(game.getCurrentPitcherTeam()).isEqualTo("home");
+        assertThat(game.getCurrentPitcherName()).isEqualTo("김태경");
+        assertThat(game.getFirstBaseOccupied()).isTrue();
+        assertThat(game.getSecondBaseOccupied()).isFalse();
+        assertThat(game.getThirdBaseOccupied()).isTrue();
+        assertThat(game.getBalls()).isEqualTo(1);
+        assertThat(game.getStrikes()).isEqualTo(2);
+        assertThat(game.getOuts()).isEqualTo(0);
+    }
+
+    private Game makeGame() {
+        Stadium stadium = new Stadium("잠실야구장", "잠실", "잠실", 37.5, 127.0, StadiumLevel.MAIN);
+        Team homeTeam = new Team("LG 트윈스", "LG", "LG", TeamStatus.ACTIVE);
+        Team awayTeam = new Team("두산 베어스", "두산", "OB", TeamStatus.ACTIVE);
+
+        return new Game(
+                stadium, homeTeam, awayTeam,
+                LocalDate.of(2026, 6, 21), LocalTime.of(18, 30), "20260621OBLG0",
+                null, null, null, null, null, null, GameState.LIVE
+        );
+    }
+}

--- a/backend/app/src/test/java/com/yagubogu/game/service/GameServiceTest.java
+++ b/backend/app/src/test/java/com/yagubogu/game/service/GameServiceTest.java
@@ -150,7 +150,8 @@ class GameServiceTest {
         GameResultParam expected = new GameResultParam(
                 ScoreBoardParam.from(expectedHomeScoreBoard()),
                 ScoreBoardParam.from(expectedAwayScoreBoard()),
-                "이포라", "김롯데"
+                "이포라", "김롯데",
+                new GameResultParam.LiveStateParam(null, null, null, null, null, null, null, null, null, null)
         );
 
         // when
@@ -158,6 +159,28 @@ class GameServiceTest {
 
         // then
         assertThat(scoreBoard).isEqualTo(expected);
+    }
+
+    @DisplayName("경기중인 경기는 스코어보드에 라이브 상태(타자/투수/진루/카운트)가 포함된다")
+    @Test
+    void findGameScoreBoard_WithLiveState() {
+        // given
+        LocalDate date = TestFixture.getToday();
+        Game game = makeGameWithScoreBoard(date, "HT", "LT", "잠실구장");
+        game.updateLiveBatterAndPitcher("away", "최지훈", "home", "김태경");
+        game.updateLiveBaseState(true, false, true, 1, 2, 0);
+        gameRepository.save(game);
+        long gameId = game.getId();
+
+        GameResultParam.LiveStateParam expectedLiveState = new GameResultParam.LiveStateParam(
+                "away", "최지훈", "home", "김태경", true, false, true, 1, 2, 0
+        );
+
+        // when
+        GameResultParam scoreBoard = gameService.findScoreBoard(gameId);
+
+        // then
+        assertThat(scoreBoard.liveState()).isEqualTo(expectedLiveState);
     }
 
     @DisplayName("해당 월에 경기가 있는 날짜 목록을 반환한다")

--- a/backend/crawling/src/main/java/yagubogu/crawling/game/service/crawler/KboGameCenterCrawler/GameCenterSyncService.java
+++ b/backend/crawling/src/main/java/yagubogu/crawling/game/service/crawler/KboGameCenterCrawler/GameCenterSyncService.java
@@ -1,14 +1,21 @@
 package yagubogu.crawling.game.service.crawler.KboGameCenterCrawler;
 
+import com.yagubogu.game.domain.Game;
 import com.yagubogu.game.domain.GameState;
 import com.yagubogu.game.exception.GameSyncException;
+import com.yagubogu.game.repository.GameRepository;
 import com.yagubogu.game.service.BronzeGameService;
+import com.yagubogu.stadium.domain.Stadium;
+import com.yagubogu.stadium.repository.StadiumRepository;
+import com.yagubogu.team.domain.Team;
+import com.yagubogu.team.repository.TeamRepository;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import yagubogu.crawling.game.dto.GameCenter;
 import yagubogu.crawling.game.dto.GameCenterDetail;
 
@@ -19,6 +26,9 @@ public class GameCenterSyncService {
 
     private final KboGameCenterCrawler crawler;
     private final BronzeGameService bronzeGameService;
+    private final GameRepository gameRepository;
+    private final TeamRepository teamRepository;
+    private final StadiumRepository stadiumRepository;
 
     /**
      * 특정 날짜 경기 상세 정보 수집 및 Bronze Layer 저장
@@ -36,6 +46,7 @@ public class GameCenterSyncService {
     /**
      * GameCenterDetail 리스트를 받아서 Bronze Layer에 저장
      */
+    @Transactional
     public int saveToBronzeLayer(java.util.List<GameCenterDetail> gameDetails) {
         int updatedCount = 0;
 
@@ -45,6 +56,9 @@ public class GameCenterSyncService {
                 if (updated) {
                     updatedCount++;
                 }
+
+                // 현재 타자/투수는 재처리 대상이 아니라 games 테이블에 바로 반영
+                updateLiveBatterAndPitcher(detail);
             } catch (Exception e) {
                 log.error("[BRONZE] 경기 상태 저장 실패: gameCode={}", detail.getGameCode(), e);
             }
@@ -52,6 +66,40 @@ public class GameCenterSyncService {
 
         log.info("[BRONZE] Processed {} games, {} state updates", gameDetails.size(), updatedCount);
         return updatedCount;
+    }
+
+    /**
+     * 크롤링한 현재 타자/투수를 games 테이블에 직접 반영 (Bronze/ETL을 거치지 않음)
+     */
+    private void updateLiveBatterAndPitcher(GameCenterDetail detail) {
+        LocalDate date = parseDate(detail.getGameDate());
+        String stadiumLocation = detail.getStadiumName();
+        String homeTeamName = detail.getHomeTeamName();
+        String awayTeamName = detail.getAwayTeamName();
+        LocalTime startTime = parseTime(detail.getStartTime());
+
+        Team homeTeam = teamRepository.findByShortName(homeTeamName).orElse(null);
+        Team awayTeam = teamRepository.findByShortName(awayTeamName).orElse(null);
+        Stadium stadium = stadiumRepository.findByLocation(stadiumLocation).orElse(null);
+
+        if (homeTeam == null || awayTeam == null || stadium == null) {
+            log.debug("[LIVE_STATE] Team/Stadium not found, skip batter/pitcher update: stadium={}, home={}, away={}",
+                    stadiumLocation, homeTeamName, awayTeamName);
+            return;
+        }
+
+        gameRepository.findByDateAndStadiumAndHomeTeamAndAwayTeamAndStartAt(date, stadium, homeTeam, awayTeam,
+                        startTime)
+                .ifPresentOrElse(
+                        game -> game.updateLiveBatterAndPitcher(
+                                detail.getCurrentBatterTeam(),
+                                detail.getCurrentBatterName(),
+                                detail.getCurrentPitcherTeam(),
+                                detail.getCurrentPitcherName()
+                        ),
+                        () -> log.debug("[LIVE_STATE] Game not found, skip batter/pitcher update: gameCode={}",
+                                detail.getGameCode())
+                );
     }
 
     /**

--- a/backend/crawling/src/main/java/yagubogu/crawling/game/service/crawler/KboScoardboardCrawler/KboScoreboardService.java
+++ b/backend/crawling/src/main/java/yagubogu/crawling/game/service/crawler/KboScoardboardCrawler/KboScoreboardService.java
@@ -171,6 +171,9 @@ public class KboScoreboardService {
             bronzeGameService.upsertByNaturalKey(date, stadium, homeTeamName, awayTeamName, startTime, payload);
             log.debug("[BRONZE] Saved gameCode={}, state={}", gameCode, data.getStatus());
 
+            // 진루정보/볼·스트라이크·아웃은 재처리 대상이 아니라 games 테이블에 바로 반영
+            updateLiveBaseState(gameCode, data);
+
             // 경기 종료 시 이벤트 발행 (ETL 트리거)
             GameState state = GameState.fromName(data.getStatus());
             if (state == GameState.COMPLETED || state == GameState.CANCELED) {
@@ -262,6 +265,23 @@ public class KboScoreboardService {
                 data.inningScores()
         );
         return existing;
+    }
+
+    /**
+     * 크롤링한 진루정보/볼·스트라이크·아웃을 games 테이블에 직접 반영 (Bronze/ETL을 거치지 않음)
+     */
+    private void updateLiveBaseState(String gameCode, KboScoreboardGame data) {
+        gameRepository.findByGameCode(gameCode).ifPresentOrElse(
+                game -> game.updateLiveBaseState(
+                        data.getFirstBaseOccupied(),
+                        data.getSecondBaseOccupied(),
+                        data.getThirdBaseOccupied(),
+                        data.getBalls(),
+                        data.getStrikes(),
+                        data.getOuts()
+                ),
+                () -> log.debug("[LIVE_STATE] Game not found for gameCode={}, skip base state update", gameCode)
+        );
     }
 
     /**

--- a/backend/crawling/src/test/java/yagubogu/crawling/game/service/crawler/KboGameCenterCrawler/GameCenterSyncServiceTest.java
+++ b/backend/crawling/src/test/java/yagubogu/crawling/game/service/crawler/KboGameCenterCrawler/GameCenterSyncServiceTest.java
@@ -1,0 +1,104 @@
+package yagubogu.crawling.game.service.crawler.KboGameCenterCrawler;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.yagubogu.game.domain.Game;
+import com.yagubogu.game.domain.GameState;
+import com.yagubogu.game.repository.GameRepository;
+import com.yagubogu.game.service.BronzeGameService;
+import com.yagubogu.stadium.domain.Stadium;
+import com.yagubogu.stadium.repository.StadiumRepository;
+import com.yagubogu.team.domain.Team;
+import com.yagubogu.team.repository.TeamRepository;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import yagubogu.crawling.game.dto.GameCenterDetail;
+
+class GameCenterSyncServiceTest {
+
+    @DisplayName("saveToBronzeLayer - 현재 타자/투수를 games 테이블에 직접 반영한다")
+    @Test
+    void saveToBronzeLayer_UpdatesLiveBatterAndPitcher() {
+        // given
+        GameRepository gameRepository = mock(GameRepository.class);
+        TeamRepository teamRepository = mock(TeamRepository.class);
+        StadiumRepository stadiumRepository = mock(StadiumRepository.class);
+        BronzeGameService bronzeGameService = mock(BronzeGameService.class);
+
+        Team homeTeam = mock(Team.class);
+        Team awayTeam = mock(Team.class);
+        Stadium stadium = mock(Stadium.class);
+        Game game = mock(Game.class);
+
+        when(teamRepository.findByShortName("LG")).thenReturn(Optional.of(homeTeam));
+        when(teamRepository.findByShortName("두산")).thenReturn(Optional.of(awayTeam));
+        when(stadiumRepository.findByLocation("잠실")).thenReturn(Optional.of(stadium));
+        when(gameRepository.findByDateAndStadiumAndHomeTeamAndAwayTeamAndStartAt(
+                LocalDate.of(2026, 6, 21), stadium, homeTeam, awayTeam, LocalTime.of(17, 0)
+        )).thenReturn(Optional.of(game));
+        when(bronzeGameService.updateGameState(any(), any(), any(), any(), any(), any())).thenReturn(true);
+
+        GameCenterSyncService service = new GameCenterSyncService(
+                mock(KboGameCenterCrawler.class), bronzeGameService, gameRepository, teamRepository,
+                stadiumRepository
+        );
+
+        GameCenterDetail detail = createDetail();
+
+        // when
+        service.saveToBronzeLayer(List.of(detail));
+
+        // then
+        verify(game).updateLiveBatterAndPitcher("away", "오명진", "home", "웰스");
+    }
+
+    @DisplayName("saveToBronzeLayer - 팀/구장을 찾을 수 없으면 타자/투수 갱신을 건너뛴다")
+    @Test
+    void saveToBronzeLayer_NoMatchingTeam_SkipsLiveStateUpdate() {
+        // given
+        GameRepository gameRepository = mock(GameRepository.class);
+        TeamRepository teamRepository = mock(TeamRepository.class);
+        StadiumRepository stadiumRepository = mock(StadiumRepository.class);
+        BronzeGameService bronzeGameService = mock(BronzeGameService.class);
+
+        when(teamRepository.findByShortName(org.mockito.ArgumentMatchers.anyString())).thenReturn(Optional.empty());
+        when(stadiumRepository.findByLocation(org.mockito.ArgumentMatchers.anyString())).thenReturn(Optional.empty());
+
+        GameCenterSyncService service = new GameCenterSyncService(
+                mock(KboGameCenterCrawler.class), bronzeGameService, gameRepository, teamRepository,
+                stadiumRepository
+        );
+
+        // when & then (예외 없이 정상 종료되어야 함)
+        service.saveToBronzeLayer(List.of(createDetail()));
+
+        verify(gameRepository, never()).findByDateAndStadiumAndHomeTeamAndAwayTeamAndStartAt(
+                any(), any(), any(), any(), any());
+    }
+
+    private GameCenterDetail createDetail() {
+        GameCenterDetail detail = new GameCenterDetail();
+        detail.setGameCode("20260621OBLG0");
+        detail.setGameDate("20260621");
+        detail.setStadiumName("잠실");
+        detail.setHomeTeamName("LG");
+        detail.setAwayTeamName("두산");
+        detail.setStartTime("17:00");
+        detail.setStatus("2회초");
+        detail.setGameStatus(GameState.LIVE.name());
+        detail.setCurrentBatterTeam("away");
+        detail.setCurrentBatterName("오명진");
+        detail.setCurrentPitcherTeam("home");
+        detail.setCurrentPitcherName("웰스");
+
+        return detail;
+    }
+}

--- a/backend/crawling/src/test/java/yagubogu/crawling/game/service/crawler/KboScoardboardCrawler/KboScoreboardServiceTest.java
+++ b/backend/crawling/src/test/java/yagubogu/crawling/game/service/crawler/KboScoardboardCrawler/KboScoreboardServiceTest.java
@@ -1,0 +1,120 @@
+package yagubogu.crawling.game.service.crawler.KboScoardboardCrawler;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.yagubogu.game.domain.Game;
+import com.yagubogu.game.repository.GameRepository;
+import com.yagubogu.game.service.BronzeGameService;
+import com.yagubogu.game.service.GameEtlService;
+import com.yagubogu.stadium.repository.StadiumRepository;
+import com.yagubogu.team.repository.TeamRepository;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.transaction.support.TransactionTemplate;
+import yagubogu.crawling.game.dto.KboScoreboardGame;
+import yagubogu.crawling.game.dto.KboScoreboardTeam;
+import yagubogu.crawling.game.repository.GameJdbcBatchUpsertRepository;
+
+class KboScoreboardServiceTest {
+
+    @DisplayName("updateFromScoreboard - 진루정보/카운트를 게임 라이브 상태로 반영한다")
+    @Test
+    void updateFromScoreboard_UpdatesLiveBaseState() {
+        // given
+        String gameCode = "20260621SKNC0";
+        GameRepository gameRepository = mock(GameRepository.class);
+        Game game = mock(Game.class);
+        when(gameRepository.findByGameCode(gameCode)).thenReturn(Optional.of(game));
+
+        KboScoreboardService service = new KboScoreboardService(
+                mock(KboScoreboardCrawler.class),
+                mock(KboScoreboardMapper.class),
+                mock(GameJdbcBatchUpsertRepository.class),
+                mock(TeamRepository.class),
+                mock(StadiumRepository.class),
+                mock(TransactionTemplate.class),
+                mock(TransactionTemplate.class),
+                gameRepository,
+                mock(BronzeGameService.class),
+                mock(GameEtlService.class),
+                createObjectMapper(),
+                mock(ApplicationEventPublisher.class)
+        );
+
+        KboScoreboardGame data = createScoreboardGame();
+        data.setFirstBaseOccupied(true);
+        data.setSecondBaseOccupied(true);
+        data.setThirdBaseOccupied(false);
+        data.setBalls(1);
+        data.setStrikes(2);
+        data.setOuts(0);
+
+        // when
+        service.updateFromScoreboard(gameCode, data);
+
+        // then
+        verify(game).updateLiveBaseState(true, true, false, 1, 2, 0);
+    }
+
+    @DisplayName("updateFromScoreboard - gameCode에 해당하는 Game이 없으면 라이브 상태 갱신을 건너뛴다")
+    @Test
+    void updateFromScoreboard_NoMatchingGame_SkipsLiveStateUpdate() {
+        // given
+        String gameCode = "20260621SKNC0";
+        GameRepository gameRepository = mock(GameRepository.class);
+        when(gameRepository.findByGameCode(gameCode)).thenReturn(Optional.empty());
+
+        KboScoreboardService service = new KboScoreboardService(
+                mock(KboScoreboardCrawler.class),
+                mock(KboScoreboardMapper.class),
+                mock(GameJdbcBatchUpsertRepository.class),
+                mock(TeamRepository.class),
+                mock(StadiumRepository.class),
+                mock(TransactionTemplate.class),
+                mock(TransactionTemplate.class),
+                gameRepository,
+                mock(BronzeGameService.class),
+                mock(GameEtlService.class),
+                createObjectMapper(),
+                mock(ApplicationEventPublisher.class)
+        );
+
+        // when & then (예외 없이 정상 종료되어야 함)
+        service.updateFromScoreboard(gameCode, createScoreboardGame());
+    }
+
+    private ObjectMapper createObjectMapper() {
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+        return objectMapper;
+    }
+
+    private KboScoreboardGame createScoreboardGame() {
+        KboScoreboardTeam awayTeam = new KboScoreboardTeam("SSG", 0, 0, 0, 0, List.of());
+        KboScoreboardTeam homeTeam = new KboScoreboardTeam("NC", 0, 0, 0, 0, List.of());
+
+        return new KboScoreboardGame(
+                LocalDate.of(2026, 6, 21),
+                "4회초",
+                "창원",
+                LocalTime.of(17, 0),
+                null,
+                awayTeam,
+                homeTeam,
+                1,
+                0,
+                null,
+                null,
+                null
+        );
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈
- feat/1097의 후속 작업입니다. 파일 수가 많아서 pr을 분리했어요. 

## ✨ 변경 내용
- `games` 테이블에 라이브 상태(현재 타자/투수, 진루정보, 볼/스트라이크/아웃) 컬럼을 추가했습니다.
- 스코어보드 라이브 폴링(`AdaptivePoller` → `updateFromScoreboard`)과 게임센터 크롤링(`GameCenterSyncService`) 결과를 `games` 테이블에 직접 반영하도록 구현했습니다.
- `GameResultParam`에 `liveState`를 추가하고, 기존에 컨트롤러 엔드포인트가 없던 `GameService.findScoreBoard`를 `GET /games/{gameId}/score-board`로 노출했습니다.

## 🎸 기타 참고 사항
- 라이브 상태는 경기 진행에 따라 계속 덮어써지는 값이라 Bronze 재처리(ETL) 대상에서 빼고 `games` 테이블에 직접 쓰는 방식으로 설계했습니다.

## DB Migration
- 참고) DB에 저장하지 않으면 동시에 조회하는 사용자 수만큼 크롤링이 발생합니다. 그래서 서버가 주기적으로 한 번만 크롤링해서 DB에 저장해두고, 사용자는 DB에서만 조회하도록 구현했습니다.

```sql
-- 경기중 실시간 상태(현재 타자/투수, 진루정보, 볼/스트라이크/아웃)
-- 경기 진행에 따라 계속 덮어써지는 값이라 Bronze 재처리 대상이 아니라 games 테이블에 직접 반영함
ALTER TABLE games
    ADD COLUMN current_batter_team    VARCHAR(10) NULL,
    ADD COLUMN current_batter_name    VARCHAR(50) NULL,
    ADD COLUMN current_pitcher_team   VARCHAR(10) NULL,
    ADD COLUMN current_pitcher_name   VARCHAR(50) NULL,
    ADD COLUMN first_base_occupied    BOOLEAN     NULL,
    ADD COLUMN second_base_occupied   BOOLEAN     NULL,
    ADD COLUMN third_base_occupied    BOOLEAN     NULL,
    ADD COLUMN balls                  TINYINT     NULL,
    ADD COLUMN strikes                TINYINT     NULL,
    ADD COLUMN outs                   TINYINT     NULL;
```