### PR TITLE
feat: 스코어보드에서 볼/스트라이크/아웃 카운트 추출

### DIFF
--- a/backend/app/src/main/java/com/yagubogu/game/scheduler/GameEtlScheduler.java
+++ b/backend/app/src/main/java/com/yagubogu/game/scheduler/GameEtlScheduler.java
@@ -14,7 +14,7 @@ import org.springframework.stereotype.Component;
  *
  * 설계 원칙:
  * - 크롤링: 1분마다 (실시간성)
- * - ETL: 1분마다 (실시간성)
+ * - ETL: 30초마다 (위젯 최신성)
  * - 경기 종료 시: 즉시 ETL (중요한 순간)
  * - 더블헤더 처리: ETL 후 같은 날짜 경기들의 순서 재정렬
  */
@@ -27,13 +27,13 @@ public class GameEtlScheduler {
     private final Clock clock;
 
     /**
-     * 1분마다 Bronze → Silver ETL 실행
+     * 30초마다 Bronze → Silver ETL 실행
      *
-     * 실시간 점수 제공을 위해 1분 주기 적용
-     * Bronze가 1분마다 갱신되므로 ETL도 1분마다 실행
+     * 위젯 실시간 점수 제공을 위해 30초 주기 적용
+     * Bronze 수집 주기보다 짧게 실행해 반영 지연을 줄임
      * ETL 중에 날짜별로 더블헤더 순서가 자동 계산됨
      */
-    @Scheduled(fixedDelay = 60_000, initialDelay = 10_000) // 1분 = 60,000ms
+    @Scheduled(fixedDelay = 30_000, initialDelay = 10_000)
     public void runEtlPeriodically() {
         log.info("[ETL] Starting periodic Bronze → Silver transformation");
 
@@ -48,4 +48,3 @@ public class GameEtlScheduler {
         }
     }
 }
-

--- a/backend/crawling/src/main/java/yagubogu/crawling/game/config/CrawlerSchedulerProperties.java
+++ b/backend/crawling/src/main/java/yagubogu/crawling/game/config/CrawlerSchedulerProperties.java
@@ -9,7 +9,7 @@ import org.springframework.format.annotation.DateTimeFormat;
 
 @Getter
 @Setter
-@ConfigurationProperties(prefix = "crawler.scheduler")
+@ConfigurationProperties(prefix = "kbo.scheduler")
 public class CrawlerSchedulerProperties {
 
     @DateTimeFormat(pattern = "HH:mm")

--- a/backend/crawling/src/main/java/yagubogu/crawling/game/config/KboCrawlerProperties.java
+++ b/backend/crawling/src/main/java/yagubogu/crawling/game/config/KboCrawlerProperties.java
@@ -82,6 +82,7 @@ public class KboCrawlerProperties {
         private String boxScoreLink;
         private ScoreTableSelectors scoreTable;
         private PitcherSelectors pitcher;
+        private BaseSelectors base;
     }
 
     @Getter
@@ -105,6 +106,15 @@ public class KboCrawlerProperties {
     public static class PitcherSelectors {
         private String container;
         private String spans;
+    }
+
+    @Getter
+    @Setter
+    public static class BaseSelectors {
+        private String container;
+        private String first;
+        private String second;
+        private String third;
     }
 
     @Getter

--- a/backend/crawling/src/main/java/yagubogu/crawling/game/config/KboCrawlerProperties.java
+++ b/backend/crawling/src/main/java/yagubogu/crawling/game/config/KboCrawlerProperties.java
@@ -115,6 +115,7 @@ public class KboCrawlerProperties {
         private String first;
         private String second;
         private String third;
+        private String count;
     }
 
     @Getter
@@ -123,5 +124,6 @@ public class KboCrawlerProperties {
         private String pitcherLabel;
         private String dateFormat;
         private String timeFormat;
+        private String countLabel;
     }
 }

--- a/backend/crawling/src/main/java/yagubogu/crawling/game/dto/GameCenterDetail.java
+++ b/backend/crawling/src/main/java/yagubogu/crawling/game/dto/GameCenterDetail.java
@@ -1,6 +1,5 @@
 package yagubogu.crawling.game.dto;
 
-import java.util.List;
 import lombok.Data;
 
 @Data
@@ -34,8 +33,10 @@ public class GameCenterDetail {
     private String homeScore;
     private String winner;  // "away" or "home"
 
-    // 투수 정보
-    private List<String> awayPitchers;
-    private List<String> homePitchers;
+    // 현재 타자/투수
+    // .today-pitcher는 공격중인 팀에서는 타자, 수비중인 팀에서는 투수를 나타냄 (이닝 초/말로 판별)
+    private String currentBatterTeam;  // "away" or "home"
+    private String currentBatterName;
+    private String currentPitcherTeam; // "away" or "home"
+    private String currentPitcherName;
 }
-

--- a/backend/crawling/src/main/java/yagubogu/crawling/game/dto/KboScoreboardGame.java
+++ b/backend/crawling/src/main/java/yagubogu/crawling/game/dto/KboScoreboardGame.java
@@ -22,6 +22,11 @@ public final class KboScoreboardGame {
     private final String savingPitcher;
     private final String losingPitcher;
 
+    // 진루정보 (경기중이 아니면 null)
+    private Boolean firstBaseOccupied;
+    private Boolean secondBaseOccupied;
+    private Boolean thirdBaseOccupied;
+
     public KboScoreboardGame(
             LocalDate date,
             String status,

--- a/backend/crawling/src/main/java/yagubogu/crawling/game/dto/KboScoreboardGame.java
+++ b/backend/crawling/src/main/java/yagubogu/crawling/game/dto/KboScoreboardGame.java
@@ -27,6 +27,11 @@ public final class KboScoreboardGame {
     private Boolean secondBaseOccupied;
     private Boolean thirdBaseOccupied;
 
+    // 볼/스트라이크/아웃 카운트 (경기중이 아니면 null)
+    private Integer balls;
+    private Integer strikes;
+    private Integer outs;
+
     public KboScoreboardGame(
             LocalDate date,
             String status,

--- a/backend/crawling/src/main/java/yagubogu/crawling/game/service/crawler/page/KboGameCenterPage.java
+++ b/backend/crawling/src/main/java/yagubogu/crawling/game/service/crawler/page/KboGameCenterPage.java
@@ -4,7 +4,6 @@ import com.microsoft.playwright.Locator;
 import com.microsoft.playwright.Page;
 import com.microsoft.playwright.TimeoutError;
 import com.microsoft.playwright.options.WaitForSelectorState;
-import java.util.ArrayList;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import yagubogu.crawling.game.config.KboCrawlerProperties;
@@ -222,14 +221,12 @@ public class KboGameCenterPage extends BaseKboPage {
     }
 
     private List<String> extractPitchers(Locator teamElement) {
-        Locator pitchers = teamElement.locator(".today-pitcher p");
-        List<String> pitcherList = new ArrayList<>();
-
-        for (int i = 0; i < pitchers.count(); i++) {
-            String pitcherInfo = pitchers.nth(i).textContent().trim();
-            pitcherList.add(pitcherInfo);
+        Locator pitcherElem = teamElement.locator(".today-pitcher");
+        if (pitcherElem.count() == 0) {
+            return List.of();
         }
 
-        return pitcherList;
+        String pitcherName = pitcherElem.textContent().trim();
+        return pitcherName.isEmpty() ? List.of() : List.of(pitcherName);
     }
 }

--- a/backend/crawling/src/main/java/yagubogu/crawling/game/service/crawler/page/KboGameCenterPage.java
+++ b/backend/crawling/src/main/java/yagubogu/crawling/game/service/crawler/page/KboGameCenterPage.java
@@ -129,6 +129,8 @@ public class KboGameCenterPage extends BaseKboPage {
             gameCenter.setGameStatus("경기종료");
         } else if (classAttr.contains("cancel")) {
             gameCenter.setGameStatus("경기취소");
+        } else if (classAttr.contains("ing")) {
+            gameCenter.setGameStatus("경기중");
         } else {
             gameCenter.setGameStatus("경기예정");
         }

--- a/backend/crawling/src/main/java/yagubogu/crawling/game/service/crawler/page/KboGameCenterPage.java
+++ b/backend/crawling/src/main/java/yagubogu/crawling/game/service/crawler/page/KboGameCenterPage.java
@@ -4,7 +4,6 @@ import com.microsoft.playwright.Locator;
 import com.microsoft.playwright.Page;
 import com.microsoft.playwright.TimeoutError;
 import com.microsoft.playwright.options.WaitForSelectorState;
-import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import yagubogu.crawling.game.config.KboCrawlerProperties;
 import yagubogu.crawling.game.dto.GameCenterDetail;
@@ -172,11 +171,21 @@ public class KboGameCenterPage extends BaseKboPage {
     }
 
     private void extractTeamInfo(Locator gameElement, GameCenterDetail gameCenter) {
-        extractAwayTeamInfo(gameElement, gameCenter);
-        extractHomeTeamInfo(gameElement, gameCenter);
+        boolean isTopInning = isTopInning(gameCenter.getStatus());
+        extractAwayTeamInfo(gameElement, gameCenter, isTopInning);
+        extractHomeTeamInfo(gameElement, gameCenter, isTopInning);
     }
 
-    private void extractAwayTeamInfo(Locator gameElement, GameCenterDetail gameCenter) {
+    /**
+     * 이닝 초(원정팀 공격)/말(홈팀 공격) 여부.
+     * .today-pitcher는 공격중인 팀에서는 타자, 수비중인 팀에서는 투수를 나타내므로
+     * 어느 팀에 어떤 의미를 부여할지 이걸로 판별한다.
+     */
+    private boolean isTopInning(String status) {
+        return status != null && status.contains("초");
+    }
+
+    private void extractAwayTeamInfo(Locator gameElement, GameCenterDetail gameCenter, boolean isTopInning) {
         Locator awayTeam = gameElement.locator(".team.away");
         if (awayTeam.count() == 0) {
             return;
@@ -193,12 +202,20 @@ public class KboGameCenterPage extends BaseKboPage {
             }
         }
 
-        // 투수 정보
-        List<String> awayPitchers = extractPitchers(awayTeam);
-        gameCenter.setAwayPitchers(awayPitchers);
+        // 현재 타자/투수: 초(원정팀 공격)면 타자, 아니면 투수
+        String todayPlayer = extractTodayPlayer(awayTeam);
+        if (todayPlayer != null) {
+            if (isTopInning) {
+                gameCenter.setCurrentBatterTeam("away");
+                gameCenter.setCurrentBatterName(todayPlayer);
+            } else {
+                gameCenter.setCurrentPitcherTeam("away");
+                gameCenter.setCurrentPitcherName(todayPlayer);
+            }
+        }
     }
 
-    private void extractHomeTeamInfo(Locator gameElement, GameCenterDetail gameCenter) {
+    private void extractHomeTeamInfo(Locator gameElement, GameCenterDetail gameCenter, boolean isTopInning) {
         Locator homeTeam = gameElement.locator(".team.home");
         if (homeTeam.count() == 0) {
             return;
@@ -215,18 +232,26 @@ public class KboGameCenterPage extends BaseKboPage {
             }
         }
 
-        // 투수 정보
-        List<String> homePitchers = extractPitchers(homeTeam);
-        gameCenter.setHomePitchers(homePitchers);
+        // 현재 타자/투수: 말(홈팀 공격)이면 타자, 아니면 투수
+        String todayPlayer = extractTodayPlayer(homeTeam);
+        if (todayPlayer != null) {
+            if (!isTopInning) {
+                gameCenter.setCurrentBatterTeam("home");
+                gameCenter.setCurrentBatterName(todayPlayer);
+            } else {
+                gameCenter.setCurrentPitcherTeam("home");
+                gameCenter.setCurrentPitcherName(todayPlayer);
+            }
+        }
     }
 
-    private List<String> extractPitchers(Locator teamElement) {
+    private String extractTodayPlayer(Locator teamElement) {
         Locator pitcherElem = teamElement.locator(".today-pitcher");
         if (pitcherElem.count() == 0) {
-            return List.of();
+            return null;
         }
 
-        String pitcherName = pitcherElem.textContent().trim();
-        return pitcherName.isEmpty() ? List.of() : List.of(pitcherName);
+        String text = pitcherElem.textContent().trim();
+        return text.isEmpty() ? null : text;
     }
 }

--- a/backend/crawling/src/main/java/yagubogu/crawling/game/service/crawler/page/KboGameCenterPage.java
+++ b/backend/crawling/src/main/java/yagubogu/crawling/game/service/crawler/page/KboGameCenterPage.java
@@ -173,21 +173,35 @@ public class KboGameCenterPage extends BaseKboPage {
     }
 
     private void extractTeamInfo(Locator gameElement, GameCenterDetail gameCenter) {
-        boolean isTopInning = isTopInning(gameCenter.getStatus());
-        extractAwayTeamInfo(gameElement, gameCenter, isTopInning);
-        extractHomeTeamInfo(gameElement, gameCenter, isTopInning);
+        InningHalf inningHalf = parseInningHalf(gameCenter.getStatus());
+        extractAwayTeamInfo(gameElement, gameCenter, inningHalf);
+        extractHomeTeamInfo(gameElement, gameCenter, inningHalf);
     }
 
     /**
      * 이닝 초(원정팀 공격)/말(홈팀 공격) 여부.
      * .today-pitcher는 공격중인 팀에서는 타자, 수비중인 팀에서는 투수를 나타내므로
      * 어느 팀에 어떤 의미를 부여할지 이걸로 판별한다.
+     * status에 초/말이 없는 경우(경기예정/종료 등)는 UNKNOWN으로 두고 배정을 건너뛴다.
      */
-    private boolean isTopInning(String status) {
-        return status != null && status.contains("초");
+    private enum InningHalf {
+        TOP, BOTTOM, UNKNOWN
     }
 
-    private void extractAwayTeamInfo(Locator gameElement, GameCenterDetail gameCenter, boolean isTopInning) {
+    private InningHalf parseInningHalf(String status) {
+        if (status == null) {
+            return InningHalf.UNKNOWN;
+        }
+        if (status.contains("초")) {
+            return InningHalf.TOP;
+        }
+        if (status.contains("말")) {
+            return InningHalf.BOTTOM;
+        }
+        return InningHalf.UNKNOWN;
+    }
+
+    private void extractAwayTeamInfo(Locator gameElement, GameCenterDetail gameCenter, InningHalf inningHalf) {
         Locator awayTeam = gameElement.locator(".team.away");
         if (awayTeam.count() == 0) {
             return;
@@ -204,20 +218,20 @@ public class KboGameCenterPage extends BaseKboPage {
             }
         }
 
-        // 현재 타자/투수: 초(원정팀 공격)면 타자, 아니면 투수
+        // 현재 타자/투수: 초(원정팀 공격)면 타자, 말이면 투수, 알 수 없으면 배정하지 않음
         String todayPlayer = extractTodayPlayer(awayTeam);
         if (todayPlayer != null) {
-            if (isTopInning) {
+            if (inningHalf == InningHalf.TOP) {
                 gameCenter.setCurrentBatterTeam("away");
                 gameCenter.setCurrentBatterName(todayPlayer);
-            } else {
+            } else if (inningHalf == InningHalf.BOTTOM) {
                 gameCenter.setCurrentPitcherTeam("away");
                 gameCenter.setCurrentPitcherName(todayPlayer);
             }
         }
     }
 
-    private void extractHomeTeamInfo(Locator gameElement, GameCenterDetail gameCenter, boolean isTopInning) {
+    private void extractHomeTeamInfo(Locator gameElement, GameCenterDetail gameCenter, InningHalf inningHalf) {
         Locator homeTeam = gameElement.locator(".team.home");
         if (homeTeam.count() == 0) {
             return;
@@ -234,13 +248,13 @@ public class KboGameCenterPage extends BaseKboPage {
             }
         }
 
-        // 현재 타자/투수: 말(홈팀 공격)이면 타자, 아니면 투수
+        // 현재 타자/투수: 말(홈팀 공격)이면 타자, 초면 투수, 알 수 없으면 배정하지 않음
         String todayPlayer = extractTodayPlayer(homeTeam);
         if (todayPlayer != null) {
-            if (!isTopInning) {
+            if (inningHalf == InningHalf.BOTTOM) {
                 gameCenter.setCurrentBatterTeam("home");
                 gameCenter.setCurrentBatterName(todayPlayer);
-            } else {
+            } else if (inningHalf == InningHalf.TOP) {
                 gameCenter.setCurrentPitcherTeam("home");
                 gameCenter.setCurrentPitcherName(todayPlayer);
             }

--- a/backend/crawling/src/main/java/yagubogu/crawling/game/service/crawler/page/KboScoreboardPage.java
+++ b/backend/crawling/src/main/java/yagubogu/crawling/game/service/crawler/page/KboScoreboardPage.java
@@ -126,7 +126,7 @@ public class KboScoreboardPage extends BaseKboPage {
         // 투수 정보 파싱
         Pitcher pitcher = parsePitcher(scoreboard);
 
-        return Optional.of(new KboScoreboardGame(
+        KboScoreboardGame game = new KboScoreboardGame(
                 date,
                 emptyToNull(status),
                 emptyToNull(stadium),
@@ -139,7 +139,35 @@ public class KboScoreboardPage extends BaseKboPage {
                 pitcher.winning(),
                 pitcher.saving(),
                 pitcher.losing()
-        ));
+        );
+
+        // 진루정보 (경기중이 아니면 .base 자체가 없어서 모두 null로 남음)
+        parseBaseOccupancy(scoreboard, game);
+
+        return Optional.of(game);
+    }
+
+    private void parseBaseOccupancy(ElementHandle scoreboard, KboScoreboardGame game) {
+        var baseSelectors = properties.getSelectors().getScoreboard().getBase();
+
+        ElementHandle container = queryCSS(scoreboard, baseSelectors.getContainer());
+        if (container == null) {
+            return;
+        }
+
+        game.setFirstBaseOccupied(isBaseOccupied(scoreboard, baseSelectors.getFirst()));
+        game.setSecondBaseOccupied(isBaseOccupied(scoreboard, baseSelectors.getSecond()));
+        game.setThirdBaseOccupied(isBaseOccupied(scoreboard, baseSelectors.getThird()));
+    }
+
+    private Boolean isBaseOccupied(ElementHandle scoreboard, String selector) {
+        ElementHandle img = queryCSS(scoreboard, selector);
+        if (img == null) {
+            return null;
+        }
+
+        String src = img.getAttribute("src");
+        return src != null && src.contains("base_on");
     }
 
     // ==================== 내부 파싱 메서드 ====================

--- a/backend/crawling/src/main/java/yagubogu/crawling/game/service/crawler/page/KboScoreboardPage.java
+++ b/backend/crawling/src/main/java/yagubogu/crawling/game/service/crawler/page/KboScoreboardPage.java
@@ -25,11 +25,13 @@ import yagubogu.crawling.game.dto.KboScoreboardTeam;
 public class KboScoreboardPage extends BaseKboPage {
 
     private final Pattern pitcherPattern;
+    private final Pattern countPattern;
     private final DateTimeFormatter timeFormatter;
 
     public KboScoreboardPage(Page page, KboCrawlerProperties properties) {
         super(page, properties);
         this.pitcherPattern = Pattern.compile(properties.getPatterns().getPitcherLabel());
+        this.countPattern = Pattern.compile(properties.getPatterns().getCountLabel());
         this.timeFormatter = DateTimeFormatter.ofPattern(properties.getPatterns().getTimeFormat());
     }
 
@@ -141,8 +143,9 @@ public class KboScoreboardPage extends BaseKboPage {
                 pitcher.losing()
         );
 
-        // 진루정보 (경기중이 아니면 .base 자체가 없어서 모두 null로 남음)
+        // 진루정보 및 볼/스트라이크/아웃 (경기중이 아니면 .base 자체가 없어서 모두 null로 남음)
         parseBaseOccupancy(scoreboard, game);
+        parseCount(scoreboard, game);
 
         return Optional.of(game);
     }
@@ -168,6 +171,25 @@ public class KboScoreboardPage extends BaseKboPage {
 
         String src = img.getAttribute("src");
         return src != null && src.contains("base_on");
+    }
+
+    private void parseCount(ElementHandle scoreboard, KboScoreboardGame game) {
+        var baseSelectors = properties.getSelectors().getScoreboard().getBase();
+
+        ElementHandle countElem = queryCSS(scoreboard, baseSelectors.getCount());
+        if (countElem == null) {
+            return;
+        }
+
+        String text = countElem.innerText().replace('\u00A0', ' ').trim();
+        Matcher matcher = countPattern.matcher(text);
+        if (!matcher.find()) {
+            return;
+        }
+
+        game.setBalls(Integer.parseInt(matcher.group(1)));
+        game.setStrikes(Integer.parseInt(matcher.group(2)));
+        game.setOuts(Integer.parseInt(matcher.group(3)));
     }
 
     // ==================== 내부 파싱 메서드 ====================

--- a/backend/crawling/src/main/resources/application.yml
+++ b/backend/crawling/src/main/resources/application.yml
@@ -94,16 +94,18 @@ kbo:
         container: ".score_wrap p.win"
         spans: "span"
 
-      # 진루정보 (경기중이 아니면 .base 자체가 없음)
+      # 진루정보 및 볼/스트라이크/아웃 (경기중이 아니면 .base 자체가 없음)
       base:
         container: ".score_wrap .base"
         first: ".base1 img"
         second: ".base2 img"
         third: ".base3 img"
+        count: ".base > p"
 
   # 정규표현식 패턴
   patterns:
     pitcherLabel: "^\\s*(승|세|패)\\s*[:：]\\s*(.+?)\\s*$"
+    countLabel: "(\\d+)-(\\d+)\\s*(\\d+)out"
     dateFormat: "yyyy.MM.dd"
     timeFormat: "HH:mm"
 

--- a/backend/crawling/src/main/resources/application.yml
+++ b/backend/crawling/src/main/resources/application.yml
@@ -94,6 +94,13 @@ kbo:
         container: ".score_wrap p.win"
         spans: "span"
 
+      # 진루정보 (경기중이 아니면 .base 자체가 없음)
+      base:
+        container: ".score_wrap .base"
+        first: ".base1 img"
+        second: ".base2 img"
+        third: ".base3 img"
+
   # 정규표현식 패턴
   patterns:
     pitcherLabel: "^\\s*(승|세|패)\\s*[:：]\\s*(.+?)\\s*$"

--- a/backend/crawling/src/test/java/yagubogu/crawling/game/service/crawler/KboGameCenterCrawlerTest.java
+++ b/backend/crawling/src/test/java/yagubogu/crawling/game/service/crawler/KboGameCenterCrawlerTest.java
@@ -302,7 +302,7 @@ class KboGameCenterCrawlerTest {
         lenient().when(scoreLocator.textContent()).thenReturn(score);
         lenient().when(scoreLocator.getAttribute("class")).thenReturn("score");
 
-        lenient().when(teamLocator.locator(".today-pitcher p")).thenReturn(pitcherLocator);
+        lenient().when(teamLocator.locator(".today-pitcher")).thenReturn(pitcherLocator);
         lenient().when(pitcherLocator.count()).thenReturn(0);
     }
 }

--- a/backend/crawling/src/test/java/yagubogu/crawling/game/service/crawler/KboScoreboardCrawlerTest.java
+++ b/backend/crawling/src/test/java/yagubogu/crawling/game/service/crawler/KboScoreboardCrawlerTest.java
@@ -65,6 +65,9 @@ class KboScoreboardCrawlerTest {
     @Mock
     private KboCrawlerProperties.PitcherSelectors mockPitcherSelectors;
 
+    @Mock
+    private KboCrawlerProperties.BaseSelectors mockBaseSelectors;
+
     @BeforeEach
     void setUp() {
         lenient().when(mockProperties.getCrawler()).thenReturn(mockCrawlerConfig);
@@ -100,6 +103,13 @@ class KboScoreboardCrawlerTest {
         lenient().when(mockScoreboardSelectors.getAwayTeam()).thenReturn(mockAwayTeamSelectors);
         lenient().when(mockScoreboardSelectors.getScoreTable()).thenReturn(mockScoreTableSelectors);
         lenient().when(mockScoreboardSelectors.getPitcher()).thenReturn(mockPitcherSelectors);
+        lenient().when(mockScoreboardSelectors.getBase()).thenReturn(mockBaseSelectors);
+
+        // BaseSelectors 설정 (테스트 픽스처에는 .base가 없어서 항상 매칭되지 않음)
+        lenient().when(mockBaseSelectors.getContainer()).thenReturn(".base");
+        lenient().when(mockBaseSelectors.getFirst()).thenReturn(".base1 img");
+        lenient().when(mockBaseSelectors.getSecond()).thenReturn(".base2 img");
+        lenient().when(mockBaseSelectors.getThird()).thenReturn(".base3 img");
 
         //  TeamSelectors 내부 설정
         lenient().when(mockHomeTeamSelectors.getName()).thenReturn(".home-team .name");

--- a/backend/crawling/src/test/java/yagubogu/crawling/game/service/crawler/KboScoreboardCrawlerTest.java
+++ b/backend/crawling/src/test/java/yagubogu/crawling/game/service/crawler/KboScoreboardCrawlerTest.java
@@ -110,6 +110,7 @@ class KboScoreboardCrawlerTest {
         lenient().when(mockBaseSelectors.getFirst()).thenReturn(".base1 img");
         lenient().when(mockBaseSelectors.getSecond()).thenReturn(".base2 img");
         lenient().when(mockBaseSelectors.getThird()).thenReturn(".base3 img");
+        lenient().when(mockBaseSelectors.getCount()).thenReturn(".base > p");
 
         //  TeamSelectors 내부 설정
         lenient().when(mockHomeTeamSelectors.getName()).thenReturn(".home-team .name");
@@ -130,6 +131,7 @@ class KboScoreboardCrawlerTest {
         lenient().when(mockPatterns.getDateFormat()).thenReturn("yyyy.MM.dd");
         lenient().when(mockPatterns.getTimeFormat()).thenReturn("HH:mm");
         lenient().when(mockPatterns.getPitcherLabel()).thenReturn("(승|패|세)\\s+(.+)");
+        lenient().when(mockPatterns.getCountLabel()).thenReturn("(\\d+)-(\\d+)\\s*(\\d+)out");
 
         crawler = new KboScoreboardCrawler(mockProperties, mockPlaywrightManager);
     }

--- a/backend/crawling/src/test/java/yagubogu/crawling/game/service/crawler/page/KboGameCenterPageTest.java
+++ b/backend/crawling/src/test/java/yagubogu/crawling/game/service/crawler/page/KboGameCenterPageTest.java
@@ -137,6 +137,41 @@ class KboGameCenterPageTest {
             assertThat(result.getGameStatus()).isEqualTo("경기예정");
         }
 
+        @Test
+        @DisplayName("extractGameDetail - 이닝(초/말)을 알 수 없으면 today-pitcher가 있어도 타자/투수로 배정하지 않음")
+        void extractGameDetail_UnknownInning_DoesNotAssignBatterOrPitcher() {
+            // Given
+            Locator gameElement = createMinimalGameElement("game-cont end");
+
+            Locator awayTeam = mock(Locator.class);
+            lenient().when(awayTeam.count()).thenReturn(1);
+            lenient().when(awayTeam.locator(".score")).thenReturn(mock(Locator.class));
+            Locator awayTodayPitcher = mock(Locator.class);
+            lenient().when(awayTodayPitcher.count()).thenReturn(1);
+            lenient().when(awayTodayPitcher.textContent()).thenReturn("선발투수A");
+            lenient().when(awayTeam.locator(".today-pitcher")).thenReturn(awayTodayPitcher);
+            lenient().when(gameElement.locator(".team.away")).thenReturn(awayTeam);
+
+            Locator homeTeam = mock(Locator.class);
+            lenient().when(homeTeam.count()).thenReturn(1);
+            lenient().when(homeTeam.locator(".score")).thenReturn(mock(Locator.class));
+            Locator homeTodayPitcher = mock(Locator.class);
+            lenient().when(homeTodayPitcher.count()).thenReturn(1);
+            lenient().when(homeTodayPitcher.textContent()).thenReturn("선발투수B");
+            lenient().when(homeTeam.locator(".today-pitcher")).thenReturn(homeTodayPitcher);
+            lenient().when(gameElement.locator(".team.home")).thenReturn(homeTeam);
+
+            // When
+            GameCenterDetail result = gameCenterPage.extractGameDetail(gameElement, "20260621");
+
+            // Then
+            assertThat(result).isNotNull();
+            assertThat(result.getCurrentBatterTeam()).isNull();
+            assertThat(result.getCurrentBatterName()).isNull();
+            assertThat(result.getCurrentPitcherTeam()).isNull();
+            assertThat(result.getCurrentPitcherName()).isNull();
+        }
+
         private Locator createMinimalGameElement(String classAttr) {
             Locator gameElement = mock(Locator.class);
             lenient().when(gameElement.getAttribute("class")).thenReturn(classAttr);

--- a/backend/crawling/src/test/java/yagubogu/crawling/game/service/crawler/page/KboGameCenterPageTest.java
+++ b/backend/crawling/src/test/java/yagubogu/crawling/game/service/crawler/page/KboGameCenterPageTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import yagubogu.crawling.game.config.KboCrawlerProperties;
+import yagubogu.crawling.game.dto.GameCenterDetail;
 
 @ExtendWith(MockitoExtension.class)
 class KboGameCenterPageTest {
@@ -87,6 +88,66 @@ class KboGameCenterPageTest {
 
             // Then
             assertThat(count).isEqualTo(5);
+        }
+    }
+
+    @Nested
+    @DisplayName("경기 상세 정보 추출 테스트")
+    class ExtractGameDetailTests {
+
+        @Test
+        @DisplayName("extractGameDetail - class에 ing가 있으면 gameStatus는 경기중")
+        void extractGameDetail_InProgress_SetsGameStatusInProgress() {
+            // Given
+            Locator gameElement = createMinimalGameElement("game-cont ing");
+
+            // When
+            GameCenterDetail result = gameCenterPage.extractGameDetail(gameElement, "20260621");
+
+            // Then
+            assertThat(result).isNotNull();
+            assertThat(result.getGameStatus()).isEqualTo("경기중");
+        }
+
+        @Test
+        @DisplayName("extractGameDetail - class에 end가 있으면 gameStatus는 경기종료")
+        void extractGameDetail_Ended_SetsGameStatusEnded() {
+            // Given
+            Locator gameElement = createMinimalGameElement("game-cont end");
+
+            // When
+            GameCenterDetail result = gameCenterPage.extractGameDetail(gameElement, "20260621");
+
+            // Then
+            assertThat(result).isNotNull();
+            assertThat(result.getGameStatus()).isEqualTo("경기종료");
+        }
+
+        @Test
+        @DisplayName("extractGameDetail - end/cancel/ing 모두 없으면 gameStatus는 경기예정")
+        void extractGameDetail_Scheduled_SetsGameStatusScheduled() {
+            // Given
+            Locator gameElement = createMinimalGameElement("game-cont");
+
+            // When
+            GameCenterDetail result = gameCenterPage.extractGameDetail(gameElement, "20260621");
+
+            // Then
+            assertThat(result).isNotNull();
+            assertThat(result.getGameStatus()).isEqualTo("경기예정");
+        }
+
+        private Locator createMinimalGameElement(String classAttr) {
+            Locator gameElement = mock(Locator.class);
+            lenient().when(gameElement.getAttribute("class")).thenReturn(classAttr);
+
+            lenient().when(gameElement.locator(".top > ul > li")).thenReturn(mock(Locator.class));
+            lenient().when(gameElement.locator(".middle .broadcasting")).thenReturn(mock(Locator.class));
+            lenient().when(gameElement.locator(".middle .staus")).thenReturn(mock(Locator.class));
+            lenient().when(gameElement.locator(".team.away")).thenReturn(mock(Locator.class));
+            lenient().when(gameElement.locator(".team.home")).thenReturn(mock(Locator.class));
+
+            return gameElement;
         }
     }
 

--- a/backend/crawling/src/test/java/yagubogu/crawling/game/service/crawler/page/KboScoreboardPageTest.java
+++ b/backend/crawling/src/test/java/yagubogu/crawling/game/service/crawler/page/KboScoreboardPageTest.java
@@ -62,6 +62,9 @@ class KboScoreboardPageTest {
     private KboCrawlerProperties.PitcherSelectors mockPitcherSelectors;
 
     @Mock
+    private KboCrawlerProperties.BaseSelectors mockBaseSelectors;
+
+    @Mock
     private KboCrawlerProperties.CalendarSelectors mockCalendarSelectors;
 
     @Mock
@@ -100,6 +103,7 @@ class KboScoreboardPageTest {
         lenient().when(mockScoreboardSelectors.getAwayTeam()).thenReturn(mockAwayTeamSelectors);
         lenient().when(mockScoreboardSelectors.getScoreTable()).thenReturn(mockScoreTableSelectors);
         lenient().when(mockScoreboardSelectors.getPitcher()).thenReturn(mockPitcherSelectors);
+        lenient().when(mockScoreboardSelectors.getBase()).thenReturn(mockBaseSelectors);
 
         // TeamSelectors 설정
         lenient().when(mockHomeTeamSelectors.getName()).thenReturn(".home-team .name");
@@ -116,6 +120,12 @@ class KboScoreboardPageTest {
         // PitcherSelectors 설정
         lenient().when(mockPitcherSelectors.getContainer()).thenReturn(".pitcher-info");
         lenient().when(mockPitcherSelectors.getSpans()).thenReturn("span");
+
+        // BaseSelectors 설정 (테스트 픽스처에는 .base가 없어서 항상 매칭되지 않음)
+        lenient().when(mockBaseSelectors.getContainer()).thenReturn(".base");
+        lenient().when(mockBaseSelectors.getFirst()).thenReturn(".base1 img");
+        lenient().when(mockBaseSelectors.getSecond()).thenReturn(".base2 img");
+        lenient().when(mockBaseSelectors.getThird()).thenReturn(".base3 img");
 
         // CalendarSelectors 설정
         lenient().when(mockCalendarSelectors.getUpdatePanel()).thenReturn("#update-panel");
@@ -277,6 +287,62 @@ class KboScoreboardPageTest {
             assertThat(game.getWinningPitcher()).isEqualTo("김광현");
             assertThat(game.getLosingPitcher()).isEqualTo("엄상백");
             assertThat(game.getSavingPitcher()).isEqualTo("고우석");
+        }
+
+        @Test
+        @DisplayName("parseScoreboard - 진루정보 파싱")
+        void parseScoreboard_WithBaseOccupancy() {
+            // Given
+            ElementHandle mockScoreboard = createCompleteScoreboardElement();
+
+            ElementHandle baseContainer = mock(ElementHandle.class);
+            lenient().when(mockScoreboard.querySelector(".base")).thenReturn(baseContainer);
+
+            ElementHandle firstBaseImg = mock(ElementHandle.class);
+            lenient().when(firstBaseImg.getAttribute("src")).thenReturn(".../base_on.png");
+            lenient().when(mockScoreboard.querySelector(".base1 img")).thenReturn(firstBaseImg);
+
+            ElementHandle secondBaseImg = mock(ElementHandle.class);
+            lenient().when(secondBaseImg.getAttribute("src")).thenReturn(".../base.png");
+            lenient().when(mockScoreboard.querySelector(".base2 img")).thenReturn(secondBaseImg);
+
+            ElementHandle thirdBaseImg = mock(ElementHandle.class);
+            lenient().when(thirdBaseImg.getAttribute("src")).thenReturn(".../base_on.png");
+            lenient().when(mockScoreboard.querySelector(".base3 img")).thenReturn(thirdBaseImg);
+
+            LocalDate date = LocalDate.of(2025, 10, 26);
+
+            // When
+            Optional<KboScoreboardGame> result = scoreboardPage.parseScoreboard(mockScoreboard, date);
+
+            // Then
+            assertThat(result).isPresent();
+            KboScoreboardGame game = result.get();
+
+            assertThat(game.getFirstBaseOccupied()).isTrue();
+            assertThat(game.getSecondBaseOccupied()).isFalse();
+            assertThat(game.getThirdBaseOccupied()).isTrue();
+        }
+
+        @Test
+        @DisplayName("parseScoreboard - 경기중이 아니면 진루정보는 null")
+        void parseScoreboard_NoBase_BaseFieldsAreNull() {
+            // Given
+            ElementHandle mockScoreboard = createCompleteScoreboardElement();
+            lenient().when(mockScoreboard.querySelector(".base")).thenReturn(null);
+
+            LocalDate date = LocalDate.of(2025, 10, 26);
+
+            // When
+            Optional<KboScoreboardGame> result = scoreboardPage.parseScoreboard(mockScoreboard, date);
+
+            // Then
+            assertThat(result).isPresent();
+            KboScoreboardGame game = result.get();
+
+            assertThat(game.getFirstBaseOccupied()).isNull();
+            assertThat(game.getSecondBaseOccupied()).isNull();
+            assertThat(game.getThirdBaseOccupied()).isNull();
         }
 
         @Test

--- a/backend/crawling/src/test/java/yagubogu/crawling/game/service/crawler/page/KboScoreboardPageTest.java
+++ b/backend/crawling/src/test/java/yagubogu/crawling/game/service/crawler/page/KboScoreboardPageTest.java
@@ -126,6 +126,7 @@ class KboScoreboardPageTest {
         lenient().when(mockBaseSelectors.getFirst()).thenReturn(".base1 img");
         lenient().when(mockBaseSelectors.getSecond()).thenReturn(".base2 img");
         lenient().when(mockBaseSelectors.getThird()).thenReturn(".base3 img");
+        lenient().when(mockBaseSelectors.getCount()).thenReturn(".base > p");
 
         // CalendarSelectors 설정
         lenient().when(mockCalendarSelectors.getUpdatePanel()).thenReturn("#update-panel");
@@ -133,6 +134,7 @@ class KboScoreboardPageTest {
         // Patterns 설정
         lenient().when(mockPatterns.getTimeFormat()).thenReturn("HH:mm");
         lenient().when(mockPatterns.getPitcherLabel()).thenReturn("(승|패|세)\\s+(.+)");
+        lenient().when(mockPatterns.getCountLabel()).thenReturn("(\\d+)-(\\d+)\\s*(\\d+)out");
 
         scoreboardPage = new KboScoreboardPage(mockPage, mockProperties);
     }
@@ -343,6 +345,50 @@ class KboScoreboardPageTest {
             assertThat(game.getFirstBaseOccupied()).isNull();
             assertThat(game.getSecondBaseOccupied()).isNull();
             assertThat(game.getThirdBaseOccupied()).isNull();
+        }
+
+        @Test
+        @DisplayName("parseScoreboard - 볼/스트라이크/아웃 카운트 파싱")
+        void parseScoreboard_WithCount() {
+            // Given
+            ElementHandle mockScoreboard = createCompleteScoreboardElement();
+
+            ElementHandle countElem = createMockElementWithText("1-2 0out");
+            lenient().when(mockScoreboard.querySelector(".base > p")).thenReturn(countElem);
+
+            LocalDate date = LocalDate.of(2025, 10, 26);
+
+            // When
+            Optional<KboScoreboardGame> result = scoreboardPage.parseScoreboard(mockScoreboard, date);
+
+            // Then
+            assertThat(result).isPresent();
+            KboScoreboardGame game = result.get();
+
+            assertThat(game.getBalls()).isEqualTo(1);
+            assertThat(game.getStrikes()).isEqualTo(2);
+            assertThat(game.getOuts()).isEqualTo(0);
+        }
+
+        @Test
+        @DisplayName("parseScoreboard - 경기중이 아니면 카운트는 null")
+        void parseScoreboard_NoCount_CountFieldsAreNull() {
+            // Given
+            ElementHandle mockScoreboard = createCompleteScoreboardElement();
+            lenient().when(mockScoreboard.querySelector(".base > p")).thenReturn(null);
+
+            LocalDate date = LocalDate.of(2025, 10, 26);
+
+            // When
+            Optional<KboScoreboardGame> result = scoreboardPage.parseScoreboard(mockScoreboard, date);
+
+            // Then
+            assertThat(result).isPresent();
+            KboScoreboardGame game = result.get();
+
+            assertThat(game.getBalls()).isNull();
+            assertThat(game.getStrikes()).isNull();
+            assertThat(game.getOuts()).isNull();
         }
 
         @Test

--- a/backend/crawling/src/test/resources/application.yml
+++ b/backend/crawling/src/test/resources/application.yml
@@ -98,6 +98,13 @@ kbo:
         container: ".score_wrap p.win"
         spans: "span"
 
+      # 진루정보 (경기중이 아니면 .base 자체가 없음)
+      base:
+        container: ".score_wrap .base"
+        first: ".base1 img"
+        second: ".base2 img"
+        third: ".base3 img"
+
   # 정규표현식 패턴
   patterns:
     pitcherLabel: "^\\s*(승|세|패)\\s*[:：]\\s*(.+?)\\s*$"

--- a/backend/crawling/src/test/resources/application.yml
+++ b/backend/crawling/src/test/resources/application.yml
@@ -98,16 +98,18 @@ kbo:
         container: ".score_wrap p.win"
         spans: "span"
 
-      # 진루정보 (경기중이 아니면 .base 자체가 없음)
+      # 진루정보 및 볼/스트라이크/아웃 (경기중이 아니면 .base 자체가 없음)
       base:
         container: ".score_wrap .base"
         first: ".base1 img"
         second: ".base2 img"
         third: ".base3 img"
+        count: ".base > p"
 
   # 정규표현식 패턴
   patterns:
     pitcherLabel: "^\\s*(승|세|패)\\s*[:：]\\s*(.+?)\\s*$"
+    countLabel: "(\\d+)-(\\d+)\\s*(\\d+)out"
     dateFormat: "yyyy.MM.dd"
     timeFormat: "HH:mm"
 


### PR DESCRIPTION
## 📌 관련 이슈
- close #1097

## ✨ 변경 내용
- KBO 게임센터와 스코어보드에서 경기 상태 정보를 추가로 파싱하도록 개선했습니다.
- 볼/스트라이크/아웃 카운트와 진루 정보 추출 로직을 보강하고 관련 테스트를 추가했습니다.
- 검증 : 진행 중인 KBO 경기 5개에 대해 크롤링되는지 검증했습니다.
- 크롤링 주기 30초로 변경했습니다.

## 🎸 기타 참고 사항
- 별도 참고 사항 없음

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added real-time base occupancy tracking to display which bases have active runners during games, along with live ball/strike/out count updates for better game tracking.
  * Enhanced game detail pages to accurately show the currently active batting and pitching players, improving overall game state accuracy and information completeness throughout each matchup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->