### PR TITLE
feat: 한국관광공사 API 연동 음식점 폴링 스케줄러 구현

### DIFF
--- a/.github/workflows/backend-dev.yml
+++ b/.github/workflows/backend-dev.yml
@@ -134,6 +134,7 @@ jobs:
             -e R2_S3_BUCKET="${{ secrets.R2_S3_BUCKET }}" \
             -e R2_PUBLIC_BASE_URL="${{ secrets.R2_PUBLIC_BASE_URL || 'https://images.yagubogu.com' }}" \
             -e R2_DEFAULT_PROFILE_IMAGE_URL="${{ secrets.R2_DEFAULT_PROFILE_IMAGE_URL || 'https://images.yagubogu.com/images/defaults/profile.png' }}" \
+            -e TOUR_API_SERVICE_KEY="${{ secrets.TOUR_API_SERVICE_KEY }}" \
             $IMAGE:$TAG
           
           echo "컨테이너 실행 완료."  

--- a/.github/workflows/backend-main.yml
+++ b/.github/workflows/backend-main.yml
@@ -185,6 +185,7 @@ jobs:
             -e R2_S3_BUCKET="${{ secrets.R2_S3_BUCKET }}" \
             -e R2_PUBLIC_BASE_URL="${{ secrets.R2_PUBLIC_BASE_URL || 'https://images.yagubogu.com' }}" \
             -e R2_DEFAULT_PROFILE_IMAGE_URL="${{ secrets.R2_DEFAULT_PROFILE_IMAGE_URL || 'https://images.yagubogu.com/images/defaults/profile.png' }}" \
+            -e TOUR_API_SERVICE_KEY="${{ secrets.TOUR_API_SERVICE_KEY }}" \
             -l app=yagubogu-backend \
             -l release.version="${NEXT_VERSION_WITH_V}" \
             -l release.digest="${DIGEST}" \

--- a/backend/app/src/main/java/com/yagubogu/restaurant/client/TourApiClient.java
+++ b/backend/app/src/main/java/com/yagubogu/restaurant/client/TourApiClient.java
@@ -72,9 +72,10 @@ public class TourApiClient {
             String resultCode = header.path("resultCode").asText();
 
             if (!RESULT_CODE_OK.equals(resultCode)) {
-                log.warn("[TourApi] Non-OK response for stadiumId={}: code={}, msg={}",
-                        stadiumId, resultCode, header.path("resultMsg").asText());
-                return Collections.emptyList();
+                String msg = header.path("resultMsg").asText();
+                log.warn("[TourApi] Non-OK response for stadiumId={}: code={}, msg={}", stadiumId, resultCode, msg);
+                throw new TourApiException(
+                        "Tour API returned non-OK code=" + resultCode + ", msg=" + msg + " for stadiumId=" + stadiumId);
             }
 
             JsonNode itemsNode = root.path("body").path("items");

--- a/backend/app/src/main/java/com/yagubogu/restaurant/client/TourApiClient.java
+++ b/backend/app/src/main/java/com/yagubogu/restaurant/client/TourApiClient.java
@@ -1,0 +1,146 @@
+package com.yagubogu.restaurant.client;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.yagubogu.restaurant.config.TourApiProperties;
+import com.yagubogu.restaurant.dto.RestaurantParam;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@Slf4j
+@RequiredArgsConstructor
+public class TourApiClient {
+
+    private static final String ENDPOINT = "/locationBasedList2";
+    private static final String RESULT_CODE_OK = "0000";
+
+    private final RestClient restClient;
+    private final TourApiProperties props;
+    private final ObjectMapper objectMapper;
+
+    /**
+     * 구장 주변 음식점(contentTypeId=39)을 한국관광공사 API로 조회합니다.
+     *
+     * @param stadiumId 야구장 ID (로깅용)
+     * @param mapX      경도 (longitude)
+     * @param mapY      위도 (latitude)
+     */
+    public List<RestaurantParam> fetchRestaurantsNear(long stadiumId, double mapX, double mapY) {
+        // ServiceKey는 공공데이터포털에서 발급된 디코딩된 값을 환경변수에 저장해야 합니다.
+        // UriComponentsBuilder가 자동으로 URL 인코딩하므로 이미 인코딩된 키를 저장하면 이중 인코딩됩니다.
+        URI uri = UriComponentsBuilder
+                .fromUriString(props.getBaseUrl() + ENDPOINT)
+                .queryParam("serviceKey", props.getServiceKey())
+                .queryParam("MobileOS", "ETC")
+                .queryParam("MobileApp", "Yagubogu")
+                .queryParam("_type", "json")
+                .queryParam("mapX", mapX)
+                .queryParam("mapY", mapY)
+                .queryParam("radius", props.getRadius())
+                .queryParam("contentTypeId", 39)
+                .queryParam("numOfRows", props.getNumOfRows())
+                .queryParam("pageNo", 1)
+                .build()
+                .toUri();
+
+        try {
+            String json = restClient.get()
+                    .uri(uri)
+                    .retrieve()
+                    .body(String.class);
+
+            return parseItems(json, stadiumId);
+        } catch (RestClientException e) {
+            log.error("[TourApi] HTTP error for stadiumId={}: {}", stadiumId, e.getMessage());
+            throw new TourApiException("Tour API call failed for stadiumId=" + stadiumId, e);
+        }
+    }
+
+    List<RestaurantParam> parseItems(String json, long stadiumId) {
+        try {
+            JsonNode root = objectMapper.readTree(json);
+            // 실제 KTO API 응답 구조: { "header": {...}, "body": {...} }
+            // "response" 래퍼 없음
+            JsonNode header = root.path("header");
+            String resultCode = header.path("resultCode").asText();
+
+            if (!RESULT_CODE_OK.equals(resultCode)) {
+                log.warn("[TourApi] Non-OK response for stadiumId={}: code={}, msg={}",
+                        stadiumId, resultCode, header.path("resultMsg").asText());
+                return Collections.emptyList();
+            }
+
+            JsonNode itemsNode = root.path("body").path("items");
+            // KTO API는 결과가 없을 때 items를 빈 문자열("")로 반환합니다.
+            if (itemsNode.isMissingNode() || itemsNode.isTextual()) {
+                return Collections.emptyList();
+            }
+
+            JsonNode itemNode = itemsNode.path("item");
+            if (itemNode.isMissingNode()) {
+                return Collections.emptyList();
+            }
+
+            List<RestaurantParam> result = new ArrayList<>();
+            if (itemNode.isArray()) {
+                // 다건: "item": [...]
+                for (JsonNode item : itemNode) {
+                    result.add(toParam(item, stadiumId));
+                }
+            } else if (itemNode.isObject()) {
+                // 단건: "item": {...}
+                result.add(toParam(itemNode, stadiumId));
+            }
+            return result;
+        } catch (Exception e) {
+            log.error("[TourApi] Failed to parse response for stadiumId={}: {}", stadiumId, e.getMessage());
+            throw new TourApiException("Failed to parse Tour API response", e);
+        }
+    }
+
+    private RestaurantParam toParam(JsonNode item, long stadiumId) {
+        return new RestaurantParam(
+                item.path("contentid").asText(),
+                stadiumId,
+                item.path("title").asText(),
+                nullableText(item, "addr1"),
+                item.path("mapx").asDouble(),
+                item.path("mapy").asDouble(),
+                nullableDistance(item, "dist"),
+                nullableText(item, "tel"),
+                nullableText(item, "firstimage")
+        );
+    }
+
+    private String nullableText(JsonNode node, String field) {
+        JsonNode n = node.path(field);
+        if (n.isMissingNode() || n.isNull()) {
+            return null;
+        }
+        String text = n.asText().trim();
+        return text.isEmpty() ? null : text;
+    }
+
+    private Integer nullableDistance(JsonNode node, String field) {
+        JsonNode n = node.path(field);
+        if (n.isMissingNode() || n.isNull()) {
+            return null;
+        }
+        String text = n.asText().trim();
+        if (text.isEmpty()) {
+            return null;
+        }
+        try {
+            return (int) Double.parseDouble(text);
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+}

--- a/backend/app/src/main/java/com/yagubogu/restaurant/client/TourApiException.java
+++ b/backend/app/src/main/java/com/yagubogu/restaurant/client/TourApiException.java
@@ -2,6 +2,10 @@ package com.yagubogu.restaurant.client;
 
 public class TourApiException extends RuntimeException {
 
+    public TourApiException(String message) {
+        super(message);
+    }
+
     public TourApiException(String message, Throwable cause) {
         super(message, cause);
     }

--- a/backend/app/src/main/java/com/yagubogu/restaurant/client/TourApiException.java
+++ b/backend/app/src/main/java/com/yagubogu/restaurant/client/TourApiException.java
@@ -1,0 +1,8 @@
+package com.yagubogu.restaurant.client;
+
+public class TourApiException extends RuntimeException {
+
+    public TourApiException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/backend/app/src/main/java/com/yagubogu/restaurant/config/TourApiClientConfig.java
+++ b/backend/app/src/main/java/com/yagubogu/restaurant/config/TourApiClientConfig.java
@@ -1,0 +1,33 @@
+package com.yagubogu.restaurant.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.yagubogu.restaurant.client.TourApiClient;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.web.client.RestClient;
+
+@Configuration
+@EnableConfigurationProperties(TourApiProperties.class)
+public class TourApiClientConfig {
+
+    @Bean
+    public RestClient tourApiRestClient(TourApiProperties props) {
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout((int) props.getConnectTimeout().toMillis());
+        factory.setReadTimeout((int) props.getReadTimeout().toMillis());
+
+        return RestClient.builder()
+                .baseUrl(props.getBaseUrl())
+                .requestFactory(factory)
+                .build();
+    }
+
+    @Bean
+    public TourApiClient tourApiClient(RestClient tourApiRestClient,
+                                       TourApiProperties props,
+                                       ObjectMapper objectMapper) {
+        return new TourApiClient(tourApiRestClient, props, objectMapper);
+    }
+}

--- a/backend/app/src/main/java/com/yagubogu/restaurant/config/TourApiProperties.java
+++ b/backend/app/src/main/java/com/yagubogu/restaurant/config/TourApiProperties.java
@@ -1,0 +1,27 @@
+package com.yagubogu.restaurant.config;
+
+import java.time.Duration;
+import lombok.Getter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Getter
+@ConfigurationProperties(prefix = "tour.api")
+public class TourApiProperties {
+
+    private final String serviceKey;
+    private final String baseUrl;
+    private final int radius;
+    private final int numOfRows;
+    private final Duration connectTimeout;
+    private final Duration readTimeout;
+
+    public TourApiProperties(String serviceKey, String baseUrl, int radius, int numOfRows,
+                             Duration connectTimeout, Duration readTimeout) {
+        this.serviceKey = serviceKey;
+        this.baseUrl = baseUrl;
+        this.radius = radius;
+        this.numOfRows = numOfRows;
+        this.connectTimeout = connectTimeout;
+        this.readTimeout = readTimeout;
+    }
+}

--- a/backend/app/src/main/java/com/yagubogu/restaurant/controller/v1/RestaurantController.java
+++ b/backend/app/src/main/java/com/yagubogu/restaurant/controller/v1/RestaurantController.java
@@ -1,0 +1,19 @@
+package com.yagubogu.restaurant.controller.v1;
+
+import com.yagubogu.restaurant.dto.v1.RestaurantsResponse;
+import com.yagubogu.restaurant.service.RestaurantQueryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class RestaurantController implements RestaurantControllerInterface {
+
+    private final RestaurantQueryService restaurantQueryService;
+
+    @Override
+    public ResponseEntity<RestaurantsResponse> getRestaurantsByStadium(Long stadiumId) {
+        return ResponseEntity.ok(restaurantQueryService.findByStadium(stadiumId));
+    }
+}

--- a/backend/app/src/main/java/com/yagubogu/restaurant/controller/v1/RestaurantControllerInterface.java
+++ b/backend/app/src/main/java/com/yagubogu/restaurant/controller/v1/RestaurantControllerInterface.java
@@ -1,0 +1,23 @@
+package com.yagubogu.restaurant.controller.v1;
+
+import com.yagubogu.restaurant.dto.v1.RestaurantsResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Tag(name = "Restaurant", description = "구장 주변 맛집 API")
+@RequestMapping("/restaurants")
+public interface RestaurantControllerInterface {
+
+    @Operation(summary = "구장 주변 맛집 목록 조회",
+               description = "지정한 구장 ID 기준으로 반경 내 음식점 목록을 반환합니다. 데이터는 매일 새벽 3시에 갱신됩니다.")
+    @GetMapping
+    ResponseEntity<RestaurantsResponse> getRestaurantsByStadium(
+            @Parameter(description = "구장 ID", required = true)
+            @RequestParam Long stadiumId
+    );
+}

--- a/backend/app/src/main/java/com/yagubogu/restaurant/domain/Restaurant.java
+++ b/backend/app/src/main/java/com/yagubogu/restaurant/domain/Restaurant.java
@@ -1,0 +1,77 @@
+package com.yagubogu.restaurant.domain;
+
+import com.yagubogu.global.domain.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Table(name = "restaurants")
+@Entity
+public class Restaurant extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "restaurant_id")
+    private Long id;
+
+    @Column(name = "content_id", nullable = false)
+    private String contentId;
+
+    @Column(name = "stadium_id", nullable = false)
+    private Long stadiumId;
+
+    @Column(name = "title", nullable = false)
+    private String title;
+
+    @Column(name = "address")
+    private String address;
+
+    @Column(name = "map_x", nullable = false)
+    private Double mapX;
+
+    @Column(name = "map_y", nullable = false)
+    private Double mapY;
+
+    @Column(name = "distance")
+    private Integer distance;
+
+    @Column(name = "tel")
+    private String tel;
+
+    @Column(name = "image_url", length = 1024)
+    private String imageUrl;
+
+    public static Restaurant of(String contentId, Long stadiumId, String title, String address,
+                                double mapX, double mapY, Integer distance, String tel, String imageUrl) {
+        Restaurant r = new Restaurant();
+        r.contentId = contentId;
+        r.stadiumId = stadiumId;
+        r.title = title;
+        r.address = address;
+        r.mapX = mapX;
+        r.mapY = mapY;
+        r.distance = distance;
+        r.tel = tel;
+        r.imageUrl = imageUrl;
+        return r;
+    }
+
+    public void update(String title, String address, double mapX, double mapY,
+                       Integer distance, String tel, String imageUrl) {
+        this.title = title;
+        this.address = address;
+        this.mapX = mapX;
+        this.mapY = mapY;
+        this.distance = distance;
+        this.tel = tel;
+        this.imageUrl = imageUrl;
+    }
+}

--- a/backend/app/src/main/java/com/yagubogu/restaurant/dto/RestaurantParam.java
+++ b/backend/app/src/main/java/com/yagubogu/restaurant/dto/RestaurantParam.java
@@ -1,0 +1,13 @@
+package com.yagubogu.restaurant.dto;
+
+public record RestaurantParam(
+        String contentId,
+        Long stadiumId,
+        String title,
+        String address,
+        double mapX,
+        double mapY,
+        Integer distance,
+        String tel,
+        String imageUrl
+) {}

--- a/backend/app/src/main/java/com/yagubogu/restaurant/dto/v1/RestaurantResponse.java
+++ b/backend/app/src/main/java/com/yagubogu/restaurant/dto/v1/RestaurantResponse.java
@@ -1,0 +1,27 @@
+package com.yagubogu.restaurant.dto.v1;
+
+import com.yagubogu.restaurant.domain.Restaurant;
+
+public record RestaurantResponse(
+        Long id,
+        String title,
+        String address,
+        Double mapX,
+        Double mapY,
+        Integer distance,
+        String tel,
+        String imageUrl
+) {
+    public static RestaurantResponse from(Restaurant restaurant) {
+        return new RestaurantResponse(
+                restaurant.getId(),
+                restaurant.getTitle(),
+                restaurant.getAddress(),
+                restaurant.getMapX(),
+                restaurant.getMapY(),
+                restaurant.getDistance(),
+                restaurant.getTel(),
+                restaurant.getImageUrl()
+        );
+    }
+}

--- a/backend/app/src/main/java/com/yagubogu/restaurant/dto/v1/RestaurantsResponse.java
+++ b/backend/app/src/main/java/com/yagubogu/restaurant/dto/v1/RestaurantsResponse.java
@@ -1,0 +1,8 @@
+package com.yagubogu.restaurant.dto.v1;
+
+import java.util.List;
+
+public record RestaurantsResponse(
+        Long stadiumId,
+        List<RestaurantResponse> restaurants
+) {}

--- a/backend/app/src/main/java/com/yagubogu/restaurant/repository/RestaurantRepository.java
+++ b/backend/app/src/main/java/com/yagubogu/restaurant/repository/RestaurantRepository.java
@@ -1,0 +1,12 @@
+package com.yagubogu.restaurant.repository;
+
+import com.yagubogu.restaurant.domain.Restaurant;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface RestaurantRepository extends JpaRepository<Restaurant, Long> {
+
+    List<Restaurant> findAllByStadiumId(Long stadiumId);
+}

--- a/backend/app/src/main/java/com/yagubogu/restaurant/scheduler/RestaurantPollingScheduler.java
+++ b/backend/app/src/main/java/com/yagubogu/restaurant/scheduler/RestaurantPollingScheduler.java
@@ -1,0 +1,29 @@
+package com.yagubogu.restaurant.scheduler;
+
+import com.yagubogu.restaurant.service.RestaurantSyncService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/**
+ * 매일 새벽 3시에 모든 구장 주변 맛집 데이터를 한국관광공사 API로부터 동기화합니다.
+ * 트래픽이 낮은 시간대를 선택하여 API 호출 영향을 최소화합니다.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RestaurantPollingScheduler {
+
+    private final RestaurantSyncService restaurantSyncService;
+
+    @Scheduled(cron = "0 0 3 * * ?")
+    public void pollRestaurants() {
+        log.info("[RestaurantPoller] Starting daily restaurant sync");
+        try {
+            restaurantSyncService.syncAll();
+        } catch (Exception e) {
+            log.error("[RestaurantPoller] Unexpected error during restaurant sync", e);
+        }
+    }
+}

--- a/backend/app/src/main/java/com/yagubogu/restaurant/service/RestaurantQueryService.java
+++ b/backend/app/src/main/java/com/yagubogu/restaurant/service/RestaurantQueryService.java
@@ -1,0 +1,26 @@
+package com.yagubogu.restaurant.service;
+
+import com.yagubogu.restaurant.dto.v1.RestaurantResponse;
+import com.yagubogu.restaurant.dto.v1.RestaurantsResponse;
+import com.yagubogu.restaurant.repository.RestaurantRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class RestaurantQueryService {
+
+    private final RestaurantRepository restaurantRepository;
+
+    @Transactional(readOnly = true)
+    public RestaurantsResponse findByStadium(Long stadiumId) {
+        List<RestaurantResponse> restaurants = restaurantRepository.findAllByStadiumId(stadiumId)
+                .stream()
+                .map(RestaurantResponse::from)
+                .toList();
+
+        return new RestaurantsResponse(stadiumId, restaurants);
+    }
+}

--- a/backend/app/src/main/java/com/yagubogu/restaurant/service/RestaurantSyncService.java
+++ b/backend/app/src/main/java/com/yagubogu/restaurant/service/RestaurantSyncService.java
@@ -1,0 +1,121 @@
+package com.yagubogu.restaurant.service;
+
+import com.yagubogu.restaurant.client.TourApiClient;
+import com.yagubogu.restaurant.client.TourApiException;
+import com.yagubogu.restaurant.domain.Restaurant;
+import com.yagubogu.restaurant.dto.RestaurantParam;
+import com.yagubogu.restaurant.repository.RestaurantRepository;
+import com.yagubogu.stadium.domain.Stadium;
+import com.yagubogu.stadium.repository.StadiumRepository;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RestaurantSyncService {
+
+    private static final int MAX_RETRIES = 3;
+
+    private final TourApiClient tourApiClient;
+    private final RestaurantRepository restaurantRepository;
+    private final StadiumRepository stadiumRepository;
+
+    public void syncAll() {
+        List<Stadium> stadiums = stadiumRepository.findAll();
+        log.info("[RestaurantSync] Starting sync for {} stadiums", stadiums.size());
+
+        int success = 0;
+        int failed = 0;
+
+        for (Stadium stadium : stadiums) {
+            try {
+                syncForStadium(stadium);
+                success++;
+            } catch (Exception e) {
+                log.error("[RestaurantSync] Failed to sync stadiumId={} ({}): {}",
+                        stadium.getId(), stadium.getShortName(), e.getMessage());
+                failed++;
+            }
+        }
+
+        log.info("[RestaurantSync] Completed: success={}, failed={}", success, failed);
+    }
+
+    @Transactional
+    public void syncForStadium(Stadium stadium) {
+        Long stadiumId = stadium.getId();
+
+        // mapX = longitude, mapY = latitude (KTO API 명세 기준)
+        List<RestaurantParam> fetched = fetchWithRetry(stadium);
+
+        Map<String, Restaurant> existing = restaurantRepository.findAllByStadiumId(stadiumId)
+                .stream()
+                .collect(Collectors.toMap(Restaurant::getContentId, r -> r));
+
+        Set<String> fetchedContentIds = fetched.stream()
+                .map(RestaurantParam::contentId)
+                .collect(Collectors.toSet());
+
+        List<Restaurant> toSave = fetched.stream()
+                .map(param -> {
+                    Restaurant r = existing.get(param.contentId());
+                    if (r != null) {
+                        r.update(param.title(), param.address(), param.mapX(), param.mapY(),
+                                param.distance(), param.tel(), param.imageUrl());
+                        return r;
+                    }
+                    return Restaurant.of(param.contentId(), stadiumId, param.title(), param.address(),
+                            param.mapX(), param.mapY(), param.distance(), param.tel(), param.imageUrl());
+                })
+                .toList();
+
+        restaurantRepository.saveAll(toSave);
+
+        List<Restaurant> toDelete = existing.values().stream()
+                .filter(r -> !fetchedContentIds.contains(r.getContentId()))
+                .toList();
+
+        if (!toDelete.isEmpty()) {
+            restaurantRepository.deleteAll(toDelete);
+        }
+
+        log.info("[RestaurantSync] stadiumId={} ({}): upserted={}, deleted={}",
+                stadiumId, stadium.getShortName(), toSave.size(), toDelete.size());
+    }
+
+    private List<RestaurantParam> fetchWithRetry(Stadium stadium) {
+        Exception lastException = null;
+
+        for (int attempt = 1; attempt <= MAX_RETRIES; attempt++) {
+            try {
+                return tourApiClient.fetchRestaurantsNear(
+                        stadium.getId(), stadium.getLongitude(), stadium.getLatitude());
+            } catch (TourApiException e) {
+                lastException = e;
+                log.warn("[RestaurantSync] Attempt {}/{} failed for stadiumId={}: {}",
+                        attempt, MAX_RETRIES, stadium.getId(), e.getMessage());
+                if (attempt < MAX_RETRIES) {
+                    sleepExponential(attempt);
+                }
+            }
+        }
+
+        throw new RuntimeException("All retries exhausted for stadiumId=" + stadium.getId(), lastException);
+    }
+
+    private void sleepExponential(int attempt) {
+        try {
+            long delayMs = 1000L << (attempt - 1); // 1s, 2s, 4s
+            Thread.sleep(delayMs);
+        } catch (InterruptedException ie) {
+            Thread.currentThread().interrupt();
+        }
+    }
+}

--- a/backend/app/src/main/java/com/yagubogu/restaurant/service/RestaurantSyncService.java
+++ b/backend/app/src/main/java/com/yagubogu/restaurant/service/RestaurantSyncService.java
@@ -1,30 +1,18 @@
 package com.yagubogu.restaurant.service;
 
-import com.yagubogu.restaurant.client.TourApiClient;
-import com.yagubogu.restaurant.client.TourApiException;
-import com.yagubogu.restaurant.domain.Restaurant;
-import com.yagubogu.restaurant.dto.RestaurantParam;
-import com.yagubogu.restaurant.repository.RestaurantRepository;
 import com.yagubogu.stadium.domain.Stadium;
 import com.yagubogu.stadium.repository.StadiumRepository;
 import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class RestaurantSyncService {
 
-    private static final int MAX_RETRIES = 3;
-
-    private final TourApiClient tourApiClient;
-    private final RestaurantRepository restaurantRepository;
+    private final RestaurantSyncTransactionService restaurantSyncTransactionService;
     private final StadiumRepository stadiumRepository;
 
     public void syncAll() {
@@ -36,7 +24,7 @@ public class RestaurantSyncService {
 
         for (Stadium stadium : stadiums) {
             try {
-                syncForStadium(stadium);
+                restaurantSyncTransactionService.syncForStadium(stadium);
                 success++;
             } catch (Exception e) {
                 log.error("[RestaurantSync] Failed to sync stadiumId={} ({}): {}",
@@ -46,76 +34,5 @@ public class RestaurantSyncService {
         }
 
         log.info("[RestaurantSync] Completed: success={}, failed={}", success, failed);
-    }
-
-    @Transactional
-    public void syncForStadium(Stadium stadium) {
-        Long stadiumId = stadium.getId();
-
-        // mapX = longitude, mapY = latitude (KTO API 명세 기준)
-        List<RestaurantParam> fetched = fetchWithRetry(stadium);
-
-        Map<String, Restaurant> existing = restaurantRepository.findAllByStadiumId(stadiumId)
-                .stream()
-                .collect(Collectors.toMap(Restaurant::getContentId, r -> r));
-
-        Set<String> fetchedContentIds = fetched.stream()
-                .map(RestaurantParam::contentId)
-                .collect(Collectors.toSet());
-
-        List<Restaurant> toSave = fetched.stream()
-                .map(param -> {
-                    Restaurant r = existing.get(param.contentId());
-                    if (r != null) {
-                        r.update(param.title(), param.address(), param.mapX(), param.mapY(),
-                                param.distance(), param.tel(), param.imageUrl());
-                        return r;
-                    }
-                    return Restaurant.of(param.contentId(), stadiumId, param.title(), param.address(),
-                            param.mapX(), param.mapY(), param.distance(), param.tel(), param.imageUrl());
-                })
-                .toList();
-
-        restaurantRepository.saveAll(toSave);
-
-        List<Restaurant> toDelete = existing.values().stream()
-                .filter(r -> !fetchedContentIds.contains(r.getContentId()))
-                .toList();
-
-        if (!toDelete.isEmpty()) {
-            restaurantRepository.deleteAll(toDelete);
-        }
-
-        log.info("[RestaurantSync] stadiumId={} ({}): upserted={}, deleted={}",
-                stadiumId, stadium.getShortName(), toSave.size(), toDelete.size());
-    }
-
-    private List<RestaurantParam> fetchWithRetry(Stadium stadium) {
-        Exception lastException = null;
-
-        for (int attempt = 1; attempt <= MAX_RETRIES; attempt++) {
-            try {
-                return tourApiClient.fetchRestaurantsNear(
-                        stadium.getId(), stadium.getLongitude(), stadium.getLatitude());
-            } catch (TourApiException e) {
-                lastException = e;
-                log.warn("[RestaurantSync] Attempt {}/{} failed for stadiumId={}: {}",
-                        attempt, MAX_RETRIES, stadium.getId(), e.getMessage());
-                if (attempt < MAX_RETRIES) {
-                    sleepExponential(attempt);
-                }
-            }
-        }
-
-        throw new RuntimeException("All retries exhausted for stadiumId=" + stadium.getId(), lastException);
-    }
-
-    private void sleepExponential(int attempt) {
-        try {
-            long delayMs = 1000L << (attempt - 1); // 1s, 2s, 4s
-            Thread.sleep(delayMs);
-        } catch (InterruptedException ie) {
-            Thread.currentThread().interrupt();
-        }
     }
 }

--- a/backend/app/src/main/java/com/yagubogu/restaurant/service/RestaurantSyncTransactionService.java
+++ b/backend/app/src/main/java/com/yagubogu/restaurant/service/RestaurantSyncTransactionService.java
@@ -1,0 +1,97 @@
+package com.yagubogu.restaurant.service;
+
+import com.yagubogu.restaurant.client.TourApiClient;
+import com.yagubogu.restaurant.client.TourApiException;
+import com.yagubogu.restaurant.domain.Restaurant;
+import com.yagubogu.restaurant.dto.RestaurantParam;
+import com.yagubogu.restaurant.repository.RestaurantRepository;
+import com.yagubogu.stadium.domain.Stadium;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RestaurantSyncTransactionService {
+
+    private static final int MAX_RETRIES = 3;
+
+    private final TourApiClient tourApiClient;
+    private final RestaurantRepository restaurantRepository;
+
+    @Transactional
+    public void syncForStadium(Stadium stadium) {
+        Long stadiumId = stadium.getId();
+
+        List<RestaurantParam> fetched = fetchWithRetry(stadium);
+
+        Map<String, Restaurant> existing = restaurantRepository.findAllByStadiumId(stadiumId)
+                .stream()
+                .collect(Collectors.toMap(Restaurant::getContentId, r -> r));
+
+        Set<String> fetchedContentIds = fetched.stream()
+                .map(RestaurantParam::contentId)
+                .collect(Collectors.toSet());
+
+        List<Restaurant> toSave = fetched.stream()
+                .map(param -> {
+                    Restaurant r = existing.get(param.contentId());
+                    if (r != null) {
+                        r.update(param.title(), param.address(), param.mapX(), param.mapY(),
+                                param.distance(), param.tel(), param.imageUrl());
+                        return r;
+                    }
+                    return Restaurant.of(param.contentId(), stadiumId, param.title(), param.address(),
+                            param.mapX(), param.mapY(), param.distance(), param.tel(), param.imageUrl());
+                })
+                .toList();
+
+        restaurantRepository.saveAll(toSave);
+
+        List<Restaurant> toDelete = existing.values().stream()
+                .filter(r -> !fetchedContentIds.contains(r.getContentId()))
+                .toList();
+
+        if (!toDelete.isEmpty()) {
+            restaurantRepository.deleteAll(toDelete);
+        }
+
+        log.info("[RestaurantSync] stadiumId={} ({}): upserted={}, deleted={}",
+                stadiumId, stadium.getShortName(), toSave.size(), toDelete.size());
+    }
+
+    private List<RestaurantParam> fetchWithRetry(Stadium stadium) {
+        Exception lastException = null;
+
+        for (int attempt = 1; attempt <= MAX_RETRIES; attempt++) {
+            try {
+                return tourApiClient.fetchRestaurantsNear(
+                        stadium.getId(), stadium.getLongitude(), stadium.getLatitude());
+            } catch (TourApiException e) {
+                lastException = e;
+                log.warn("[RestaurantSync] Attempt {}/{} failed for stadiumId={}: {}",
+                        attempt, MAX_RETRIES, stadium.getId(), e.getMessage());
+                if (attempt < MAX_RETRIES) {
+                    sleepExponential(attempt);
+                }
+            }
+        }
+
+        throw new RuntimeException("All retries exhausted for stadiumId=" + stadium.getId(), lastException);
+    }
+
+    private void sleepExponential(int attempt) {
+        try {
+            long delayMs = 1000L << (attempt - 1); // 1s, 2s, 4s
+            Thread.sleep(delayMs);
+        } catch (InterruptedException ie) {
+            Thread.currentThread().interrupt();
+        }
+    }
+}

--- a/backend/app/src/main/resources/application.yml
+++ b/backend/app/src/main/resources/application.yml
@@ -78,6 +78,16 @@ api:
     read-timeout: 30s
     content-type: application/x-www-form-urlencoded; charset=UTF-8
 
+tour:
+  api:
+    # 공공데이터포털에서 발급받은 디코딩된(Decoded) 서비스키를 사용하세요. (이중 인코딩 방지)
+    service-key: ${TOUR_API_SERVICE_KEY}
+    base-url: https://apis.data.go.kr/B551011/KorService2
+    radius: 1000        # 구장 중심으로부터 반경 (미터)
+    num-of-rows: 50     # 한 번에 가져올 최대 결과 수
+    connect-timeout: 10s
+    read-timeout: 30s
+
 sse:
   heartbeat:
     enabled: true

--- a/backend/app/src/main/resources/db/migration/mysql/V17__create_restaurants.sql
+++ b/backend/app/src/main/resources/db/migration/mysql/V17__create_restaurants.sql
@@ -1,0 +1,19 @@
+CREATE TABLE restaurants
+(
+    restaurant_id BIGINT        NOT NULL AUTO_INCREMENT,
+    content_id    VARCHAR(50)   NOT NULL,
+    stadium_id    BIGINT        NOT NULL,
+    title         VARCHAR(255)  NOT NULL,
+    address       VARCHAR(512)  NULL,
+    map_x         DOUBLE        NOT NULL,
+    map_y         DOUBLE        NOT NULL,
+    distance      INT           NULL,
+    tel           VARCHAR(100)  NULL,
+    image_url     VARCHAR(1024) NULL,
+    created_at    DATETIME(6)   NOT NULL,
+    updated_at    DATETIME(6)   NOT NULL,
+    deleted_at    DATETIME(6)   NULL,
+    PRIMARY KEY (restaurant_id),
+    UNIQUE KEY uq_restaurants_content_stadium (content_id, stadium_id),
+    CONSTRAINT fk_restaurants_stadium FOREIGN KEY (stadium_id) REFERENCES stadiums (stadium_id)
+) ENGINE = InnoDB;

--- a/backend/app/src/test/java/com/yagubogu/restaurant/RestaurantE2eTest.java
+++ b/backend/app/src/test/java/com/yagubogu/restaurant/RestaurantE2eTest.java
@@ -1,0 +1,114 @@
+package com.yagubogu.restaurant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.yagubogu.auth.config.AuthTestConfig;
+import com.yagubogu.global.config.JpaAuditingConfig;
+import com.yagubogu.restaurant.domain.Restaurant;
+import com.yagubogu.restaurant.dto.v1.RestaurantsResponse;
+import com.yagubogu.restaurant.repository.RestaurantRepository;
+import com.yagubogu.support.base.E2eTestBase;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.context.annotation.Import;
+
+@Import({AuthTestConfig.class, JpaAuditingConfig.class})
+class RestaurantE2eTest extends E2eTestBase {
+
+    // 잠실야구장 (Flyway R__seed_lookup.sql로 시드된 구장 ID)
+    private static final Long JAMSIL_STADIUM_ID = 2L;
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private RestaurantRepository restaurantRepository;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+    }
+
+    @DisplayName("구장 ID로 주변 맛집 목록을 조회하면 저장된 맛집 정보가 반환된다")
+    @Test
+    void getRestaurantsByStadium_맛집_목록_반환() {
+        // given
+        restaurantRepository.save(
+                Restaurant.of("1001", JAMSIL_STADIUM_ID, "잠실 원조 순대국밥",
+                        "서울 송파구 올림픽로 25", 127.0715, 37.5122, 320, "02-123-4567", null));
+        restaurantRepository.save(
+                Restaurant.of("1002", JAMSIL_STADIUM_ID, "잠실 청국장",
+                        "서울 송파구 잠실동 10", 127.0720, 37.5130, 150, null, "https://img.com/img.jpg"));
+
+        // when & then
+        RestaurantsResponse response = RestAssured.given().log().all()
+                .contentType(ContentType.JSON)
+                .queryParam("stadiumId", JAMSIL_STADIUM_ID)
+                .when().get("/api/v1/restaurants")
+                .then().log().all()
+                .statusCode(200)
+                .extract()
+                .as(RestaurantsResponse.class);
+
+        assertThat(response.stadiumId()).isEqualTo(JAMSIL_STADIUM_ID);
+        assertThat(response.restaurants()).hasSize(2);
+        assertThat(response.restaurants()).extracting(r -> r.title())
+                .containsExactlyInAnyOrder("잠실 원조 순대국밥", "잠실 청국장");
+    }
+
+    @DisplayName("맛집이 없는 구장을 조회하면 빈 목록이 반환된다")
+    @Test
+    void getRestaurantsByStadium_맛집_없으면_빈_리스트() {
+        // when & then
+        RestaurantsResponse response = RestAssured.given().log().all()
+                .contentType(ContentType.JSON)
+                .queryParam("stadiumId", JAMSIL_STADIUM_ID)
+                .when().get("/api/v1/restaurants")
+                .then().log().all()
+                .statusCode(200)
+                .extract()
+                .as(RestaurantsResponse.class);
+
+        assertThat(response.stadiumId()).isEqualTo(JAMSIL_STADIUM_ID);
+        assertThat(response.restaurants()).isEmpty();
+    }
+
+    @DisplayName("stadiumId 없이 요청하면 400 Bad Request를 반환한다")
+    @Test
+    void getRestaurantsByStadium_stadiumId_누락_400() {
+        RestAssured.given().log().all()
+                .contentType(ContentType.JSON)
+                .when().get("/api/v1/restaurants")
+                .then().log().all()
+                .statusCode(400);
+    }
+
+    @DisplayName("맛집의 좌표(mapX, mapY)와 거리(distance) 정보가 응답에 포함된다")
+    @Test
+    void getRestaurantsByStadium_좌표_거리_포함() {
+        // given
+        restaurantRepository.save(
+                Restaurant.of("2001", JAMSIL_STADIUM_ID, "좌표 맛집",
+                        "서울 송파구", 127.0715, 37.5122, 300, "02-999-8888", null));
+
+        // when & then
+        RestaurantsResponse response = RestAssured.given()
+                .queryParam("stadiumId", JAMSIL_STADIUM_ID)
+                .when().get("/api/v1/restaurants")
+                .then()
+                .statusCode(200)
+                .extract()
+                .as(RestaurantsResponse.class);
+
+        var restaurant = response.restaurants().get(0);
+        assertThat(restaurant.mapX()).isEqualTo(127.0715);
+        assertThat(restaurant.mapY()).isEqualTo(37.5122);
+        assertThat(restaurant.distance()).isEqualTo(300);
+        assertThat(restaurant.tel()).isEqualTo("02-999-8888");
+    }
+}

--- a/backend/app/src/test/java/com/yagubogu/restaurant/client/TourApiClientTest.java
+++ b/backend/app/src/test/java/com/yagubogu/restaurant/client/TourApiClientTest.java
@@ -1,0 +1,233 @@
+package com.yagubogu.restaurant.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.yagubogu.restaurant.config.TourApiProperties;
+import com.yagubogu.restaurant.dto.RestaurantParam;
+import java.net.URI;
+import java.time.Duration;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
+
+@ExtendWith(MockitoExtension.class)
+class TourApiClientTest {
+
+    @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+    private RestClient restClient;
+
+    private TourApiClient tourApiClient;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @BeforeEach
+    void setUp() {
+        TourApiProperties props = new TourApiProperties(
+                "test-service-key",
+                "https://apis.data.go.kr/B551011/KorService2",
+                1000, 50,
+                Duration.ofSeconds(10), Duration.ofSeconds(30)
+        );
+        tourApiClient = new TourApiClient(restClient, props, objectMapper);
+    }
+
+    @DisplayName("유효한 API 응답을 RestaurantParam 리스트로 파싱한다")
+    @Test
+    void parseItems_유효한_응답_파싱() {
+        String json = """
+                {
+                  "header": { "resultCode": "0000", "resultMsg": "OK" },
+                  "body": {
+                    "numOfRows": 50,
+                    "pageNo": 1,
+                    "totalCount": 1,
+                    "items": {
+                      "item": [
+                        {
+                          "contentid": "2779091",
+                          "contenttypeid": "39",
+                          "title": "잠실 원조 순대국밥",
+                          "addr1": "서울특별시 송파구 올림픽로 25",
+                          "addr2": "",
+                          "mapx": "127.0715",
+                          "mapy": "37.5122",
+                          "dist": "320.5",
+                          "tel": "02-123-4567",
+                          "firstimage": "https://example.com/image.jpg"
+                        }
+                      ]
+                    }
+                  }
+                }
+                """;
+
+        List<RestaurantParam> result = tourApiClient.parseItems(json, 1L);
+
+        assertThat(result).hasSize(1);
+        RestaurantParam param = result.get(0);
+        assertThat(param.contentId()).isEqualTo("2779091");
+        assertThat(param.stadiumId()).isEqualTo(1L);
+        assertThat(param.title()).isEqualTo("잠실 원조 순대국밥");
+        assertThat(param.address()).isEqualTo("서울특별시 송파구 올림픽로 25");
+        assertThat(param.mapX()).isEqualTo(127.0715);
+        assertThat(param.mapY()).isEqualTo(37.5122);
+        assertThat(param.distance()).isEqualTo(320);
+        assertThat(param.tel()).isEqualTo("02-123-4567");
+        assertThat(param.imageUrl()).isEqualTo("https://example.com/image.jpg");
+    }
+
+    @DisplayName("items가 빈 문자열일 때 빈 리스트를 반환한다 (KTO API 결과 없음 엣지케이스)")
+    @Test
+    void parseItems_빈_문자열_items_빈_리스트_반환() {
+        String json = """
+                {
+                  "header": { "resultCode": "0000", "resultMsg": "OK" },
+                  "body": {
+                    "numOfRows": 50,
+                    "pageNo": 1,
+                    "totalCount": 0,
+                    "items": ""
+                  }
+                }
+                """;
+
+        List<RestaurantParam> result = tourApiClient.parseItems(json, 1L);
+
+        assertThat(result).isEmpty();
+    }
+
+    @DisplayName("resultCode가 0000이 아니면 빈 리스트를 반환한다")
+    @Test
+    void parseItems_비정상_resultCode_빈_리스트_반환() {
+        String json = """
+                {
+                  "header": { "resultCode": "99", "resultMsg": "SERVICE_ERROR" },
+                  "body": { "items": "" }
+                }
+                """;
+
+        List<RestaurantParam> result = tourApiClient.parseItems(json, 1L);
+
+        assertThat(result).isEmpty();
+    }
+
+    @DisplayName("선택 필드(tel, firstimage, addr1)가 없거나 비어있으면 null로 처리한다")
+    @Test
+    void parseItems_선택_필드_누락_시_null_처리() {
+        String json = """
+                {
+                  "header": { "resultCode": "0000", "resultMsg": "OK" },
+                  "body": {
+                    "numOfRows": 50,
+                    "pageNo": 1,
+                    "totalCount": 1,
+                    "items": {
+                      "item": [
+                        {
+                          "contentid": "9999",
+                          "title": "필드 없는 맛집",
+                          "mapx": "127.0",
+                          "mapy": "37.5",
+                          "dist": ""
+                        }
+                      ]
+                    }
+                  }
+                }
+                """;
+
+        List<RestaurantParam> result = tourApiClient.parseItems(json, 2L);
+
+        assertThat(result).hasSize(1);
+        RestaurantParam param = result.get(0);
+        assertThat(param.address()).isNull();
+        assertThat(param.tel()).isNull();
+        assertThat(param.imageUrl()).isNull();
+        assertThat(param.distance()).isNull();
+    }
+
+    @DisplayName("여러 아이템을 한 번에 파싱한다 (item이 배열)")
+    @Test
+    void parseItems_여러_아이템_파싱() {
+        String json = """
+                {
+                  "header": { "resultCode": "0000", "resultMsg": "OK" },
+                  "body": {
+                    "numOfRows": 50,
+                    "pageNo": 1,
+                    "totalCount": 3,
+                    "items": {
+                      "item": [
+                        { "contentid": "1", "title": "맛집A", "mapx": "127.0", "mapy": "37.5" },
+                        { "contentid": "2", "title": "맛집B", "mapx": "127.1", "mapy": "37.6" },
+                        { "contentid": "3", "title": "맛집C", "mapx": "127.2", "mapy": "37.7" }
+                      ]
+                    }
+                  }
+                }
+                """;
+
+        List<RestaurantParam> result = tourApiClient.parseItems(json, 1L);
+
+        assertThat(result).hasSize(3);
+        assertThat(result).extracting(RestaurantParam::contentId)
+                .containsExactly("1", "2", "3");
+    }
+
+    @DisplayName("단건 결과일 때 item이 배열이 아닌 단일 객체로 와도 파싱한다")
+    @Test
+    void parseItems_단건_item_객체_파싱() {
+        String json = """
+                {
+                  "header": { "resultCode": "0000", "resultMsg": "OK" },
+                  "body": {
+                    "numOfRows": 50,
+                    "pageNo": 1,
+                    "totalCount": 1,
+                    "items": {
+                      "item": {
+                        "contentid": "9001",
+                        "title": "단건 맛집",
+                        "addr1": "서울 강남구",
+                        "mapx": "127.0495",
+                        "mapy": "37.5145",
+                        "dist": "450",
+                        "tel": "02-999-1234",
+                        "firstimage": "https://img.com/food.jpg"
+                      }
+                    }
+                  }
+                }
+                """;
+
+        List<RestaurantParam> result = tourApiClient.parseItems(json, 1L);
+
+        assertThat(result).hasSize(1);
+        RestaurantParam param = result.get(0);
+        assertThat(param.contentId()).isEqualTo("9001");
+        assertThat(param.title()).isEqualTo("단건 맛집");
+        assertThat(param.distance()).isEqualTo(450);
+    }
+
+    @DisplayName("HTTP 호출 실패 시 TourApiException을 던진다")
+    @Test
+    void fetchRestaurantsNear_HTTP_실패_시_TourApiException() {
+        when(restClient.get().uri(any(URI.class)).retrieve().body(String.class))
+                .thenThrow(new RestClientException("Connection refused"));
+
+        assertThatThrownBy(() -> tourApiClient.fetchRestaurantsNear(1L, 127.07, 37.51))
+                .isInstanceOf(TourApiException.class)
+                .hasMessageContaining("Tour API call failed for stadiumId=1");
+    }
+}

--- a/backend/app/src/test/java/com/yagubogu/restaurant/service/RestaurantQueryServiceTest.java
+++ b/backend/app/src/test/java/com/yagubogu/restaurant/service/RestaurantQueryServiceTest.java
@@ -1,0 +1,70 @@
+package com.yagubogu.restaurant.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+import com.yagubogu.restaurant.domain.Restaurant;
+import com.yagubogu.restaurant.dto.v1.RestaurantsResponse;
+import com.yagubogu.restaurant.repository.RestaurantRepository;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class RestaurantQueryServiceTest {
+
+    @Mock
+    private RestaurantRepository restaurantRepository;
+
+    @InjectMocks
+    private RestaurantQueryService restaurantQueryService;
+
+    @DisplayName("구장 ID로 맛집 목록을 반환한다")
+    @Test
+    void findByStadium_맛집_목록_반환() {
+        Long stadiumId = 1L;
+        List<Restaurant> restaurants = List.of(
+                Restaurant.of("1001", stadiumId, "맛집A", "서울 송파구", 127.07, 37.51, 300, "02-111", null),
+                Restaurant.of("1002", stadiumId, "맛집B", "서울 송파구", 127.08, 37.52, 500, null, "https://img.com")
+        );
+        given(restaurantRepository.findAllByStadiumId(stadiumId)).willReturn(restaurants);
+
+        RestaurantsResponse response = restaurantQueryService.findByStadium(stadiumId);
+
+        assertThat(response.stadiumId()).isEqualTo(stadiumId);
+        assertThat(response.restaurants()).hasSize(2);
+        assertThat(response.restaurants()).extracting(r -> r.title())
+                .containsExactly("맛집A", "맛집B");
+        assertThat(response.restaurants().get(0).distance()).isEqualTo(300);
+        assertThat(response.restaurants().get(1).imageUrl()).isEqualTo("https://img.com");
+    }
+
+    @DisplayName("해당 구장에 맛집이 없으면 빈 리스트를 반환한다")
+    @Test
+    void findByStadium_맛집_없으면_빈_리스트() {
+        Long stadiumId = 99L;
+        given(restaurantRepository.findAllByStadiumId(stadiumId)).willReturn(List.of());
+
+        RestaurantsResponse response = restaurantQueryService.findByStadium(stadiumId);
+
+        assertThat(response.stadiumId()).isEqualTo(stadiumId);
+        assertThat(response.restaurants()).isEmpty();
+    }
+
+    @DisplayName("응답에 mapX, mapY 좌표가 포함된다")
+    @Test
+    void findByStadium_좌표_포함_반환() {
+        Long stadiumId = 2L;
+        Restaurant restaurant = Restaurant.of("2001", stadiumId, "좌표맛집", null, 127.0715, 37.5122, null, null, null);
+        given(restaurantRepository.findAllByStadiumId(stadiumId)).willReturn(List.of(restaurant));
+
+        RestaurantsResponse response = restaurantQueryService.findByStadium(stadiumId);
+
+        assertThat(response.restaurants().get(0).mapX()).isEqualTo(127.0715);
+        assertThat(response.restaurants().get(0).mapY()).isEqualTo(37.5122);
+    }
+}

--- a/backend/app/src/test/java/com/yagubogu/restaurant/service/RestaurantSyncServiceTest.java
+++ b/backend/app/src/test/java/com/yagubogu/restaurant/service/RestaurantSyncServiceTest.java
@@ -1,0 +1,177 @@
+package com.yagubogu.restaurant.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyDouble;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.yagubogu.restaurant.client.TourApiClient;
+import com.yagubogu.restaurant.client.TourApiException;
+import com.yagubogu.restaurant.domain.Restaurant;
+import com.yagubogu.restaurant.dto.RestaurantParam;
+import com.yagubogu.restaurant.repository.RestaurantRepository;
+import com.yagubogu.stadium.domain.Stadium;
+import com.yagubogu.stadium.domain.StadiumLevel;
+import com.yagubogu.stadium.repository.StadiumRepository;
+import java.lang.reflect.Field;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class RestaurantSyncServiceTest {
+
+    @Mock
+    private TourApiClient tourApiClient;
+
+    @Mock
+    private RestaurantRepository restaurantRepository;
+
+    @Mock
+    private StadiumRepository stadiumRepository;
+
+    @InjectMocks
+    private RestaurantSyncService restaurantSyncService;
+
+    private Stadium jamsil;
+    private Stadium suwon;
+
+    @BeforeEach
+    void setUp() {
+        jamsil = stadium(1L, "잠실", 37.5122, 127.0715);
+        suwon = stadium(2L, "수원", 37.2998, 127.0097);
+    }
+
+    @DisplayName("API에서 받은 신규 맛집을 DB에 저장한다")
+    @Test
+    void syncForStadium_신규_맛집_저장() {
+        List<RestaurantParam> fetched = List.of(
+                new RestaurantParam("1001", 1L, "맛집A", "서울 송파구", 127.07, 37.51, 300, "02-111", null)
+        );
+        given(tourApiClient.fetchRestaurantsNear(anyLong(), anyDouble(), anyDouble())).willReturn(fetched);
+        given(restaurantRepository.findAllByStadiumId(1L)).willReturn(List.of());
+
+        restaurantSyncService.syncForStadium(jamsil);
+
+        ArgumentCaptor<List<Restaurant>> captor = ArgumentCaptor.forClass(List.class);
+        verify(restaurantRepository).saveAll(captor.capture());
+        assertThat(captor.getValue()).hasSize(1);
+        assertThat(captor.getValue().get(0).getContentId()).isEqualTo("1001");
+        assertThat(captor.getValue().get(0).getTitle()).isEqualTo("맛집A");
+        verify(restaurantRepository, never()).deleteAll(any());
+    }
+
+    @DisplayName("이미 존재하는 맛집의 정보를 업데이트한다")
+    @Test
+    void syncForStadium_기존_맛집_업데이트() {
+        Restaurant existing = Restaurant.of("1001", 1L, "구 이름", "구 주소", 127.0, 37.5, 500, null, null);
+
+        List<RestaurantParam> fetched = List.of(
+                new RestaurantParam("1001", 1L, "새 이름", "새 주소", 127.07, 37.51, 300, "02-111", "https://img.com")
+        );
+        given(tourApiClient.fetchRestaurantsNear(anyLong(), anyDouble(), anyDouble())).willReturn(fetched);
+        given(restaurantRepository.findAllByStadiumId(1L)).willReturn(List.of(existing));
+
+        restaurantSyncService.syncForStadium(jamsil);
+
+        ArgumentCaptor<List<Restaurant>> captor = ArgumentCaptor.forClass(List.class);
+        verify(restaurantRepository).saveAll(captor.capture());
+        Restaurant updated = captor.getValue().get(0);
+        assertThat(updated.getTitle()).isEqualTo("새 이름");
+        assertThat(updated.getAddress()).isEqualTo("새 주소");
+        assertThat(updated.getDistance()).isEqualTo(300);
+        assertThat(updated.getImageUrl()).isEqualTo("https://img.com");
+    }
+
+    @DisplayName("API 응답에 없는 기존 맛집은 삭제한다")
+    @Test
+    void syncForStadium_사라진_맛집_삭제() {
+        Restaurant stale = Restaurant.of("GONE", 1L, "없어진 맛집", null, 127.0, 37.5, null, null, null);
+
+        List<RestaurantParam> fetched = List.of(
+                new RestaurantParam("NEW", 1L, "새 맛집", null, 127.07, 37.51, 100, null, null)
+        );
+        given(tourApiClient.fetchRestaurantsNear(anyLong(), anyDouble(), anyDouble())).willReturn(fetched);
+        given(restaurantRepository.findAllByStadiumId(1L)).willReturn(List.of(stale));
+
+        restaurantSyncService.syncForStadium(jamsil);
+
+        ArgumentCaptor<List<Restaurant>> deleteCaptor = ArgumentCaptor.forClass(List.class);
+        verify(restaurantRepository).deleteAll(deleteCaptor.capture());
+        assertThat(deleteCaptor.getValue()).hasSize(1);
+        assertThat(deleteCaptor.getValue().get(0).getContentId()).isEqualTo("GONE");
+    }
+
+    @DisplayName("API 호출이 실패하면 재시도하고, 성공 시 동기화를 완료한다")
+    @Test
+    void syncForStadium_재시도_후_성공() {
+        List<RestaurantParam> fetched = List.of(
+                new RestaurantParam("1001", 1L, "맛집A", null, 127.07, 37.51, 100, null, null)
+        );
+        given(tourApiClient.fetchRestaurantsNear(anyLong(), anyDouble(), anyDouble()))
+                .willThrow(new TourApiException("timeout", new RuntimeException()))
+                .willReturn(fetched);
+        given(restaurantRepository.findAllByStadiumId(1L)).willReturn(List.of());
+
+        restaurantSyncService.syncForStadium(jamsil);
+
+        verify(tourApiClient, times(2)).fetchRestaurantsNear(anyLong(), anyDouble(), anyDouble());
+        verify(restaurantRepository).saveAll(any());
+    }
+
+    @DisplayName("syncAll은 한 구장이 실패해도 나머지 구장의 동기화를 계속한다")
+    @Test
+    void syncAll_한_구장_실패해도_나머지_진행() {
+        given(stadiumRepository.findAll()).willReturn(List.of(jamsil, suwon));
+        given(tourApiClient.fetchRestaurantsNear(anyLong(), anyDouble(), anyDouble()))
+                .willThrow(new TourApiException("fail", new RuntimeException()));
+
+        restaurantSyncService.syncAll();
+
+        // 2개 구장 × 최대 3회 재시도 = 6번 호출
+        verify(tourApiClient, times(6)).fetchRestaurantsNear(anyLong(), anyDouble(), anyDouble());
+        verify(restaurantRepository, never()).saveAll(any());
+    }
+
+    @DisplayName("API 응답이 비어있으면 기존 데이터를 모두 삭제한다")
+    @Test
+    void syncForStadium_API_빈_응답_기존_데이터_삭제() {
+        Restaurant existing = Restaurant.of("OLD", 1L, "기존 맛집", null, 127.0, 37.5, null, null, null);
+
+        given(tourApiClient.fetchRestaurantsNear(anyLong(), anyDouble(), anyDouble())).willReturn(List.of());
+        given(restaurantRepository.findAllByStadiumId(1L)).willReturn(List.of(existing));
+
+        restaurantSyncService.syncForStadium(jamsil);
+
+        ArgumentCaptor<List<Restaurant>> saveCaptor = ArgumentCaptor.forClass(List.class);
+        verify(restaurantRepository).saveAll(saveCaptor.capture());
+        assertThat(saveCaptor.getValue()).isEmpty();
+
+        ArgumentCaptor<List<Restaurant>> deleteCaptor = ArgumentCaptor.forClass(List.class);
+        verify(restaurantRepository).deleteAll(deleteCaptor.capture());
+        assertThat(deleteCaptor.getValue()).isNotEmpty();
+    }
+
+    // Stadium은 @GeneratedValue이므로 리플렉션으로 ID 주입
+    private static Stadium stadium(long id, String shortName, double lat, double lon) {
+        Stadium s = new Stadium("full-" + shortName, shortName, "loc", lat, lon, StadiumLevel.MAIN);
+        try {
+            Field f = Stadium.class.getDeclaredField("id");
+            f.setAccessible(true);
+            f.set(s, id);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        return s;
+    }
+}

--- a/backend/app/src/test/java/com/yagubogu/support/base/E2eTestBase.java
+++ b/backend/app/src/test/java/com/yagubogu/support/base/E2eTestBase.java
@@ -66,6 +66,7 @@ public abstract class E2eTestBase {
             em.createNativeQuery("TRUNCATE TABLE likes").executeUpdate();
             em.createNativeQuery("TRUNCATE TABLE like_windows").executeUpdate();
             em.createNativeQuery("TRUNCATE TABLE member_badges").executeUpdate();
+            em.createNativeQuery("TRUNCATE TABLE restaurants").executeUpdate();
 
             em.createNativeQuery("SET FOREIGN_KEY_CHECKS = 1").executeUpdate();
         });

--- a/backend/app/src/test/resources/application.yml
+++ b/backend/app/src/test/resources/application.yml
@@ -64,6 +64,15 @@ sse:
     enabled: true
     interval-ms: 25000
 
+tour:
+  api:
+    service-key: test-service-key
+    base-url: https://apis.data.go.kr/B551011/KorService2
+    radius: 1000
+    num-of-rows: 50
+    connect-timeout: 10s
+    read-timeout: 30s
+
 app:
   s3:
     bucket: yagubogu


### PR DESCRIPTION
구장 주변 음식점 데이터를 KTO locationBasedList2 API로 매일 오전 3시에 수집하여 DB에 upsert하고 /api/v1/restaurants 엔드포인트로 조회 가능하도록 구현.
Flyway 마이그레이션(V17), 재시도 로직, E2e/단위 테스트 포함.

## 📌 관련 이슈
- close #이슈번호

## ✨ 변경 내용
- 어떤 기능/수정이 포함되었는지 간단 요약

## 🎸 기타 참고 사항
- 스크린샷, 참고 링크, 추가 설명 등 (없으면 생략 가능)