### PR TITLE
fix: KBO gameCode 기반 경기 정합성 개선

### DIFF
--- a/backend/app/src/main/java/com/yagubogu/game/domain/BronzeGame.java
+++ b/backend/app/src/main/java/com/yagubogu/game/domain/BronzeGame.java
@@ -33,6 +33,9 @@ public class BronzeGame {
     @Column(name = "raw_id")
     private Long id;
 
+    @Column(name = "game_code", unique = true, length = 20)
+    private String gameCode;
+
     @Column(name = "date", nullable = false)
     private LocalDate date;
 
@@ -65,7 +68,8 @@ public class BronzeGame {
     @Column(name = "state", length = 30)
     private GameState state;
 
-    public BronzeGame(final LocalDate date,
+    public BronzeGame(final String gameCode,
+                      final LocalDate date,
                       final String stadium,
                       final String homeTeam,
                       final String awayTeam,
@@ -73,6 +77,7 @@ public class BronzeGame {
                       final LocalDateTime collectedAt,
                       final String payload,
                       final String contentHash) {
+        this.gameCode = gameCode;
         this.date = date;
         this.stadium = stadium;
         this.homeTeam = homeTeam;
@@ -85,7 +90,21 @@ public class BronzeGame {
         this.state = null;
     }
 
-    public void update(final LocalDateTime collectedAt, final String payload, final String contentHash) {
+    public void update(final String gameCode,
+                       final LocalDate date,
+                       final String stadium,
+                       final String homeTeam,
+                       final String awayTeam,
+                       final LocalTime startTime,
+                       final LocalDateTime collectedAt,
+                       final String payload,
+                       final String contentHash) {
+        this.gameCode = gameCode;
+        this.date = date;
+        this.stadium = stadium;
+        this.homeTeam = homeTeam;
+        this.awayTeam = awayTeam;
+        this.startTime = startTime;
         this.collectedAt = collectedAt;
         this.payload = payload;
         this.contentHash = contentHash;
@@ -96,11 +115,21 @@ public class BronzeGame {
         this.etlProcessedAt = processedAt;
     }
 
+    public boolean updateGameCode(final String newGameCode) {
+        if (newGameCode == null || newGameCode.isBlank() || newGameCode.equals(this.gameCode)) {
+            return false;
+        }
+        this.gameCode = newGameCode;
+        this.etlProcessedAt = null;
+        return true;
+    }
+
     public boolean updateState(final GameState newState) {
         if (newState == null || newState.equals(this.state)) {
             return false;
         }
         this.state = newState;
+        this.etlProcessedAt = null;
         return true;
     }
 }

--- a/backend/app/src/main/java/com/yagubogu/game/domain/BronzeGame.java
+++ b/backend/app/src/main/java/com/yagubogu/game/domain/BronzeGame.java
@@ -12,6 +12,7 @@ import jakarta.persistence.UniqueConstraint;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.util.Objects;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -115,11 +116,31 @@ public class BronzeGame {
         this.etlProcessedAt = processedAt;
     }
 
-    public boolean updateGameCode(final String newGameCode) {
-        if (newGameCode == null || newGameCode.isBlank() || newGameCode.equals(this.gameCode)) {
+    public boolean updateMetadata(final String newGameCode,
+                                  final LocalDate newDate,
+                                  final String newStadium,
+                                  final String newHomeTeam,
+                                  final String newAwayTeam,
+                                  final LocalTime newStartTime,
+                                  final LocalDateTime newCollectedAt) {
+        String resolvedGameCode = newGameCode == null || newGameCode.isBlank() ? this.gameCode : newGameCode;
+        boolean changed = !Objects.equals(this.gameCode, resolvedGameCode)
+                || !Objects.equals(this.date, newDate)
+                || !Objects.equals(this.stadium, newStadium)
+                || !Objects.equals(this.homeTeam, newHomeTeam)
+                || !Objects.equals(this.awayTeam, newAwayTeam)
+                || !Objects.equals(this.startTime, newStartTime);
+        if (!changed) {
             return false;
         }
-        this.gameCode = newGameCode;
+
+        this.gameCode = resolvedGameCode;
+        this.date = newDate;
+        this.stadium = newStadium;
+        this.homeTeam = newHomeTeam;
+        this.awayTeam = newAwayTeam;
+        this.startTime = newStartTime;
+        this.collectedAt = newCollectedAt;
         this.etlProcessedAt = null;
         return true;
     }

--- a/backend/app/src/main/java/com/yagubogu/game/domain/GameState.java
+++ b/backend/app/src/main/java/com/yagubogu/game/domain/GameState.java
@@ -46,7 +46,7 @@ public enum GameState {
         }
 
         return switch (this) {
-            case SCHEDULED -> newState == LIVE || newState == CANCELED;
+            case SCHEDULED -> newState == LIVE || newState == COMPLETED || newState == CANCELED;
             case LIVE -> newState == COMPLETED || newState == CANCELED;
             default -> false;
         };

--- a/backend/app/src/main/java/com/yagubogu/game/event/GameFinalizedEventHandler.java
+++ b/backend/app/src/main/java/com/yagubogu/game/event/GameFinalizedEventHandler.java
@@ -28,6 +28,7 @@ public class GameFinalizedEventHandler {
         try {
             // 단일 게임 ETL
             gameEtlService.transformSpecificGame(
+                    event.gameCode(),
                     event.date(),
                     event.stadium(),
                     event.homeTeam(),

--- a/backend/app/src/main/java/com/yagubogu/game/repository/BronzeGameRepository.java
+++ b/backend/app/src/main/java/com/yagubogu/game/repository/BronzeGameRepository.java
@@ -12,6 +12,8 @@ import org.springframework.data.repository.query.Param;
 
 public interface BronzeGameRepository extends JpaRepository<BronzeGame, Long> {
 
+    Optional<BronzeGame> findByGameCode(String gameCode);
+
     /**
      * 미처리 Bronze 데이터 조회 (ETL용)
      * collected_at >= since AND etl_processed_at IS NULL
@@ -24,12 +26,30 @@ public interface BronzeGameRepository extends JpaRepository<BronzeGame, Long> {
             """)
     List<BronzeGame> findPendingEtl(@Param("since") LocalDateTime since);
 
+    @Query("""
+            SELECT b FROM BronzeGame b
+            WHERE b.date BETWEEN :startDate AND :endDate
+            AND b.etlProcessedAt IS NULL
+            ORDER BY b.date, b.startTime
+            """)
+    List<BronzeGame> findPendingEtlByDateRange(
+            @Param("startDate") LocalDate startDate,
+            @Param("endDate") LocalDate endDate
+    );
+
     Optional<BronzeGame> findByDateAndStadiumAndHomeTeamAndAwayTeamAndStartTime(
             LocalDate date,
             String stadium,
             String homeTeam,
             String awayTeam,
             LocalTime startTime
+    );
+
+    List<BronzeGame> findByDateAndStadiumAndHomeTeamAndAwayTeam(
+            LocalDate date,
+            String stadium,
+            String homeTeam,
+            String awayTeam
     );
 
     @Query("SELECT b FROM BronzeGame b WHERE b.collectedAt >= :since ORDER BY b.collectedAt DESC")

--- a/backend/app/src/main/java/com/yagubogu/game/repository/GameRepository.java
+++ b/backend/app/src/main/java/com/yagubogu/game/repository/GameRepository.java
@@ -31,6 +31,13 @@ public interface GameRepository extends JpaRepository<Game, Long> {
             LocalTime startAt
     );
 
+    List<Game> findByDateAndStadiumAndHomeTeamAndAwayTeam(
+            LocalDate date,
+            Stadium stadium,
+            Team homeTeam,
+            Team awayTeam
+    );
+
     @Query("""
             SELECT new com.yagubogu.game.dto.GameWithCheckInParam(
                 g.id,

--- a/backend/app/src/main/java/com/yagubogu/game/service/BronzeGameService.java
+++ b/backend/app/src/main/java/com/yagubogu/game/service/BronzeGameService.java
@@ -10,6 +10,9 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.HexFormat;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -24,6 +27,7 @@ public class BronzeGameService {
 
     @Transactional
     public boolean upsertByNaturalKey(
+            final String gameCode,
             final LocalDate date,
             final String stadium,
             final String homeTeam,
@@ -34,19 +38,54 @@ public class BronzeGameService {
         final String contentHash = calculateHash(payload);
         final LocalDateTime now = LocalDateTime.now();
 
-        return bronzeGameRepository
-                .findByDateAndStadiumAndHomeTeamAndAwayTeamAndStartTime(
-                        date, stadium, homeTeam, awayTeam, startTime
-                )
-                .map(existing -> updateIfHashChanged(existing, payload, contentHash, now))
+        return findExisting(gameCode, date, stadium, homeTeam, awayTeam, startTime)
+                .map(existing -> updateIfHashChanged(
+                        existing, gameCode, date, stadium, homeTeam, awayTeam, startTime,
+                        payload, contentHash, now
+                ))
                 .orElseGet(() -> createNewByNaturalKey(
-                        date, stadium, homeTeam, awayTeam, startTime,
+                        gameCode, date, stadium, homeTeam, awayTeam, startTime,
                         payload, contentHash, now
                 ));
     }
 
+    private Optional<BronzeGame> findExisting(
+            final String gameCode,
+            final LocalDate date,
+            final String stadium,
+            final String homeTeam,
+            final String awayTeam,
+            final LocalTime startTime
+    ) {
+        if (gameCode != null && !gameCode.isBlank()) {
+            Optional<BronzeGame> byGameCode = bronzeGameRepository.findByGameCode(gameCode);
+            if (byGameCode.isPresent()) {
+                return byGameCode;
+            }
+        }
+
+        Optional<BronzeGame> byNaturalKey = bronzeGameRepository
+                .findByDateAndStadiumAndHomeTeamAndAwayTeamAndStartTime(
+                date, stadium, homeTeam, awayTeam, startTime
+        );
+        if (byNaturalKey.isPresent()) {
+            return byNaturalKey;
+        }
+
+        List<BronzeGame> sameMatchup = bronzeGameRepository.findByDateAndStadiumAndHomeTeamAndAwayTeam(
+                date, stadium, homeTeam, awayTeam
+        );
+        if (sameMatchup.size() == 1) {
+            log.info("Bronze matched without startTime: gameCode={}, date={}, stadium={}, home={}, away={}",
+                    gameCode, date, stadium, homeTeam, awayTeam);
+            return Optional.of(sameMatchup.getFirst());
+        }
+        return Optional.empty();
+    }
+
     @Transactional
     public boolean updateGameState(
+            final String gameCode,
             final LocalDate date,
             final String stadium,
             final String homeTeam,
@@ -54,15 +93,14 @@ public class BronzeGameService {
             final LocalTime startTime,
             final GameState gameState
     ) {
-        return bronzeGameRepository
-                .findByDateAndStadiumAndHomeTeamAndAwayTeamAndStartTime(
-                        date, stadium, homeTeam, awayTeam, startTime
-                )
+        return findExisting(gameCode, date, stadium, homeTeam, awayTeam, startTime)
                 .map(existing -> {
-                    boolean updated = existing.updateState(gameState);
+                    boolean gameCodeUpdated = existing.updateGameCode(gameCode);
+                    boolean stateUpdated = existing.updateState(gameState);
+                    boolean updated = gameCodeUpdated || stateUpdated;
                     if (updated) {
-                        log.info("Bronze gameCenterState updated: date={}, stadium={}, home={}, away={}, state={}",
-                                date, stadium, homeTeam, awayTeam, gameState);
+                        log.info("Bronze GameCenter data updated: gameCode={}, date={}, stadium={}, home={}, away={}, state={}",
+                                gameCode, date, stadium, homeTeam, awayTeam, gameState);
                     }
                     return updated;
                 })
@@ -73,21 +111,35 @@ public class BronzeGameService {
                 });
     }
 
-    private boolean updateIfHashChanged(final BronzeGame existing, final String payload,
+    private boolean updateIfHashChanged(final BronzeGame existing,
+                                        final String gameCode,
+                                        final LocalDate date,
+                                        final String stadium,
+                                        final String homeTeam,
+                                        final String awayTeam,
+                                        final LocalTime startTime,
+                                        final String payload,
                                         final String contentHash, final LocalDateTime now) {
-        if (existing.getContentHash().equals(contentHash)) {
+        boolean identityChanged = !Objects.equals(existing.getGameCode(), gameCode)
+                || !existing.getDate().equals(date)
+                || !existing.getStadium().equals(stadium)
+                || !existing.getHomeTeam().equals(homeTeam)
+                || !existing.getAwayTeam().equals(awayTeam)
+                || !Objects.equals(existing.getStartTime(), startTime);
+        if (!identityChanged && existing.getContentHash().equals(contentHash)) {
             log.debug("No change detected: date={}, stadium={}, home={}, away={}",
                     existing.getDate(), existing.getStadium(), existing.getHomeTeam(), existing.getAwayTeam());
             return false;
         }
 
-        existing.update(now, payload, contentHash);
+        existing.update(gameCode, date, stadium, homeTeam, awayTeam, startTime, now, payload, contentHash);
         log.info("Bronze updated: date={}, stadium={}, home={}, away={}",
                 existing.getDate(), existing.getStadium(), existing.getHomeTeam(), existing.getAwayTeam());
         return true;
     }
 
     private boolean createNewByNaturalKey(
+            final String gameCode,
             final LocalDate date,
             final String stadium,
             final String homeTeam,
@@ -98,7 +150,7 @@ public class BronzeGameService {
             final LocalDateTime now
     ) {
         final BronzeGame bronzeGame = new BronzeGame(
-                date, stadium, homeTeam, awayTeam, startTime,
+                gameCode, date, stadium, homeTeam, awayTeam, startTime,
                 now, payload, contentHash
         );
         bronzeGameRepository.save(bronzeGame);

--- a/backend/app/src/main/java/com/yagubogu/game/service/BronzeGameService.java
+++ b/backend/app/src/main/java/com/yagubogu/game/service/BronzeGameService.java
@@ -95,12 +95,15 @@ public class BronzeGameService {
     ) {
         return findExisting(gameCode, date, stadium, homeTeam, awayTeam, startTime)
                 .map(existing -> {
-                    boolean gameCodeUpdated = existing.updateGameCode(gameCode);
+                    boolean metadataUpdated = existing.updateMetadata(
+                            gameCode, date, stadium, homeTeam, awayTeam, startTime, LocalDateTime.now()
+                    );
                     boolean stateUpdated = existing.updateState(gameState);
-                    boolean updated = gameCodeUpdated || stateUpdated;
+                    boolean updated = metadataUpdated || stateUpdated;
                     if (updated) {
-                        log.info("Bronze GameCenter data updated: gameCode={}, date={}, stadium={}, home={}, away={}, state={}",
-                                gameCode, date, stadium, homeTeam, awayTeam, gameState);
+                        log.info("Bronze GameCenter data updated: gameCode={}, date={}, stadium={}, home={}, away={}, "
+                                        + "startTime={}, state={}, metadataChanged={}",
+                                gameCode, date, stadium, homeTeam, awayTeam, startTime, gameState, metadataUpdated);
                     }
                     return updated;
                 })

--- a/backend/app/src/main/java/com/yagubogu/game/service/GameEtlService.java
+++ b/backend/app/src/main/java/com/yagubogu/game/service/GameEtlService.java
@@ -30,6 +30,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
 
 /**
  * Bronze → Silver ETL 서비스
@@ -47,6 +48,7 @@ public class GameEtlService {
     private final StadiumRepository stadiumRepository;
     private final ObjectMapper objectMapper;
     private final Clock clock;
+    private final TransactionTemplate transactionTemplate;
 
     /**
      * 최근 수집된 Bronze 데이터를 Silver로 ETL
@@ -55,12 +57,18 @@ public class GameEtlService {
      * @param since 이 시각 이후 수집된 데이터만 처리
      * @return 처리된 게임 수
      */
-    @Transactional
     public int transformBronzeToSilver(final LocalDateTime since) {
-         final List<BronzeGame> bronzeGames = bronzeGameRepository.findPendingEtl(since);
+        return transformPendingGames(bronzeGameRepository.findPendingEtl(since));
+    }
+
+    public int transformPendingDateRange(final LocalDate startDate, final LocalDate endDate) {
+        return transformPendingGames(bronzeGameRepository.findPendingEtlByDateRange(startDate, endDate));
+    }
+
+    private int transformPendingGames(final List<BronzeGame> bronzeGames) {
 
         if (bronzeGames.isEmpty()) {
-            log.debug("No bronze data to transform since {}", since);
+            log.debug("No pending bronze data to transform");
             return 0;
         }
 
@@ -97,10 +105,12 @@ public class GameEtlService {
             for (BronzeGame bronzeGame : gamesOnDate) {
                 try {
                     final int order = doubleHeaderOrderMap.getOrDefault(bronzeGame, 0);
-                    transformSingleGame(bronzeGame, order);
-                    bronzeGame.markEtlProcessed(LocalDateTime.now(clock));
-
-                    transformedCount++;
+                    Boolean transformed = transactionTemplate.execute(status ->
+                            transformAndMarkProcessed(bronzeGame.getId(), order)
+                    );
+                    if (Boolean.TRUE.equals(transformed)) {
+                        transformedCount++;
+                    }
                 } catch (Exception e) {
                     log.error("Failed to transform bronze game: bronzeGameId={}",
                             bronzeGame.getId(), e);
@@ -112,23 +122,34 @@ public class GameEtlService {
         return transformedCount;
     }
 
+    private boolean transformAndMarkProcessed(final Long bronzeGameId, final int doubleHeaderOrder) {
+        final BronzeGame bronzeGame = bronzeGameRepository.findById(bronzeGameId)
+                .orElseThrow(() -> new NotFoundException("Bronze game not found: " + bronzeGameId));
+        try {
+            transformSingleGame(bronzeGame, doubleHeaderOrder);
+            bronzeGame.markEtlProcessed(LocalDateTime.now(clock));
+            return true;
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to transform bronze game: " + bronzeGameId, e);
+        }
+    }
+
     /**
      * 특정 게임 코드들에 대해 즉시 ETL 실행
      *
      * 경기 종료 이벤트 발생 시 호출
      */
-    @Transactional
     public void transformSpecificGame(
+            final String gameCode,
             final LocalDate date,
             final String stadium,
             final String homeTeam,
             final String awayTeam,
             final LocalTime startTime
     ) {
-        final Optional<BronzeGame> bronzeGameOpt = bronzeGameRepository
-                .findByDateAndStadiumAndHomeTeamAndAwayTeamAndStartTime(
-                        date, stadium, homeTeam, awayTeam, startTime
-                );
+        final Optional<BronzeGame> bronzeGameOpt = findBronzeGame(
+                gameCode, date, stadium, homeTeam, awayTeam, startTime
+        );
 
         if (bronzeGameOpt.isEmpty()) {
             log.warn("Bronze game not found: date={}, stadium={}, home={}, away={}",
@@ -156,13 +177,35 @@ public class GameEtlService {
                 }
             }
 
-            transformSingleGame(targetGame, order);
+            final int doubleHeaderOrder = order;
+            transactionTemplate.executeWithoutResult(status ->
+                    transformAndMarkProcessed(targetGame.getId(), doubleHeaderOrder)
+            );
             log.info("Immediate ETL completed: date={}, home={}, away={}, order={}",
                     date, homeTeam, awayTeam, order);
         } catch (Exception e) {
             log.error("Failed to transform game: date={}, home={}, away={}",
                     date, homeTeam, awayTeam, e);
         }
+    }
+
+    private Optional<BronzeGame> findBronzeGame(
+            final String gameCode,
+            final LocalDate date,
+            final String stadium,
+            final String homeTeam,
+            final String awayTeam,
+            final LocalTime startTime
+    ) {
+        if (gameCode != null && !gameCode.isBlank()) {
+            Optional<BronzeGame> byGameCode = bronzeGameRepository.findByGameCode(gameCode);
+            if (byGameCode.isPresent()) {
+                return byGameCode;
+            }
+        }
+        return bronzeGameRepository.findByDateAndStadiumAndHomeTeamAndAwayTeamAndStartTime(
+                date, stadium, homeTeam, awayTeam, startTime
+        );
     }
 
     /**
@@ -267,10 +310,16 @@ public class GameEtlService {
         final Stadium stadium = stadiumRepository.findByLocation(stadiumLocation)
                 .orElseThrow(() -> new NotFoundException("Stadium not found: " + stadiumLocation));
 
-        // 올바른 더블헤더 순서로 게임 코드 생성
-        final String gameCode = generateGameCode(date, homeTeam, awayTeam, doubleHeaderOrder);
+        // KBO가 제공한 gameId를 사용하고, 기존 Bronze 데이터만 조합 방식으로 호환한다.
+        final String payloadGameCode = json.path("gameCode").asText(null);
+        final String gameCode = firstNonBlank(
+                bronzeGame.getGameCode(),
+                payloadGameCode,
+                generateGameCode(date, homeTeam, awayTeam, doubleHeaderOrder)
+        );
 
-        final GameState gameState = GameState.fromName(status);
+        final GameState payloadState = GameState.fromName(status);
+        final GameState gameState = Optional.ofNullable(bronzeGame.getState()).orElse(payloadState);
 
         PitcherResult result = assignPitchers(homeScore, awayScore, winningPitcher, losingPitcher);
         final String homePitcher = result.home();
@@ -280,9 +329,9 @@ public class GameEtlService {
         final ScoreBoard awayScoreBoard = convertToScoreBoardFromJson(awayTeamScoreboard);
 
         // 3. Load: Game 엔티티 UPSERT
-        // Natural Key로 조회하여 더블헤더 구분
-        final Optional<Game> existingGameOpt = gameRepository.findByDateAndStadiumAndHomeTeamAndAwayTeamAndStartAt(
-                date, stadium, homeTeam, awayTeam, startTime
+        // gameCode가 경기 시각 변경에도 안정적인 식별자다. Natural Key는 기존 데이터 호환용 fallback이다.
+        final Optional<Game> existingGameOpt = findExistingGame(
+                gameCode, date, stadium, homeTeam, awayTeam, startTime
         );
 
         existingGameOpt.ifPresentOrElse(
@@ -313,6 +362,46 @@ public class GameEtlService {
         );
 
         log.debug("[ETL] Processed Game: gameCode={}, state={}", gameCode, gameState);
+    }
+
+    private Optional<Game> findExistingGame(
+            final String gameCode,
+            final LocalDate date,
+            final Stadium stadium,
+            final Team homeTeam,
+            final Team awayTeam,
+            final LocalTime startTime
+    ) {
+        Optional<Game> byGameCode = gameRepository.findByGameCode(gameCode);
+        if (byGameCode.isPresent()) {
+            return byGameCode;
+        }
+
+        Optional<Game> byNaturalKey = gameRepository.findByDateAndStadiumAndHomeTeamAndAwayTeamAndStartAt(
+                date, stadium, homeTeam, awayTeam, startTime
+        );
+        if (byNaturalKey.isPresent()) {
+            return byNaturalKey;
+        }
+
+        List<Game> sameMatchup = gameRepository.findByDateAndStadiumAndHomeTeamAndAwayTeam(
+                date, stadium, homeTeam, awayTeam
+        );
+        if (sameMatchup.size() == 1) {
+            log.info("[ETL] Game matched without startTime: gameCode={}, date={}, stadium={}, home={}, away={}",
+                    gameCode, date, stadium.getLocation(), homeTeam.getShortName(), awayTeam.getShortName());
+            return Optional.of(sameMatchup.getFirst());
+        }
+        return Optional.empty();
+    }
+
+    private String firstNonBlank(final String... values) {
+        for (String value : values) {
+            if (value != null && !value.isBlank()) {
+                return value;
+            }
+        }
+        throw new IllegalArgumentException("gameCode must not be blank");
     }
 
     /**

--- a/backend/app/src/main/java/com/yagubogu/game/service/GameEtlService.java
+++ b/backend/app/src/main/java/com/yagubogu/game/service/GameEtlService.java
@@ -284,12 +284,14 @@ public class GameEtlService {
 
         // JSON 필드 추출
         final String status = json.path("status").asText(null);
-        final String stadiumLocation = json.path("stadium").asText();
-        final LocalDate date = LocalDate.parse(json.path("date").asText());
+        final String stadiumLocation = bronzeGame.getStadium();
+        final LocalDate date = bronzeGame.getDate();
         final String startTimeStr = json.path("startTime").asText(null);
-        final LocalTime startTime = startTimeStr != null && !startTimeStr.isEmpty()
+        final LocalTime payloadStartTime = startTimeStr != null && !startTimeStr.isEmpty()
                 ? LocalTime.parse(startTimeStr)
-                : LocalTime.of(0, 0);
+                : null;
+        final LocalTime startTime = Optional.ofNullable(bronzeGame.getStartTime())
+                .orElse(Optional.ofNullable(payloadStartTime).orElse(LocalTime.of(0, 0)));
 
         final Integer homeScore = json.path("homeScore").isNull() ? null : json.path("homeScore").asInt();
         final Integer awayScore = json.path("awayScore").isNull() ? null : json.path("awayScore").asInt();
@@ -299,8 +301,8 @@ public class GameEtlService {
         final JsonNode homeTeamScoreboard = json.path("homeTeamScoreboard");
         final JsonNode awayTeamScoreboard = json.path("awayTeamScoreboard");
 
-        final String homeTeamName = homeTeamScoreboard.path("name").asText();
-        final String awayTeamName = awayTeamScoreboard.path("name").asText();
+        final String homeTeamName = bronzeGame.getHomeTeam();
+        final String awayTeamName = bronzeGame.getAwayTeam();
 
         // 2. Transform: Team/Stadium 조회
         final Team homeTeam = teamRepository.findByShortName(homeTeamName)

--- a/backend/app/src/main/java/com/yagubogu/global/config/PipelineConfig.java
+++ b/backend/app/src/main/java/com/yagubogu/global/config/PipelineConfig.java
@@ -15,6 +15,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.transaction.support.TransactionTemplate;
 
 @EnableScheduling
 @Configuration
@@ -30,10 +31,10 @@ public class PipelineConfig {
     public GameEtlService gameEtlService(final BronzeGameRepository bronzeGameRepository,
                                          final GameRepository gameRepository, final TeamRepository teamRepository,
                                          final StadiumRepository stadiumRepository, final ObjectMapper objectMapper,
-                                         final Clock clock
+                                         final Clock clock, final TransactionTemplate transactionTemplate
     ) {
         return new GameEtlService(bronzeGameRepository, gameRepository, teamRepository, stadiumRepository,
-                objectMapper, clock);
+                objectMapper, clock, transactionTemplate);
     }
 
     @Bean

--- a/backend/app/src/main/resources/db/migration/mysql/V18__add_game_code_to_bronze_games.sql
+++ b/backend/app/src/main/resources/db/migration/mysql/V18__add_game_code_to_bronze_games.sql
@@ -1,0 +1,3 @@
+ALTER TABLE bronze_games_raw
+    ADD COLUMN game_code VARCHAR(20) NULL AFTER raw_id,
+    ADD UNIQUE KEY uk_bronze_game_code (game_code);

--- a/backend/app/src/test/java/com/yagubogu/game/service/BronzeGameServiceTest.java
+++ b/backend/app/src/test/java/com/yagubogu/game/service/BronzeGameServiceTest.java
@@ -1,0 +1,76 @@
+package com.yagubogu.game.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.yagubogu.game.domain.BronzeGame;
+import com.yagubogu.game.domain.GameState;
+import com.yagubogu.game.repository.BronzeGameRepository;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class BronzeGameServiceTest {
+
+    private final BronzeGameRepository bronzeGameRepository = mock(BronzeGameRepository.class);
+    private final BronzeGameService bronzeGameService = new BronzeGameService(bronzeGameRepository);
+
+    @DisplayName("GameCenter의 공식 gameCode를 기존 예정 경기 Bronze에 연결한다")
+    @Test
+    void assignOfficialGameCodeToExistingBronzeGame() {
+        LocalDate date = LocalDate.of(2026, 8, 13);
+        LocalTime startTime = LocalTime.of(18, 30);
+        String gameCode = "20260813HHOB0";
+        BronzeGame bronzeGame = new BronzeGame(
+                null, date, "잠실", "두산", "한화", startTime,
+                LocalDateTime.of(2026, 8, 12, 0, 0), "{}", "hash"
+        );
+        bronzeGame.markEtlProcessed(LocalDateTime.of(2026, 8, 12, 0, 1));
+
+        when(bronzeGameRepository.findByGameCode(gameCode)).thenReturn(Optional.empty());
+        when(bronzeGameRepository.findByDateAndStadiumAndHomeTeamAndAwayTeamAndStartTime(
+                date, "잠실", "두산", "한화", startTime
+        )).thenReturn(Optional.of(bronzeGame));
+
+        boolean updated = bronzeGameService.updateGameState(
+                gameCode, date, "잠실", "두산", "한화", startTime, GameState.SCHEDULED
+        );
+
+        assertThat(updated).isTrue();
+        assertThat(bronzeGame.getGameCode()).isEqualTo(gameCode);
+        assertThat(bronzeGame.getEtlProcessedAt()).isNull();
+    }
+
+    @DisplayName("공식 gameCode가 새로 수집되면 시작 시각이 달라도 같은 Bronze 경기를 갱신한다")
+    @Test
+    void updateSameMatchupWhenStartTimeChanged() {
+        LocalDate date = LocalDate.of(2026, 8, 11);
+        String gameCode = "20260811KTNC0";
+        BronzeGame bronzeGame = new BronzeGame(
+                null, date, "창원", "NC", "KT", LocalTime.of(18, 30),
+                LocalDateTime.of(2026, 8, 11, 0, 0), "old", "old-hash"
+        );
+
+        when(bronzeGameRepository.findByGameCode(gameCode)).thenReturn(Optional.empty());
+        when(bronzeGameRepository.findByDateAndStadiumAndHomeTeamAndAwayTeamAndStartTime(
+                date, "창원", "NC", "KT", LocalTime.of(19, 0)
+        )).thenReturn(Optional.empty());
+        when(bronzeGameRepository.findByDateAndStadiumAndHomeTeamAndAwayTeam(
+                date, "창원", "NC", "KT"
+        )).thenReturn(List.of(bronzeGame));
+
+        boolean updated = bronzeGameService.upsertByNaturalKey(
+                gameCode, date, "창원", "NC", "KT", LocalTime.of(19, 0), "new"
+        );
+
+        assertThat(updated).isTrue();
+        assertThat(bronzeGame.getGameCode()).isEqualTo(gameCode);
+        assertThat(bronzeGame.getStartTime()).isEqualTo(LocalTime.of(19, 0));
+        assertThat(bronzeGame.getPayload()).isEqualTo("new");
+    }
+}

--- a/backend/app/src/test/java/com/yagubogu/game/service/BronzeGameServiceTest.java
+++ b/backend/app/src/test/java/com/yagubogu/game/service/BronzeGameServiceTest.java
@@ -73,4 +73,26 @@ class BronzeGameServiceTest {
         assertThat(bronzeGame.getStartTime()).isEqualTo(LocalTime.of(19, 0));
         assertThat(bronzeGame.getPayload()).isEqualTo("new");
     }
+
+    @DisplayName("같은 gameCode의 시작 시각이 바뀌면 GameCenter 정보로 Bronze 메타데이터를 갱신한다")
+    @Test
+    void updateMetadataByGameCodeWhenStartTimeChanged() {
+        LocalDate date = LocalDate.of(2026, 8, 13);
+        String gameCode = "20260813HHOB0";
+        BronzeGame bronzeGame = new BronzeGame(
+                gameCode, date, "잠실", "두산", "한화", LocalTime.of(18, 30),
+                LocalDateTime.of(2026, 8, 13, 0, 0), "{}", "hash"
+        );
+        bronzeGame.markEtlProcessed(LocalDateTime.of(2026, 8, 13, 0, 1));
+
+        when(bronzeGameRepository.findByGameCode(gameCode)).thenReturn(Optional.of(bronzeGame));
+
+        boolean updated = bronzeGameService.updateGameState(
+                gameCode, date, "잠실", "두산", "한화", LocalTime.of(19, 0), GameState.SCHEDULED
+        );
+
+        assertThat(updated).isTrue();
+        assertThat(bronzeGame.getStartTime()).isEqualTo(LocalTime.of(19, 0));
+        assertThat(bronzeGame.getEtlProcessedAt()).isNull();
+    }
 }

--- a/backend/app/src/test/java/com/yagubogu/game/service/GameEtlServiceTest.java
+++ b/backend/app/src/test/java/com/yagubogu/game/service/GameEtlServiceTest.java
@@ -1,0 +1,121 @@
+package com.yagubogu.game.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.yagubogu.game.domain.BronzeGame;
+import com.yagubogu.game.domain.Game;
+import com.yagubogu.game.domain.GameState;
+import com.yagubogu.game.repository.BronzeGameRepository;
+import com.yagubogu.game.repository.GameRepository;
+import com.yagubogu.stadium.domain.Stadium;
+import com.yagubogu.stadium.domain.StadiumLevel;
+import com.yagubogu.stadium.repository.StadiumRepository;
+import com.yagubogu.team.domain.Team;
+import com.yagubogu.team.domain.TeamStatus;
+import com.yagubogu.team.repository.TeamRepository;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.transaction.TransactionStatus;
+import org.springframework.transaction.support.TransactionCallback;
+import org.springframework.transaction.support.TransactionTemplate;
+
+class GameEtlServiceTest {
+
+    private final BronzeGameRepository bronzeGameRepository = mock(BronzeGameRepository.class);
+    private final GameRepository gameRepository = mock(GameRepository.class);
+    private final TeamRepository teamRepository = mock(TeamRepository.class);
+    private final StadiumRepository stadiumRepository = mock(StadiumRepository.class);
+    private final TransactionTemplate transactionTemplate = mock(TransactionTemplate.class);
+
+    private GameEtlService gameEtlService;
+
+    @BeforeEach
+    void setUp() {
+        when(transactionTemplate.execute(any())).thenAnswer(invocation -> {
+            TransactionCallback<?> callback = invocation.getArgument(0);
+            return callback.doInTransaction(mock(TransactionStatus.class));
+        });
+
+        Clock clock = Clock.fixed(Instant.parse("2026-08-12T00:00:00Z"), ZoneId.of("Asia/Seoul"));
+        gameEtlService = new GameEtlService(
+                bronzeGameRepository,
+                gameRepository,
+                teamRepository,
+                stadiumRepository,
+                new ObjectMapper().findAndRegisterModules(),
+                clock,
+                transactionTemplate
+        );
+    }
+
+    @DisplayName("공식 gameCode와 시작 시각이 달라져도 같은 대진의 기존 경기를 갱신한다")
+    @Test
+    void transformByGameCodeWhenStartTimeChanged() {
+        LocalDate date = LocalDate.of(2026, 8, 11);
+        String gameCode = "20260811KTNC0";
+        String legacyGameCode = "20260811KTNC1";
+        Team homeTeam = new Team("NC 다이노스", "NC", "NC", TeamStatus.ACTIVE);
+        Team awayTeam = new Team("KT 위즈", "KT", "KT", TeamStatus.ACTIVE);
+        Stadium stadium = new Stadium("창원NC파크", "창원", "창원", 0.0, 0.0, StadiumLevel.MAIN);
+        Game existingGame = new Game(
+                stadium, homeTeam, awayTeam, date, LocalTime.of(18, 30), legacyGameCode,
+                null, null, null, null, null, null, GameState.SCHEDULED
+        );
+        String payload = """
+                {
+                  "gameCode":"20260811KTNC0",
+                  "date":"2026-08-11",
+                  "status":"경기종료",
+                  "stadium":"창원",
+                  "startTime":"19:00:00",
+                  "awayScore":0,
+                  "homeScore":3,
+                  "winningPitcher":"구창모",
+                  "losingPitcher":"소형준",
+                  "awayTeamScoreboard":{"name":"KT","runs":0,"hits":4,"errors":0,"basesOnBalls":1,"inningScores":[]},
+                  "homeTeamScoreboard":{"name":"NC","runs":3,"hits":8,"errors":0,"basesOnBalls":2,"inningScores":[]}
+                }
+                """;
+        BronzeGame bronzeGame = new BronzeGame(
+                gameCode, date, "창원", "NC", "KT", LocalTime.of(19, 0),
+                LocalDateTime.of(2026, 8, 12, 0, 0), payload, "hash"
+        );
+        ReflectionTestUtils.setField(bronzeGame, "id", 1L);
+
+        when(bronzeGameRepository.findPendingEtlByDateRange(date, date)).thenReturn(java.util.List.of(bronzeGame));
+        when(bronzeGameRepository.findById(1L)).thenReturn(Optional.of(bronzeGame));
+        when(teamRepository.findByShortName("NC")).thenReturn(Optional.of(homeTeam));
+        when(teamRepository.findByShortName("KT")).thenReturn(Optional.of(awayTeam));
+        when(stadiumRepository.findByLocation("창원")).thenReturn(Optional.of(stadium));
+        when(gameRepository.findByGameCode(gameCode)).thenReturn(Optional.empty());
+        when(gameRepository.findByDateAndStadiumAndHomeTeamAndAwayTeamAndStartAt(
+                date, stadium, homeTeam, awayTeam, LocalTime.of(19, 0)
+        )).thenReturn(Optional.empty());
+        when(gameRepository.findByDateAndStadiumAndHomeTeamAndAwayTeam(
+                date, stadium, homeTeam, awayTeam
+        )).thenReturn(java.util.List.of(existingGame));
+
+        int transformed = gameEtlService.transformPendingDateRange(date, date);
+
+        assertThat(transformed).isEqualTo(1);
+        assertThat(existingGame.getStartAt()).isEqualTo(LocalTime.of(19, 0));
+        assertThat(existingGame.getGameCode()).isEqualTo(gameCode);
+        assertThat(existingGame.getHomeScore()).isEqualTo(3);
+        assertThat(existingGame.getAwayScore()).isZero();
+        assertThat(existingGame.getGameState()).isEqualTo(GameState.COMPLETED);
+        assertThat(bronzeGame.getEtlProcessedAt()).isNotNull();
+    }
+}

--- a/backend/app/src/test/java/com/yagubogu/game/service/GameEtlServiceTest.java
+++ b/backend/app/src/test/java/com/yagubogu/game/service/GameEtlServiceTest.java
@@ -80,7 +80,7 @@ class GameEtlServiceTest {
                   "date":"2026-08-11",
                   "status":"경기종료",
                   "stadium":"창원",
-                  "startTime":"19:00:00",
+                  "startTime":"18:30:00",
                   "awayScore":0,
                   "homeScore":3,
                   "winningPitcher":"구창모",

--- a/backend/crawling/src/main/java/yagubogu/crawling/game/dto/KboScoreboardGame.java
+++ b/backend/crawling/src/main/java/yagubogu/crawling/game/dto/KboScoreboardGame.java
@@ -9,6 +9,7 @@ import lombok.Setter;
 @Getter
 public final class KboScoreboardGame {
 
+    private final String gameCode;
     private final LocalDate date;
     private final String status;
     private final String stadium;
@@ -21,6 +22,36 @@ public final class KboScoreboardGame {
     private final String winningPitcher;
     private final String savingPitcher;
     private final String losingPitcher;
+
+    public KboScoreboardGame(
+            String gameCode,
+            LocalDate date,
+            String status,
+            String stadium,
+            LocalTime startTime,
+            String boxScoreUrl,
+            KboScoreboardTeam awayTeamScoreboard,
+            KboScoreboardTeam homeTeamScoreboard,
+            Integer awayScore,
+            Integer homeScore,
+            String winningPitcher,
+            String savingPitcher,
+            String losingPitcher
+    ) {
+        this.gameCode = gameCode;
+        this.date = date;
+        this.status = status;
+        this.stadium = stadium;
+        this.startTime = startTime;
+        this.boxScoreUrl = boxScoreUrl;
+        this.awayTeamScoreboard = awayTeamScoreboard;
+        this.homeTeamScoreboard = homeTeamScoreboard;
+        this.awayScore = awayScore;
+        this.homeScore = homeScore;
+        this.winningPitcher = winningPitcher;
+        this.savingPitcher = savingPitcher;
+        this.losingPitcher = losingPitcher;
+    }
 
     public KboScoreboardGame(
             LocalDate date,
@@ -36,17 +67,8 @@ public final class KboScoreboardGame {
             String savingPitcher,
             String losingPitcher
     ) {
-        this.date = date;
-        this.status = status;
-        this.stadium = stadium;
-        this.startTime = startTime;
-        this.boxScoreUrl = boxScoreUrl;
-        this.awayTeamScoreboard = awayTeamScoreboard;
-        this.homeTeamScoreboard = homeTeamScoreboard;
-        this.awayScore = awayScore;
-        this.homeScore = homeScore;
-        this.winningPitcher = winningPitcher;
-        this.savingPitcher = savingPitcher;
-        this.losingPitcher = losingPitcher;
+        this(null, date, status, stadium, startTime, boxScoreUrl,
+                awayTeamScoreboard, homeTeamScoreboard, awayScore, homeScore,
+                winningPitcher, savingPitcher, losingPitcher);
     }
 }

--- a/backend/crawling/src/main/java/yagubogu/crawling/game/scheduler/GameScheduler.java
+++ b/backend/crawling/src/main/java/yagubogu/crawling/game/scheduler/GameScheduler.java
@@ -54,4 +54,27 @@ public class GameScheduler {
             log.error("[DAILY_SCHEDULE] Unexpected error for {}: {}", today, e.getMessage(), e);
         }
     }
+
+    /**
+     * 경기 당일 GameCenter 메타데이터를 주기적으로 확인한다.
+     * 시작 시각이 앞당겨져 기존 Poller 기상 시각보다 빨라지는 경우도 이 동기화로 감지한다.
+     */
+    @Scheduled(fixedDelay = 600_000, initialDelay = 300_000)
+    public void refreshTodayGameMetadata() {
+        LocalDate today = LocalDate.now(clock);
+
+        try {
+            int updatedCount = gameCenterSyncService.fetchGameCenter(today);
+            if (updatedCount == 0) {
+                return;
+            }
+
+            int etlCount = gameEtlService.transformPendingDateRange(today, today);
+            adaptivePoller.initializeTodaySchedule(today);
+            log.info("[GAME_METADATA_REFRESH] date={}, updated={}, transformed={}",
+                    today, updatedCount, etlCount);
+        } catch (Exception e) {
+            log.error("[GAME_METADATA_REFRESH] Failed for {}", today, e);
+        }
+    }
 }

--- a/backend/crawling/src/main/java/yagubogu/crawling/game/scheduler/GameScheduler.java
+++ b/backend/crawling/src/main/java/yagubogu/crawling/game/scheduler/GameScheduler.java
@@ -39,9 +39,9 @@ public class GameScheduler {
             int savedCount = gameCenterSyncService.fetchGameCenter(today);
             log.info("[DAILY_SCHEDULE] Bronze layer saved {} games", savedCount);
 
-            // 2. 즉시 ETL 실행 (오늘 날짜)
-            LocalDateTime todayStart = today.atStartOfDay();
-            int etlCount = gameEtlService.transformBronzeToSilver(todayStart);
+            // 2. 즉시 ETL 실행 (함께 수집한 전날 데이터 포함)
+            LocalDateTime yesterdayStart = yesterday.atStartOfDay();
+            int etlCount = gameEtlService.transformBronzeToSilver(yesterdayStart);
             log.info("[DAILY_SCHEDULE] ETL completed: {} games transformed", etlCount);
 
             // 3. AdaptivePoller 초기화 (Silver 최신 상태)

--- a/backend/crawling/src/main/java/yagubogu/crawling/game/service/crawler/KboGameCenterCrawler/GameCenterSyncService.java
+++ b/backend/crawling/src/main/java/yagubogu/crawling/game/service/crawler/KboGameCenterCrawler/GameCenterSyncService.java
@@ -50,7 +50,7 @@ public class GameCenterSyncService {
             }
         }
 
-        log.info("[BRONZE] Processed {} games, {} state updates", gameDetails.size(), updatedCount);
+        log.info("[BRONZE] Processed {} games, {} data updates", gameDetails.size(), updatedCount);
         return updatedCount;
     }
 

--- a/backend/crawling/src/main/java/yagubogu/crawling/game/service/crawler/KboGameCenterCrawler/GameCenterSyncService.java
+++ b/backend/crawling/src/main/java/yagubogu/crawling/game/service/crawler/KboGameCenterCrawler/GameCenterSyncService.java
@@ -66,7 +66,7 @@ public class GameCenterSyncService {
         GameState state = GameState.fromName(detail.getStatus());
 
         boolean updated = bronzeGameService.updateGameState(
-                date, stadium, homeTeam, awayTeam, startTime, state
+                detail.getGameCode(), date, stadium, homeTeam, awayTeam, startTime, state
         );
 
         if (updated) {

--- a/backend/crawling/src/main/java/yagubogu/crawling/game/service/crawler/KboScoardboardCrawler/KboScoreboardService.java
+++ b/backend/crawling/src/main/java/yagubogu/crawling/game/service/crawler/KboScoardboardCrawler/KboScoreboardService.java
@@ -1,6 +1,5 @@
 package yagubogu.crawling.game.service.crawler.KboScoardboardCrawler;
 
-import static java.time.format.DateTimeFormatter.BASIC_ISO_DATE;
 import static java.util.stream.Collectors.toMap;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -8,7 +7,6 @@ import com.yagubogu.game.domain.GameState;
 import com.yagubogu.game.domain.ScoreBoard;
 import com.yagubogu.game.event.GameFinalizedEvent;
 import com.yagubogu.game.exception.GameSyncException;
-import com.yagubogu.game.repository.GameRepository;
 import com.yagubogu.game.service.BronzeGameService;
 import com.yagubogu.game.service.GameEtlService;
 import com.yagubogu.stadium.domain.Stadium;
@@ -19,7 +17,6 @@ import jakarta.annotation.PostConstruct;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -36,6 +33,8 @@ import org.springframework.transaction.support.TransactionTemplate;
 import org.springframework.util.StopWatch;
 import yagubogu.crawling.game.dto.BatchResult;
 import yagubogu.crawling.game.dto.FailedGame;
+import yagubogu.crawling.game.dto.GameCenter;
+import yagubogu.crawling.game.dto.GameCenterDetail;
 import yagubogu.crawling.game.dto.GameDateCrawlResponse;
 import yagubogu.crawling.game.dto.GameUpsertRow;
 import yagubogu.crawling.game.dto.KboScoreboardGame;
@@ -45,6 +44,7 @@ import yagubogu.crawling.game.dto.ScoreBoardData;
 import yagubogu.crawling.game.dto.ScoreboardResponse;
 import yagubogu.crawling.game.dto.UpsertResult;
 import yagubogu.crawling.game.repository.GameJdbcBatchUpsertRepository;
+import yagubogu.crawling.game.service.crawler.KboGameCenterCrawler.GameCenterSyncService;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -58,9 +58,9 @@ public class KboScoreboardService {
     private final StadiumRepository stadiumRepository;
     private final TransactionTemplate transactionTemplate;
     private final TransactionTemplate readOnlyTransactionTemplate;
-    private final GameRepository gameRepository;
     private final BronzeGameService bronzeGameService;
     private final GameEtlService gameEtlService;
+    private final GameCenterSyncService gameCenterSyncService;
     private final ObjectMapper objectMapper;
     private final ApplicationEventPublisher applicationEventPublisher;
 
@@ -111,31 +111,31 @@ public class KboScoreboardService {
         Map<LocalDate, List<KboScoreboardGame>> gamesByDate = kboScoreboardCrawler.crawl(List.of(date));
         Map<String, Team> teamByShort = loadTeams();
         Map<String, Stadium> stadiumByLocation = loadStadiums();
-        Map<String, KboScoreboardGame> scoreboardGamesByCode = mapByGameCode(gamesByDate, teamByShort);
 
-        List<Map.Entry<String, KboScoreboardGame>> newGameEntries = scoreboardGamesByCode.entrySet().stream()
-                .filter(entry -> !gameRepository.existsByGameCode(entry.getKey()))
+        List<KboScoreboardGame> crawledGames = gamesByDate.values().stream()
+                .flatMap(List::stream)
                 .toList();
-        List<KboScoreboardGame> newGames = newGameEntries.stream()
-                .map(Map.Entry::getValue)
-                .toList();
-        List<String> savedGameCodes = newGameEntries.stream()
+        int savedCount = saveToBronzeLayerInChunks(crawledGames, teamByShort, stadiumByLocation);
+
+        // 예정 경기의 ScoreBoard에는 gameId가 없으므로 GameCenter의 공식 g_id를 Bronze에 연결한다.
+        GameCenter gameCenter = gameCenterSyncService.fetchGameCenterOnly(date);
+        gameCenterSyncService.saveToBronzeLayer(gameCenter.getGames());
+
+        Map<String, GameState> gamesByOfficialCode = collectOfficialGameCodes(gamesByDate, gameCenter);
+        List<String> savedGameCodes = List.copyOf(gamesByOfficialCode.keySet());
+        List<String> completedGameCodes = gamesByOfficialCode.entrySet().stream()
+                .filter(entry -> entry.getValue().isCompleted())
                 .map(Map.Entry::getKey)
                 .toList();
-        List<String> completedGameCodes = newGameEntries.stream()
-                .filter(entry -> GameState.fromName(entry.getValue().getStatus()).isCompleted())
-                .map(Map.Entry::getKey)
-                .toList();
 
-        int savedCount = saveToBronzeLayerInChunks(newGames, teamByShort, stadiumByLocation);
-        int transformedCount = newGames.isEmpty() ? 0 : gameEtlService.transformBronzeToSilver(date.atStartOfDay());
-        int skippedCount = scoreboardGamesByCode.size() - newGameEntries.size();
+        int transformedCount = crawledGames.isEmpty() ? 0 : gameEtlService.transformPendingDateRange(date, date);
+        int skippedCount = Math.max(0, crawledGames.size() - savedCount);
 
         log.info("[GAME_DATE_CRAWL] date={}, matched={}, saved={}, skipped={}, transformed={}",
-                date, scoreboardGamesByCode.size(), savedCount, skippedCount, transformedCount);
+                date, gamesByOfficialCode.size(), savedCount, skippedCount, transformedCount);
         return new GameDateCrawlResponse(
-                scoreboardGamesByCode.size(),
-                scoreboardGamesByCode.size(),
+                crawledGames.size(),
+                gamesByOfficialCode.size(),
                 savedCount,
                 skippedCount,
                 transformedCount,
@@ -168,7 +168,12 @@ public class KboScoreboardService {
             String homeTeamName = data.getHomeTeamScoreboard().name();
             String awayTeamName = data.getAwayTeamScoreboard().name();
             LocalTime startTime = data.getStartTime();
-            bronzeGameService.upsertByNaturalKey(date, stadium, homeTeamName, awayTeamName, startTime, payload);
+            String officialGameCode = data.getGameCode() == null || data.getGameCode().isBlank()
+                    ? gameCode
+                    : data.getGameCode();
+            bronzeGameService.upsertByNaturalKey(
+                    officialGameCode, date, stadium, homeTeamName, awayTeamName, startTime, payload
+            );
             log.debug("[BRONZE] Saved gameCode={}, state={}", gameCode, data.getStatus());
 
             // 경기 종료 시 이벤트 발행 (ETL 트리거)
@@ -217,6 +222,7 @@ public class KboScoreboardService {
                         String payload = objectMapper.writeValueAsString(game);
 
                         boolean changed = bronzeGameService.upsertByNaturalKey(
+                                game.getGameCode(),
                                 game.getDate(),
                                 game.getStadium(),
                                 game.getHomeTeamScoreboard().name(),
@@ -294,33 +300,47 @@ public class KboScoreboardService {
     }
 
     private Map<String, KboScoreboardGame> mapByGameCode(
-            final Map<LocalDate, List<KboScoreboardGame>> gamesByDate,
-            final Map<String, Team> teamByShort
+            final Map<LocalDate, List<KboScoreboardGame>> gamesByDate
     ) {
         Map<String, KboScoreboardGame> result = new LinkedHashMap<>();
 
-        gamesByDate.forEach((date, games) -> games.stream()
-                .collect(Collectors.groupingBy(game -> game.getHomeTeamScoreboard().name()))
-                .values()
-                .forEach(homeTeamGames -> {
-                    homeTeamGames.sort(Comparator.comparing(
-                            KboScoreboardGame::getStartTime,
-                            Comparator.nullsLast(Comparator.naturalOrder())
-                    ));
-
-                    for (int order = 0; order < homeTeamGames.size(); order++) {
-                        KboScoreboardGame game = homeTeamGames.get(order);
-                        Team awayTeam = teamByShort.get(game.getAwayTeamScoreboard().name());
-                        Team homeTeam = teamByShort.get(game.getHomeTeamScoreboard().name());
-                        if (awayTeam == null || homeTeam == null) {
-                            continue;
-                        }
-
-                        result.put(generateGameCode(date, homeTeam, awayTeam, order), game);
+        gamesByDate.values().stream()
+                .flatMap(List::stream)
+                .forEach(game -> {
+                    if (game.getGameCode() == null || game.getGameCode().isBlank()) {
+                        log.warn("[GAME_CODE] Skip scoreboard without KBO gameId: date={}, stadium={}",
+                                game.getDate(), game.getStadium());
+                        return;
                     }
-                }));
+                    result.put(game.getGameCode(), game);
+                });
 
         return result;
+    }
+
+    private Map<String, GameState> collectOfficialGameCodes(
+            final Map<LocalDate, List<KboScoreboardGame>> gamesByDate,
+            final GameCenter gameCenter
+    ) {
+        Map<String, GameState> result = new LinkedHashMap<>();
+        mapByGameCode(gamesByDate).forEach((gameCode, game) ->
+                result.put(gameCode, GameState.fromName(game.getStatus()))
+        );
+        for (GameCenterDetail detail : gameCenter.getGames()) {
+            if (detail.getGameCode() == null || detail.getGameCode().isBlank()) {
+                continue;
+            }
+            result.put(detail.getGameCode(), parseGameCenterState(detail));
+        }
+        return result;
+    }
+
+    private GameState parseGameCenterState(final GameCenterDetail detail) {
+        try {
+            return GameState.fromNumber(Integer.parseInt(detail.getGameSc()));
+        } catch (RuntimeException ignored) {
+            return GameState.fromName(detail.getStatus());
+        }
     }
 
     /**
@@ -458,11 +478,6 @@ public class KboScoreboardService {
         } else {
             return new PitcherAssignment(losingPitcher, winningPitcher);
         }
-    }
-
-    private String generateGameCode(final LocalDate date, final Team homeTeam, final Team awayTeam,
-                                    final int headerOrder) {
-        return date.format(BASIC_ISO_DATE) + awayTeam.getTeamCode() + homeTeam.getTeamCode() + headerOrder;
     }
 
 //    private void applyDoubleHeaderOrder(final List<KboScoreboardGame> games) {

--- a/backend/crawling/src/main/java/yagubogu/crawling/game/service/crawler/page/KboScoreboardPage.java
+++ b/backend/crawling/src/main/java/yagubogu/crawling/game/service/crawler/page/KboScoreboardPage.java
@@ -6,6 +6,9 @@ import com.microsoft.playwright.Page;
 import com.microsoft.playwright.PlaywrightException;
 import com.microsoft.playwright.options.WaitForSelectorState;
 import com.yagubogu.game.exception.GameSyncException;
+import java.net.URI;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
@@ -109,6 +112,7 @@ public class KboScoreboardPage extends BaseKboPage {
         // 박스스코어 URL
         ElementHandle boxScoreAnchor = queryCSS(scoreboard, selectors.getBoxScoreLink());
         String boxScoreUrl = boxScoreAnchor != null ? resolveUrl(boxScoreAnchor.getAttribute("href")) : null;
+        String gameCode = extractGameCode(boxScoreUrl);
 
         // 테이블 점수 파싱
         ElementHandle table = queryCSS(scoreboard, selectors.getScoreTable().getTable());
@@ -127,6 +131,7 @@ public class KboScoreboardPage extends BaseKboPage {
         Pitcher pitcher = parsePitcher(scoreboard);
 
         return Optional.of(new KboScoreboardGame(
+                gameCode,
                 date,
                 emptyToNull(status),
                 emptyToNull(stadium),
@@ -140,6 +145,29 @@ public class KboScoreboardPage extends BaseKboPage {
                 pitcher.saving(),
                 pitcher.losing()
         ));
+    }
+
+    private String extractGameCode(String boxScoreUrl) {
+        if (boxScoreUrl == null || boxScoreUrl.isBlank()) {
+            return null;
+        }
+
+        try {
+            String query = URI.create(boxScoreUrl).getRawQuery();
+            if (query == null) {
+                return null;
+            }
+
+            for (String parameter : query.split("&")) {
+                String[] pair = parameter.split("=", 2);
+                if (pair.length == 2 && "gameId".equals(pair[0])) {
+                    return URLDecoder.decode(pair[1], StandardCharsets.UTF_8);
+                }
+            }
+        } catch (IllegalArgumentException e) {
+            log.warn("게임센터 URL에서 gameCode 추출 실패: {}", boxScoreUrl);
+        }
+        return null;
     }
 
     // ==================== 내부 파싱 메서드 ====================

--- a/backend/crawling/src/main/java/yagubogu/crawling/game/service/poller/AdaptivePoller.java
+++ b/backend/crawling/src/main/java/yagubogu/crawling/game/service/poller/AdaptivePoller.java
@@ -5,7 +5,6 @@ import com.yagubogu.game.domain.GameState;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.LocalDate;
-import java.time.LocalTime;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -112,7 +111,7 @@ public class AdaptivePoller {
     private void processGame(Game game, Map<String, KboScoreboardGame> scoreboardGames) {
         try {
             KboScoreboardGame scoreboardGame = scoreboardGames.get(
-                    makeGameKey(game.getDate(), game.getStartAt(), game.getStadium().getLocation()));
+                    game.getGameCode());
 
             if (scoreboardGame == null) {
                 handleMissingGame(game);
@@ -173,8 +172,9 @@ public class AdaptivePoller {
             List<KboScoreboardGame> scoreboardResponses = kboScoreboardService.fetchScoreboardOnly(date);
 
             return scoreboardResponses.stream()
+                    .filter(game -> game.getGameCode() != null && !game.getGameCode().isBlank())
                     .collect(Collectors.toMap(
-                            game -> makeGameKey(game.getDate(), game.getStartTime(), game.getStadium()),
+                            KboScoreboardGame::getGameCode,
                             game -> game
                     ));
         } catch (Exception e) {
@@ -182,10 +182,6 @@ public class AdaptivePoller {
             log.warn("[POLLER] Scoreboard fetch failed: {}", e.getMessage());
             return Map.of();
         }
-    }
-
-    private String makeGameKey(LocalDate date, LocalTime startAt, String stadium) {
-        return String.format("%s_%s_%s", date, startAt, stadium);
     }
 
     private Game fetchFromGameCenter(Game game) {

--- a/backend/crawling/src/main/java/yagubogu/crawling/game/service/poller/AdaptivePoller.java
+++ b/backend/crawling/src/main/java/yagubogu/crawling/game/service/poller/AdaptivePoller.java
@@ -7,6 +7,7 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -219,27 +220,41 @@ public class AdaptivePoller {
      * 업데이트 케이스:
      * - 상태 변경 (SCHEDULED → LIVE → FINALIZED)
      * - LIVE 상태 (점수/이닝 변경 가능성)
+     * - 같은 gameCode의 날짜/시각/구장/대진 정보 변경
      *
      * 생략 케이스:
-     * - SCHEDULED 상태 유지 (변경 사항 없음)
+     * - 상태와 경기 정보가 모두 동일한 SCHEDULED 경기
      */
     private void updateGameIfNeeded(Game game, KboScoreboardGame scoreboardGame) {
         GameState fetchedState = GameState.fromName(scoreboardGame.getStatus());
 
         boolean stateChanged = game.getGameState() != fetchedState;
         boolean isLive = fetchedState == GameState.LIVE;
+        boolean metadataChanged = hasMetadataChanged(game, scoreboardGame);
 
-        if (stateChanged || isLive) {
-            log.debug("[UPDATE] Calling updateFromScoreboard for gameCode={}, stadium={}, home={}, away={}",
+        if (stateChanged || isLive || metadataChanged) {
+            log.info("[UPDATE] Scoreboard changed: gameCode={}, stadium={}, home={}, away={}, "
+                            + "startTime={}→{}, metadataChanged={}",
                     game.getGameCode(), scoreboardGame.getStadium(),
                     scoreboardGame.getHomeTeamScoreboard().name(),
-                    scoreboardGame.getAwayTeamScoreboard().name());
+                    scoreboardGame.getAwayTeamScoreboard().name(), game.getStartAt(),
+                    scoreboardGame.getStartTime(), metadataChanged);
             kboScoreboardService.updateFromScoreboard(
                     game.getGameCode(),
                     scoreboardGame
             );
             game.updateGameState(fetchedState);
         }
+    }
+
+    private boolean hasMetadataChanged(final Game game, final KboScoreboardGame scoreboardGame) {
+        return !Objects.equals(game.getDate(), scoreboardGame.getDate())
+                || !Objects.equals(game.getStartAt(), scoreboardGame.getStartTime())
+                || !Objects.equals(game.getStadium().getLocation(), scoreboardGame.getStadium())
+                || !Objects.equals(game.getHomeTeam().getShortName(),
+                scoreboardGame.getHomeTeamScoreboard().name())
+                || !Objects.equals(game.getAwayTeam().getShortName(),
+                scoreboardGame.getAwayTeamScoreboard().name());
     }
 
     private boolean isGameFinalized(KboScoreboardGame scoreboardGame) {

--- a/backend/crawling/src/test/java/yagubogu/crawling/game/scheduler/GameSchedulerTest.java
+++ b/backend/crawling/src/test/java/yagubogu/crawling/game/scheduler/GameSchedulerTest.java
@@ -1,0 +1,41 @@
+package yagubogu.crawling.game.scheduler;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.yagubogu.game.service.GameEtlService;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import yagubogu.crawling.game.service.crawler.KboGameCenterCrawler.GameCenterSyncService;
+import yagubogu.crawling.game.service.crawler.KboScoardboardCrawler.KboScoreboardService;
+import yagubogu.crawling.game.service.poller.AdaptivePoller;
+
+class GameSchedulerTest {
+
+    @DisplayName("GameCenter 경기 정보가 바뀌면 당일 ETL 후 Poller 일정을 다시 계산한다")
+    @Test
+    void refreshChangedGameMetadata() {
+        KboScoreboardService scoreboardService = mock(KboScoreboardService.class);
+        GameCenterSyncService gameCenterSyncService = mock(GameCenterSyncService.class);
+        AdaptivePoller adaptivePoller = mock(AdaptivePoller.class);
+        GameEtlService gameEtlService = mock(GameEtlService.class);
+        Clock clock = Clock.fixed(Instant.parse("2026-08-13T05:00:00Z"), ZoneId.of("Asia/Seoul"));
+        GameScheduler scheduler = new GameScheduler(
+                scoreboardService, gameCenterSyncService, adaptivePoller, gameEtlService, clock
+        );
+        LocalDate today = LocalDate.of(2026, 8, 13);
+
+        when(gameCenterSyncService.fetchGameCenter(today)).thenReturn(1);
+        when(gameEtlService.transformPendingDateRange(today, today)).thenReturn(1);
+
+        scheduler.refreshTodayGameMetadata();
+
+        verify(gameEtlService).transformPendingDateRange(today, today);
+        verify(adaptivePoller).initializeTodaySchedule(today);
+    }
+}

--- a/backend/crawling/src/test/java/yagubogu/crawling/game/service/crawler/KboScoardboardCrawler/KboScoreboardServiceTest.java
+++ b/backend/crawling/src/test/java/yagubogu/crawling/game/service/crawler/KboScoardboardCrawler/KboScoreboardServiceTest.java
@@ -1,0 +1,119 @@
+package yagubogu.crawling.game.service.crawler.KboScoardboardCrawler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.yagubogu.game.service.BronzeGameService;
+import com.yagubogu.game.service.GameEtlService;
+import com.yagubogu.stadium.domain.Stadium;
+import com.yagubogu.stadium.domain.StadiumLevel;
+import com.yagubogu.stadium.repository.StadiumRepository;
+import com.yagubogu.team.domain.Team;
+import com.yagubogu.team.domain.TeamStatus;
+import com.yagubogu.team.repository.TeamRepository;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.transaction.TransactionStatus;
+import org.springframework.transaction.support.TransactionCallback;
+import org.springframework.transaction.support.TransactionTemplate;
+import yagubogu.crawling.game.dto.GameCenter;
+import yagubogu.crawling.game.dto.GameCenterDetail;
+import yagubogu.crawling.game.dto.GameDateCrawlResponse;
+import yagubogu.crawling.game.dto.KboScoreboardGame;
+import yagubogu.crawling.game.dto.KboScoreboardTeam;
+import yagubogu.crawling.game.repository.GameJdbcBatchUpsertRepository;
+import yagubogu.crawling.game.service.crawler.KboGameCenterCrawler.GameCenterSyncService;
+
+class KboScoreboardServiceTest {
+
+    @DisplayName("예정 경기의 gameCode는 GameCenter의 공식 g_id를 사용한다")
+    @Test
+    void fetchOfficialGameCodeFromGameCenterForScheduledGame() {
+        LocalDate date = LocalDate.of(2026, 8, 13);
+        String gameCode = "20260813HHOB0";
+        KboScoreboardGame scheduledGame = new KboScoreboardGame(
+                date,
+                "경기전",
+                "잠실",
+                LocalTime.of(18, 30),
+                null,
+                new KboScoreboardTeam("한화", null, null, null, null, List.of()),
+                new KboScoreboardTeam("두산", null, null, null, null, List.of()),
+                null,
+                null,
+                null,
+                null,
+                null
+        );
+        GameCenterDetail detail = new GameCenterDetail();
+        detail.setGameCode(gameCode);
+        detail.setGameSc("1");
+        detail.setStatus("경기전");
+        GameCenter gameCenter = new GameCenter();
+        gameCenter.setGames(List.of(detail));
+
+        KboScoreboardCrawler crawler = mock(KboScoreboardCrawler.class);
+        TeamRepository teamRepository = mock(TeamRepository.class);
+        StadiumRepository stadiumRepository = mock(StadiumRepository.class);
+        TransactionTemplate transactionTemplate = executeCallbacksImmediately();
+        TransactionTemplate readOnlyTransactionTemplate = executeCallbacksImmediately();
+        BronzeGameService bronzeGameService = mock(BronzeGameService.class);
+        GameEtlService gameEtlService = mock(GameEtlService.class);
+        GameCenterSyncService gameCenterSyncService = mock(GameCenterSyncService.class);
+
+        Team awayTeam = new Team("한화 이글스", "한화", "HH", TeamStatus.ACTIVE);
+        Team homeTeam = new Team("두산 베어스", "두산", "OB", TeamStatus.ACTIVE);
+        Stadium stadium = new Stadium("서울종합운동장 야구장", "잠실", "잠실", 0.0, 0.0, StadiumLevel.MAIN);
+
+        when(crawler.crawl(List.of(date))).thenReturn(Map.of(date, List.of(scheduledGame)));
+        when(teamRepository.findAll()).thenReturn(List.of(awayTeam, homeTeam));
+        when(stadiumRepository.findAll()).thenReturn(List.of(stadium));
+        when(bronzeGameService.upsertByNaturalKey(
+                any(), any(), any(), any(), any(), any(), any()
+        )).thenReturn(true);
+        when(gameCenterSyncService.fetchGameCenterOnly(date)).thenReturn(gameCenter);
+        when(gameEtlService.transformPendingDateRange(date, date)).thenReturn(1);
+
+        KboScoreboardService service = new KboScoreboardService(
+                crawler,
+                mock(KboScoreboardMapper.class),
+                mock(GameJdbcBatchUpsertRepository.class),
+                teamRepository,
+                stadiumRepository,
+                transactionTemplate,
+                readOnlyTransactionTemplate,
+                bronzeGameService,
+                gameEtlService,
+                gameCenterSyncService,
+                new ObjectMapper().findAndRegisterModules(),
+                mock(ApplicationEventPublisher.class)
+        );
+
+        GameDateCrawlResponse response = service.fetchGamesByDate(date);
+
+        verify(gameCenterSyncService).saveToBronzeLayer(List.of(detail));
+        verify(gameEtlService).transformPendingDateRange(date, date);
+        assertThat(response.requested()).isEqualTo(1);
+        assertThat(response.matched()).isEqualTo(1);
+        assertThat(response.savedGameCodes()).containsExactly(gameCode);
+        assertThat(response.completedGameCodes()).isEmpty();
+    }
+
+    private TransactionTemplate executeCallbacksImmediately() {
+        TransactionTemplate template = mock(TransactionTemplate.class);
+        when(template.execute(any())).thenAnswer(invocation -> {
+            TransactionCallback<?> callback = invocation.getArgument(0);
+            return callback.doInTransaction(mock(TransactionStatus.class));
+        });
+        return template;
+    }
+}

--- a/backend/crawling/src/test/java/yagubogu/crawling/game/service/crawler/KboScoreboardCrawlerTest.java
+++ b/backend/crawling/src/test/java/yagubogu/crawling/game/service/crawler/KboScoreboardCrawlerTest.java
@@ -340,7 +340,9 @@ class KboScoreboardCrawlerTest {
 
         //  BoxScore Link
         ElementHandle boxScoreLink = mock(ElementHandle.class);
-        lenient().when(boxScoreLink.getAttribute("href")).thenReturn("/game/boxscore/20251026LGKT");
+        lenient().when(boxScoreLink.getAttribute("href")).thenReturn(
+                "/Schedule/GameCenter/Main.aspx?gameDate=20251026&gameId=20251026KTLG0&section=REVIEW"
+        );
         lenient().when(scoreboard.querySelector("a.box-score")).thenReturn(boxScoreLink);
 
         //  스코어 테이블 (완전한 Mock)

--- a/backend/crawling/src/test/java/yagubogu/crawling/game/service/crawler/page/KboScoreboardPageTest.java
+++ b/backend/crawling/src/test/java/yagubogu/crawling/game/service/crawler/page/KboScoreboardPageTest.java
@@ -238,6 +238,7 @@ class KboScoreboardPageTest {
             KboScoreboardGame game = result.get();
 
             assertThat(game.getDate()).isEqualTo(date);
+            assertThat(game.getGameCode()).isEqualTo("20251026KTLG0");
             assertThat(game.getStatus()).isEqualTo("경기종료");
             assertThat(game.getStadium()).isEqualTo("잠실");
             assertThat(game.getStartTime()).isEqualTo(LocalTime.of(18, 30));
@@ -287,7 +288,9 @@ class KboScoreboardPageTest {
             ElementHandle mockAnchor = mock(ElementHandle.class);
 
             when(mockScoreboard.querySelector("a.box-score")).thenReturn(mockAnchor);
-            when(mockAnchor.getAttribute("href")).thenReturn("/game/boxscore/20251026LGKT");
+            when(mockAnchor.getAttribute("href")).thenReturn(
+                    "/Schedule/GameCenter/Main.aspx?gameDate=20251026&gameId=20251026KTLG0&section=REVIEW"
+            );
 
             LocalDate date = LocalDate.of(2025, 10, 26);
 
@@ -297,7 +300,9 @@ class KboScoreboardPageTest {
             // Then
             assertThat(result).isPresent();
             assertThat(result.get().getBoxScoreUrl())
-                    .isEqualTo("https://www.koreabaseball.com/game/boxscore/20251026LGKT");
+                    .isEqualTo("https://www.koreabaseball.com/Schedule/GameCenter/Main.aspx"
+                            + "?gameDate=20251026&gameId=20251026KTLG0&section=REVIEW");
+            assertThat(result.get().getGameCode()).isEqualTo("20251026KTLG0");
         }
     }
 
@@ -373,7 +378,9 @@ class KboScoreboardPageTest {
 
         // BoxScore Link
         ElementHandle boxScoreLink = mock(ElementHandle.class);
-        lenient().when(boxScoreLink.getAttribute("href")).thenReturn("/game/boxscore/20251026LGKT");
+        lenient().when(boxScoreLink.getAttribute("href")).thenReturn(
+                "/Schedule/GameCenter/Main.aspx?gameDate=20251026&gameId=20251026KTLG0&section=REVIEW"
+        );
         lenient().when(mockScoreboard.querySelector("a.box-score")).thenReturn(boxScoreLink);
 
         // 스코어 테이블

--- a/backend/crawling/src/test/java/yagubogu/crawling/game/service/poller/AdaptivePollerTest.java
+++ b/backend/crawling/src/test/java/yagubogu/crawling/game/service/poller/AdaptivePollerTest.java
@@ -1,0 +1,89 @@
+package yagubogu.crawling.game.service.poller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.yagubogu.game.domain.Game;
+import com.yagubogu.game.domain.GameState;
+import com.yagubogu.stadium.domain.Stadium;
+import com.yagubogu.stadium.domain.StadiumLevel;
+import com.yagubogu.team.domain.Team;
+import com.yagubogu.team.domain.TeamStatus;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+import yagubogu.crawling.game.dto.KboScoreboardGame;
+import yagubogu.crawling.game.dto.KboScoreboardTeam;
+import yagubogu.crawling.game.service.GameReadOnlyService;
+import yagubogu.crawling.game.service.crawler.KboGameCenterCrawler.GameCenterSyncService;
+import yagubogu.crawling.game.service.crawler.KboScoardboardCrawler.KboScoreboardService;
+
+class AdaptivePollerTest {
+
+    @DisplayName("시작 시각이 변경되어도 KBO gameCode로 기존 경기를 찾아 갱신한다")
+    @Test
+    void pollByGameCodeWhenStartTimeChanged() {
+        GameReadOnlyService gameReadOnlyService = mock(GameReadOnlyService.class);
+        KboScoreboardService scoreboardService = mock(KboScoreboardService.class);
+        GameCenterSyncService gameCenterSyncService = mock(GameCenterSyncService.class);
+        GameScheduleManager scheduleManager = mock(GameScheduleManager.class);
+        BackoffStrategy backoffStrategy = mock(BackoffStrategy.class);
+        GlobalBackOffManager globalBackoff = mock(GlobalBackOffManager.class);
+        Clock clock = Clock.fixed(Instant.parse("2026-08-11T10:30:00Z"), ZoneId.of("Asia/Seoul"));
+        AdaptivePoller poller = new AdaptivePoller(
+                gameReadOnlyService,
+                scoreboardService,
+                gameCenterSyncService,
+                scheduleManager,
+                backoffStrategy,
+                globalBackoff,
+                clock
+        );
+
+        LocalDate date = LocalDate.of(2026, 8, 11);
+        String gameCode = "20260811KTNC0";
+        Team homeTeam = new Team("NC 다이노스", "NC", "NC", TeamStatus.ACTIVE);
+        Team awayTeam = new Team("KT 위즈", "KT", "KT", TeamStatus.ACTIVE);
+        Stadium stadium = new Stadium("창원NC파크", "창원", "창원", 0.0, 0.0, StadiumLevel.MAIN);
+        Game game = new Game(
+                stadium, homeTeam, awayTeam, date, LocalTime.of(18, 30), gameCode,
+                null, null, null, null, null, null, GameState.SCHEDULED
+        );
+        ReflectionTestUtils.setField(game, "id", 1L);
+        KboScoreboardGame fetched = new KboScoreboardGame(
+                gameCode,
+                date,
+                "경기중",
+                "창원",
+                LocalTime.of(19, 0),
+                null,
+                new KboScoreboardTeam("KT", 0, 1, 0, 0, List.of()),
+                new KboScoreboardTeam("NC", 1, 2, 0, 1, List.of()),
+                0,
+                1,
+                null,
+                null,
+                null
+        );
+
+        when(globalBackoff.isActive(any())).thenReturn(false);
+        when(scheduleManager.shouldWake(any())).thenReturn(true);
+        when(gameReadOnlyService.existsByDateAndGameStateIn(any(), any())).thenReturn(true);
+        when(scoreboardService.fetchScoreboardOnly(date)).thenReturn(List.of(fetched));
+        when(gameReadOnlyService.findAllByDateWithStadium(date)).thenReturn(List.of(game));
+        when(scheduleManager.shouldPollGame(1L, Instant.now(clock))).thenReturn(true);
+
+        poller.pollGameWhenReachDue();
+
+        verify(scoreboardService).updateFromScoreboard(gameCode, fetched);
+        verify(scheduleManager).scheduleNextPoll(1L);
+    }
+}

--- a/backend/crawling/src/test/java/yagubogu/crawling/game/service/poller/AdaptivePollerTest.java
+++ b/backend/crawling/src/test/java/yagubogu/crawling/game/service/poller/AdaptivePollerTest.java
@@ -86,4 +86,58 @@ class AdaptivePollerTest {
         verify(scoreboardService).updateFromScoreboard(gameCode, fetched);
         verify(scheduleManager).scheduleNextPoll(1L);
     }
+
+    @DisplayName("상태가 경기전으로 같아도 시작 시각이 바뀌면 갱신한다")
+    @Test
+    void updateScheduledGameWhenStartTimeChanged() {
+        GameReadOnlyService gameReadOnlyService = mock(GameReadOnlyService.class);
+        KboScoreboardService scoreboardService = mock(KboScoreboardService.class);
+        GameCenterSyncService gameCenterSyncService = mock(GameCenterSyncService.class);
+        GameScheduleManager scheduleManager = mock(GameScheduleManager.class);
+        BackoffStrategy backoffStrategy = mock(BackoffStrategy.class);
+        GlobalBackOffManager globalBackoff = mock(GlobalBackOffManager.class);
+        Clock clock = Clock.fixed(Instant.parse("2026-08-13T09:30:00Z"), ZoneId.of("Asia/Seoul"));
+        AdaptivePoller poller = new AdaptivePoller(
+                gameReadOnlyService, scoreboardService, gameCenterSyncService, scheduleManager,
+                backoffStrategy, globalBackoff, clock
+        );
+
+        LocalDate date = LocalDate.of(2026, 8, 13);
+        String gameCode = "20260813HHOB0";
+        Team homeTeam = new Team("두산 베어스", "두산", "OB", TeamStatus.ACTIVE);
+        Team awayTeam = new Team("한화 이글스", "한화", "HH", TeamStatus.ACTIVE);
+        Stadium stadium = new Stadium("서울종합운동장 야구장", "잠실", "잠실", 0.0, 0.0, StadiumLevel.MAIN);
+        Game game = new Game(
+                stadium, homeTeam, awayTeam, date, LocalTime.of(18, 30), gameCode,
+                null, null, null, null, null, null, GameState.SCHEDULED
+        );
+        ReflectionTestUtils.setField(game, "id", 1L);
+        KboScoreboardGame fetched = new KboScoreboardGame(
+                gameCode,
+                date,
+                "경기전",
+                "잠실",
+                LocalTime.of(19, 0),
+                null,
+                new KboScoreboardTeam("한화", null, null, null, null, List.of()),
+                new KboScoreboardTeam("두산", null, null, null, null, List.of()),
+                null,
+                null,
+                null,
+                null,
+                null
+        );
+
+        when(globalBackoff.isActive(any())).thenReturn(false);
+        when(scheduleManager.shouldWake(any())).thenReturn(true);
+        when(gameReadOnlyService.existsByDateAndGameStateIn(any(), any())).thenReturn(true);
+        when(scoreboardService.fetchScoreboardOnly(date)).thenReturn(List.of(fetched));
+        when(gameReadOnlyService.findAllByDateWithStadium(date)).thenReturn(List.of(game));
+        when(scheduleManager.shouldPollGame(1L, Instant.now(clock))).thenReturn(true);
+
+        poller.pollGameWhenReachDue();
+
+        verify(scoreboardService).updateFromScoreboard(gameCode, fetched);
+        verify(scheduleManager).scheduleNextPoll(1L);
+    }
 }


### PR DESCRIPTION
## 문제
- KBO가 경기 시작 시각을 변경하면 Poller와 ETL이 날짜/시각/구장 natural key로 기존 경기를 찾지 못했습니다.
- ETL이 동일 gameCode INSERT를 시도한 뒤 하나의 트랜잭션이 오염되어 같은 배치의 나머지 경기까지 롤백됐습니다.
- 예정 경기 ScoreBoard에는 gameId 링크가 없어 최초 수집 시 gameCode를 임의 조합하고 있었습니다.
- 상태가 SCHEDULED로 유지되면서 시작 시각만 바뀌면 Poller가 변경을 저장하지 않았고, 시작이 앞당겨진 경우 기존 Poller 기상 시각 전에는 감지할 수 없었습니다.

## 변경 사항
- GameCenter 경기 카드의 공식 `g_id`를 최초 수집 gameCode로 Bronze에 연결합니다.
- 진행/종료 ScoreBoard의 GameCenter 링크에서 공식 `gameId`를 추출합니다.
- Adaptive Poller와 Bronze/Silver ETL의 우선 식별자를 gameCode로 변경합니다.
- 동일 gameCode의 날짜/시각/구장/대진이 달라지면 상태가 같아도 Bronze와 Silver를 갱신합니다.
- GameCenter 메타데이터를 10분마다 동기화하고, 변경 시 ETL과 Poller 일정 재계산을 수행합니다.
- 시작 시각이 바뀐 레거시 데이터는 동일 날짜/구장/대진이 하나인 경우에만 안전하게 fallback 매칭합니다.
- Bronze에 nullable unique game_code 컬럼을 추가하고, ETL을 경기별 독립 트랜잭션으로 처리합니다.
- 자정 ETL 범위에 함께 수집한 전날 경기를 포함합니다.
- Admin 날짜 재수집이 기존 gameCode도 건너뛰지 않고 재수집/ETL하도록 변경합니다.

## API Spec
### `POST /admin/crawling/games`
요청/응답 스키마 변경은 없습니다.

```json
{
  "startDate": "2026-08-11",
  "endDate": "2026-08-11",
  "sleepMillis": 0,
  "reviewRetryDelayMinutes": 30
}
```

동작 변경: 이미 `games`에 존재하는 gameCode도 ScoreBoard와 GameCenter에서 다시 수집하여 Bronze를 갱신하고 Silver ETL을 수행합니다. 이를 통해 누락된 점수/상태 및 변경된 시작 시각을 복구할 수 있습니다.

내부 `POST /api/kbo/games/by-date` 응답 스키마도 유지되며, `savedGameCodes`는 GameCenter/ScoreBoard에서 확인한 공식 KBO gameCode를 반환합니다.

## 검증
- gameCode 동일 + SCHEDULED 동일 + 시작 시각 변경 회귀 테스트 통과
- GameCenter 메타데이터 변경 후 ETL/Poller 재초기화 테스트 통과
- 관련 app/crawling 회귀 테스트 통과
- crawling 모듈 전체 테스트 통과
- 전체 app 테스트 중 Docker/Testcontainers가 필요한 12개는 로컬 Docker 미가동으로 실행 불가

Resolves #1123