### PR TITLE
fix: Docker Gradle 빌드 xargs 누락 해결

### DIFF
--- a/backend/app/Dockerfile
+++ b/backend/app/Dockerfile
@@ -1,5 +1,5 @@
 # --- Build stage ---
-FROM amazoncorretto:21-al2023-jdk AS build
+FROM amazoncorretto:21 AS build
 WORKDIR /workspace
 
 # Gradle wrapper가 JVM 옵션 파싱에 사용하는 xargs 설치

--- a/backend/app/Dockerfile
+++ b/backend/app/Dockerfile
@@ -1,6 +1,10 @@
 # --- Build stage ---
-FROM amazoncorretto:21 AS build
+FROM amazoncorretto:21-al2023-jdk AS build
 WORKDIR /workspace
+
+# Gradle wrapper가 JVM 옵션 파싱에 사용하는 xargs 설치
+RUN yum install -y findutils \
+    && yum clean all
 
 # Gradle 캐시 최적화: wrapper/gradle 관련 파일을 먼저 복사
 # 빌드 컨텍스트는 backend/ (Gradle 루트)
@@ -16,7 +20,7 @@ COPY app/build.gradle app/build.gradle
 COPY crawling/build.gradle crawling/build.gradle
 
 RUN sed -i 's/\r$//' gradlew && chmod +x gradlew
-RUN ./gradlew --no-daemon dependencies || true
+RUN ./gradlew --no-daemon dependencies
 
 # app 소스만 복사 (crawling은 불필요)
 COPY app/src app/src

--- a/backend/crawling/Dockerfile.dev
+++ b/backend/crawling/Dockerfile.dev
@@ -1,6 +1,10 @@
 # --- Build stage ---
-FROM amazoncorretto:21 AS build
+FROM amazoncorretto:21-al2023-jdk AS build
 WORKDIR /workspace
+
+# Gradle wrapper가 JVM 옵션 파싱에 사용하는 xargs 설치
+RUN yum install -y findutils \
+    && yum clean all
 
 # 빌드 컨텍스트는 backend/ (Gradle 루트)
 COPY gradlew gradlew
@@ -13,7 +17,7 @@ COPY app/build.gradle app/build.gradle
 COPY crawling/build.gradle crawling/build.gradle
 
 RUN sed -i 's/\r$//' gradlew && chmod +x gradlew
-RUN ./gradlew --no-daemon dependencies || true
+RUN ./gradlew --no-daemon dependencies
 
 # crawling 모듈은 app 모듈 의존성이 있어 둘 다 복사
 COPY app/src app/src

--- a/backend/crawling/Dockerfile.dev
+++ b/backend/crawling/Dockerfile.dev
@@ -1,5 +1,5 @@
 # --- Build stage ---
-FROM amazoncorretto:21-al2023-jdk AS build
+FROM amazoncorretto:21 AS build
 WORKDIR /workspace
 
 # Gradle wrapper가 JVM 옵션 파싱에 사용하는 xargs 설치

--- a/backend/crawling/Dockerfile.main
+++ b/backend/crawling/Dockerfile.main
@@ -1,6 +1,10 @@
 # --- Build stage ---
-FROM amazoncorretto:21 AS build
+FROM amazoncorretto:21-al2023-jdk AS build
 WORKDIR /workspace
+
+# Gradle wrapper가 JVM 옵션 파싱에 사용하는 xargs 설치
+RUN yum install -y findutils \
+    && yum clean all
 
 # 빌드 컨텍스트는 backend/ (Gradle 루트)
 COPY gradlew gradlew
@@ -13,7 +17,7 @@ COPY app/build.gradle app/build.gradle
 COPY crawling/build.gradle crawling/build.gradle
 
 RUN sed -i 's/\r$//' gradlew && chmod +x gradlew
-RUN ./gradlew --no-daemon dependencies || true
+RUN ./gradlew --no-daemon dependencies
 
 # crawling 모듈은 app 모듈 의존성이 있어 둘 다 복사
 COPY app/src app/src

--- a/backend/crawling/Dockerfile.main
+++ b/backend/crawling/Dockerfile.main
@@ -1,5 +1,5 @@
 # --- Build stage ---
-FROM amazoncorretto:21-al2023-jdk AS build
+FROM amazoncorretto:21 AS build
 WORKDIR /workspace
 
 # Gradle wrapper가 JVM 옵션 파싱에 사용하는 xargs 설치


### PR DESCRIPTION
## 원인
`amazoncorretto:21` floating 태그가 가리키는 Build stage 기반 OS가 변경됐다.

- 2026-07-18 성공 digest `edb6b3e...`: Amazon Linux 2, `findutils`/`xargs` 포함
- 2026-08-12 실패 digest `ff30d87...`: Amazon Linux 2023, `findutils`/`xargs` 미포함

Gradle wrapper가 JVM 옵션 파싱에 `xargs`를 사용하므로 Backend/Crawling Docker 빌드가 Gradle 실행 전에 종료됐다. dependency warm-up 단계는 `|| true`로 같은 실패를 숨기고 있었다.

## 변경 사항
- 기존 `amazoncorretto:21` floating 태그를 유지해 Corretto 및 기반 이미지 업데이트를 계속 반영
- app, crawling dev/main Build stage에 `findutils`를 명시적으로 설치
- dependency warm-up 명령의 `|| true` 제거해 향후 실패를 즉시 노출

## 검증
- 성공/실패 당시 Corretto digest를 직접 실행해 OS 및 `xargs` 포함 여부 비교
- 현재 `amazoncorretto:21`에서 `yum` 사용 가능 및 `xargs` 미포함 확인
- `yum install -y findutils` 후 `/usr/bin/xargs`, GNU findutils 4.8.0 확인
- `./gradlew :app:bootJar :crawling:bootJar --no-daemon --build-cache -x test` 성공
- 로컬 Docker 데몬 미가동으로 전체 이미지 조립은 미실행

## API Spec
API 변경 없음.

Resolves #1125