### PR TITLE
feat: Admin 경기 정합성 강제 복구

### DIFF
--- a/backend/app/src/main/java/com/yagubogu/admin/dto/AdminCrawlingGamesResponse.java
+++ b/backend/app/src/main/java/com/yagubogu/admin/dto/AdminCrawlingGamesResponse.java
@@ -6,6 +6,7 @@ public record AdminCrawlingGamesResponse(
         int requested,
         int saved,
         int skipped,
+        int transformed,
         int reviewSaved,
         int reviewQueued,
         int failed,

--- a/backend/app/src/main/java/com/yagubogu/admin/service/AdminCrawlingService.java
+++ b/backend/app/src/main/java/com/yagubogu/admin/service/AdminCrawlingService.java
@@ -27,6 +27,7 @@ public class AdminCrawlingService {
         int requested = 0;
         int saved = 0;
         int skipped = 0;
+        int transformed = 0;
         int reviewSaved = 0;
         int reviewQueued = 0;
         List<String> savedGameCodes = new ArrayList<>();
@@ -40,6 +41,7 @@ public class AdminCrawlingService {
                 requested += crawlingResponse.requested();
                 saved += crawlingResponse.saved();
                 skipped += crawlingResponse.skipped();
+                transformed += crawlingResponse.transformed();
                 savedGameCodes.addAll(crawlingResponse.savedGameCodes());
             } catch (Exception exception) {
                 failedDates.add(date.toString());
@@ -70,6 +72,7 @@ public class AdminCrawlingService {
                 requested,
                 saved,
                 skipped,
+                transformed,
                 reviewSaved,
                 reviewQueued,
                 failedDates.size() + failedGameCodes.size(),

--- a/backend/app/src/main/java/com/yagubogu/game/domain/Game.java
+++ b/backend/app/src/main/java/com/yagubogu/game/domain/Game.java
@@ -122,6 +122,42 @@ public class Game {
             final ScoreBoard awayScoreBoard, final String homePitcher, final String awayPitcher,
             final GameState newState
     ) {
+        updateDetails(
+                stadium, homeTeam, awayTeam,
+                date, startAt, gameCode,
+                homeScore, awayScore,
+                homeScoreBoard, awayScoreBoard,
+                homePitcher, awayPitcher
+        );
+        updateGameState(newState);
+    }
+
+    /**
+     * Admin 정합성 복구 시 Bronze 원본을 기준으로 전체 필드를 강제 동기화한다.
+     */
+    public void reconcile(
+            final Stadium stadium, final Team homeTeam, final Team awayTeam,
+            final LocalDate date, final LocalTime startAt, final String gameCode,
+            final Integer homeScore, final Integer awayScore, final ScoreBoard homeScoreBoard,
+            final ScoreBoard awayScoreBoard, final String homePitcher, final String awayPitcher,
+            final GameState gameState
+    ) {
+        updateDetails(
+                stadium, homeTeam, awayTeam,
+                date, startAt, gameCode,
+                homeScore, awayScore,
+                homeScoreBoard, awayScoreBoard,
+                homePitcher, awayPitcher
+        );
+        this.gameState = gameState;
+    }
+
+    private void updateDetails(
+            final Stadium stadium, final Team homeTeam, final Team awayTeam,
+            final LocalDate date, final LocalTime startAt, final String gameCode,
+            final Integer homeScore, final Integer awayScore, final ScoreBoard homeScoreBoard,
+            final ScoreBoard awayScoreBoard, final String homePitcher, final String awayPitcher
+    ) {
         this.stadium = stadium;
         this.homeTeam = homeTeam;
         this.awayTeam = awayTeam;
@@ -134,7 +170,6 @@ public class Game {
         this.awayScoreBoard = awayScoreBoard;
         this.homePitcher = homePitcher;
         this.awayPitcher = awayPitcher;
-        updateGameState(newState);
     }
 
     public boolean hasTeam(final Team team) {

--- a/backend/app/src/main/java/com/yagubogu/game/service/GameEtlService.java
+++ b/backend/app/src/main/java/com/yagubogu/game/service/GameEtlService.java
@@ -58,17 +58,30 @@ public class GameEtlService {
      * @return 처리된 게임 수
      */
     public int transformBronzeToSilver(final LocalDateTime since) {
-        return transformPendingGames(bronzeGameRepository.findPendingEtl(since));
+        return transformGames(bronzeGameRepository.findPendingEtl(since), false);
     }
 
     public int transformPendingDateRange(final LocalDate startDate, final LocalDate endDate) {
-        return transformPendingGames(bronzeGameRepository.findPendingEtlByDateRange(startDate, endDate));
+        return transformGames(bronzeGameRepository.findPendingEtlByDateRange(startDate, endDate), false);
     }
 
-    private int transformPendingGames(final List<BronzeGame> bronzeGames) {
+    /**
+     * Admin 정합성 복구용 강제 재처리.
+     * Bronze의 ETL 완료 여부와 경기 상태 전이 규칙에 관계없이 해당 날짜 Silver를 원본과 맞춘다.
+     */
+    public int reprocessDate(final LocalDate date) {
+        List<BronzeGame> bronzeGames = bronzeGameRepository.findByDate(date);
+        log.info("[ETL_REPROCESS] Starting forced reconciliation: date={}, games={}", date, bronzeGames.size());
+        int transformedCount = transformGames(bronzeGames, true);
+        log.info("[ETL_REPROCESS] Completed forced reconciliation: date={}, transformed={}",
+                date, transformedCount);
+        return transformedCount;
+    }
+
+    private int transformGames(final List<BronzeGame> bronzeGames, final boolean forceReconcile) {
 
         if (bronzeGames.isEmpty()) {
-            log.debug("No pending bronze data to transform");
+            log.debug("No bronze data to transform");
             return 0;
         }
 
@@ -106,7 +119,7 @@ public class GameEtlService {
                 try {
                     final int order = doubleHeaderOrderMap.getOrDefault(bronzeGame, 0);
                     Boolean transformed = transactionTemplate.execute(status ->
-                            transformAndMarkProcessed(bronzeGame.getId(), order)
+                            transformAndMarkProcessed(bronzeGame.getId(), order, forceReconcile)
                     );
                     if (Boolean.TRUE.equals(transformed)) {
                         transformedCount++;
@@ -122,11 +135,12 @@ public class GameEtlService {
         return transformedCount;
     }
 
-    private boolean transformAndMarkProcessed(final Long bronzeGameId, final int doubleHeaderOrder) {
+    private boolean transformAndMarkProcessed(final Long bronzeGameId, final int doubleHeaderOrder,
+                                              final boolean forceReconcile) {
         final BronzeGame bronzeGame = bronzeGameRepository.findById(bronzeGameId)
                 .orElseThrow(() -> new NotFoundException("Bronze game not found: " + bronzeGameId));
         try {
-            transformSingleGame(bronzeGame, doubleHeaderOrder);
+            transformSingleGame(bronzeGame, doubleHeaderOrder, forceReconcile);
             bronzeGame.markEtlProcessed(LocalDateTime.now(clock));
             return true;
         } catch (Exception e) {
@@ -179,7 +193,7 @@ public class GameEtlService {
 
             final int doubleHeaderOrder = order;
             transactionTemplate.executeWithoutResult(status ->
-                    transformAndMarkProcessed(targetGame.getId(), doubleHeaderOrder)
+                    transformAndMarkProcessed(targetGame.getId(), doubleHeaderOrder, false)
             );
             log.info("Immediate ETL completed: date={}, home={}, away={}, order={}",
                     date, homeTeam, awayTeam, order);
@@ -278,7 +292,8 @@ public class GameEtlService {
      * 단일 BronzeGame을 Silver(Game)로 변환
      * gameCode는 해당 게임의 더블헤더 순서를 미리 계산하여 생성
      */
-    private void transformSingleGame(final BronzeGame bronzeGame, final int doubleHeaderOrder) throws Exception {
+    private void transformSingleGame(final BronzeGame bronzeGame, final int doubleHeaderOrder,
+                                     final boolean forceReconcile) throws Exception {
         // 1. Extract: Bronze에서 JSON 파싱
         final JsonNode json = objectMapper.readTree(bronzeGame.getPayload());
 
@@ -344,7 +359,8 @@ public class GameEtlService {
                             date, startTime, gameCode,
                             homeScore, awayScore,
                             homeScoreBoard, awayScoreBoard,
-                            homePitcher, awayPitcher, gameState
+                            homePitcher, awayPitcher, gameState,
+                            forceReconcile
                     );
                     log.debug("[ETL] Updated Game: stadium={}, date={}, startTime={}, gameCode={}",
                             stadium, date, startTime, gameCode);
@@ -482,19 +498,31 @@ public class GameEtlService {
             Integer homeScore, Integer awayScore,
             ScoreBoard homeScoreBoard, ScoreBoard awayScoreBoard,
             String homePitcher, String awayPitcher,
-            GameState gameState
+            GameState gameState,
+            boolean forceReconcile
     ) {
         ScoreBoard updatedHome = resolveScoreBoard(existing.getHomeScoreBoard(), homeScoreBoard);
         ScoreBoard updatedAway = resolveScoreBoard(existing.getAwayScoreBoard(), awayScoreBoard);
 
-        existing.update(
-                stadium, homeTeam, awayTeam,
-                date, startTime, gameCode,
-                homeScore, awayScore,
-                updatedHome, updatedAway,
-                homePitcher, awayPitcher,
-                gameState
-        );
+        if (forceReconcile) {
+            existing.reconcile(
+                    stadium, homeTeam, awayTeam,
+                    date, startTime, gameCode,
+                    homeScore, awayScore,
+                    updatedHome, updatedAway,
+                    homePitcher, awayPitcher,
+                    gameState
+            );
+        } else {
+            existing.update(
+                    stadium, homeTeam, awayTeam,
+                    date, startTime, gameCode,
+                    homeScore, awayScore,
+                    updatedHome, updatedAway,
+                    homePitcher, awayPitcher,
+                    gameState
+            );
+        }
         return existing;
     }
 

--- a/backend/app/src/test/java/com/yagubogu/admin/service/AdminCrawlingServiceTest.java
+++ b/backend/app/src/test/java/com/yagubogu/admin/service/AdminCrawlingServiceTest.java
@@ -1,0 +1,44 @@
+package com.yagubogu.admin.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.yagubogu.admin.client.CrawlingAdminClient;
+import com.yagubogu.admin.dto.AdminCrawlingGamesRequest;
+import com.yagubogu.admin.dto.AdminCrawlingGamesResponse;
+import com.yagubogu.admin.dto.CrawlingGameDateResponse;
+import java.time.LocalDate;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class AdminCrawlingServiceTest {
+
+    private final CrawlingAdminClient crawlingAdminClient = mock(CrawlingAdminClient.class);
+    private final AdminCrawlingService adminCrawlingService = new AdminCrawlingService(crawlingAdminClient);
+
+    @DisplayName("Admin 경기 크롤링 응답에 날짜별 강제 ETL 처리 건수를 합산한다")
+    @Test
+    void aggregateTransformedCount() {
+        LocalDate firstDate = LocalDate.of(2026, 8, 12);
+        LocalDate secondDate = LocalDate.of(2026, 8, 13);
+        AdminCrawlingGamesRequest request = new AdminCrawlingGamesRequest(
+                firstDate, secondDate, 0L, 0L
+        );
+        when(crawlingAdminClient.fetchGames(firstDate)).thenReturn(new CrawlingGameDateResponse(
+                5, 5, 0, 5, 5, List.of("20260812HHOB0"), List.of()
+        ));
+        when(crawlingAdminClient.fetchGames(secondDate)).thenReturn(new CrawlingGameDateResponse(
+                5, 5, 0, 5, 5, List.of("20260813HHOB0"), List.of()
+        ));
+
+        AdminCrawlingGamesResponse response = adminCrawlingService.crawlGames(request);
+
+        assertThat(response.requested()).isEqualTo(10);
+        assertThat(response.saved()).isZero();
+        assertThat(response.skipped()).isEqualTo(10);
+        assertThat(response.transformed()).isEqualTo(10);
+        assertThat(response.savedGameCodes()).containsExactly("20260812HHOB0", "20260813HHOB0");
+    }
+}

--- a/backend/app/src/test/java/com/yagubogu/game/service/GameEtlServiceTest.java
+++ b/backend/app/src/test/java/com/yagubogu/game/service/GameEtlServiceTest.java
@@ -3,6 +3,8 @@ package com.yagubogu.game.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -117,5 +119,60 @@ class GameEtlServiceTest {
         assertThat(existingGame.getAwayScore()).isZero();
         assertThat(existingGame.getGameState()).isEqualTo(GameState.COMPLETED);
         assertThat(bronzeGame.getEtlProcessedAt()).isNotNull();
+    }
+
+    @DisplayName("Admin 강제 재처리는 ETL 완료된 Bronze로 gameCode가 같은 Silver의 정합성을 복구한다")
+    @Test
+    void reprocessCompletedBronzeByGameCode() {
+        LocalDate date = LocalDate.of(2026, 8, 13);
+        String gameCode = "20260813HHOB0";
+        Team homeTeam = new Team("두산 베어스", "두산", "OB", TeamStatus.ACTIVE);
+        Team awayTeam = new Team("한화 이글스", "한화", "HH", TeamStatus.ACTIVE);
+        Stadium stadium = new Stadium("서울종합운동장 야구장", "잠실", "잠실", 0.0, 0.0, StadiumLevel.MAIN);
+        Game inconsistentGame = new Game(
+                stadium, homeTeam, awayTeam, date, LocalTime.of(18, 30), gameCode,
+                9, 6, null, null, "최민석", "류현진", GameState.CANCELED
+        );
+        String payload = """
+                {
+                  "gameCode":"20260813HHOB0",
+                  "date":"2026-08-13",
+                  "status":"경기종료",
+                  "stadium":"잠실",
+                  "startTime":"19:00:00",
+                  "awayScore":6,
+                  "homeScore":9,
+                  "winningPitcher":"최민석",
+                  "losingPitcher":"류현진",
+                  "awayTeamScoreboard":{"name":"한화","runs":6,"hits":8,"errors":0,"basesOnBalls":2,"inningScores":[]},
+                  "homeTeamScoreboard":{"name":"두산","runs":9,"hits":12,"errors":0,"basesOnBalls":4,"inningScores":[]}
+                }
+                """;
+        BronzeGame processedBronze = new BronzeGame(
+                gameCode, date, "잠실", "두산", "한화", LocalTime.of(19, 0),
+                LocalDateTime.of(2026, 8, 13, 23, 0), payload, "hash"
+        );
+        ReflectionTestUtils.setField(processedBronze, "id", 2L);
+        processedBronze.markEtlProcessed(LocalDateTime.of(2026, 8, 13, 23, 1));
+
+        when(bronzeGameRepository.findByDate(date)).thenReturn(java.util.List.of(processedBronze));
+        when(bronzeGameRepository.findById(2L)).thenReturn(Optional.of(processedBronze));
+        when(teamRepository.findByShortName("두산")).thenReturn(Optional.of(homeTeam));
+        when(teamRepository.findByShortName("한화")).thenReturn(Optional.of(awayTeam));
+        when(stadiumRepository.findByLocation("잠실")).thenReturn(Optional.of(stadium));
+        when(gameRepository.findByGameCode(gameCode)).thenReturn(Optional.of(inconsistentGame));
+
+        int transformed = gameEtlService.reprocessDate(date);
+
+        assertThat(transformed).isEqualTo(1);
+        assertThat(inconsistentGame.getStartAt()).isEqualTo(LocalTime.of(19, 0));
+        assertThat(inconsistentGame.getGameCode()).isEqualTo(gameCode);
+        assertThat(inconsistentGame.getHomeScore()).isEqualTo(9);
+        assertThat(inconsistentGame.getAwayScore()).isEqualTo(6);
+        assertThat(inconsistentGame.getHomePitcher()).isEqualTo("최민석");
+        assertThat(inconsistentGame.getAwayPitcher()).isEqualTo("류현진");
+        assertThat(inconsistentGame.getGameState()).isEqualTo(GameState.COMPLETED);
+        assertThat(processedBronze.getEtlProcessedAt()).isNotNull();
+        verify(gameRepository, never()).save(any(Game.class));
     }
 }

--- a/backend/crawling/src/main/java/yagubogu/crawling/game/controller/KboCrawlerControllerInterface.java
+++ b/backend/crawling/src/main/java/yagubogu/crawling/game/controller/KboCrawlerControllerInterface.java
@@ -41,7 +41,7 @@ public interface KboCrawlerControllerInterface {
     ResponseEntity<Integer> fetchGameCenter(
             @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date);
 
-    @Operation(summary = "특정 날짜 게임 크롤링", description = "지정한 날짜의 모든 스코어보드를 가져와 신규 게임을 저장하고 즉시 ETL합니다.")
+    @Operation(summary = "특정 날짜 게임 크롤링", description = "지정한 날짜의 스코어보드와 게임센터를 가져온 뒤 Bronze 처리 여부와 관계없이 Silver를 강제 동기화합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "날짜 기반 크롤링 성공")
     })

--- a/backend/crawling/src/main/java/yagubogu/crawling/game/service/crawler/KboScoardboardCrawler/KboScoreboardService.java
+++ b/backend/crawling/src/main/java/yagubogu/crawling/game/service/crawler/KboScoardboardCrawler/KboScoreboardService.java
@@ -128,7 +128,8 @@ public class KboScoreboardService {
                 .map(Map.Entry::getKey)
                 .toList();
 
-        int transformedCount = crawledGames.isEmpty() ? 0 : gameEtlService.transformPendingDateRange(date, date);
+        // Admin 복구 요청은 Bronze 변경 여부와 무관하게 해당 날짜 Silver를 강제로 원본과 맞춘다.
+        int transformedCount = gameEtlService.reprocessDate(date);
         int skippedCount = Math.max(0, crawledGames.size() - savedCount);
 
         log.info("[GAME_DATE_CRAWL] date={}, matched={}, saved={}, skipped={}, transformed={}",

--- a/backend/crawling/src/test/java/yagubogu/crawling/game/service/crawler/KboScoardboardCrawler/KboScoreboardServiceTest.java
+++ b/backend/crawling/src/test/java/yagubogu/crawling/game/service/crawler/KboScoardboardCrawler/KboScoreboardServiceTest.java
@@ -81,7 +81,7 @@ class KboScoreboardServiceTest {
                 any(), any(), any(), any(), any(), any(), any()
         )).thenReturn(true);
         when(gameCenterSyncService.fetchGameCenterOnly(date)).thenReturn(gameCenter);
-        when(gameEtlService.transformPendingDateRange(date, date)).thenReturn(1);
+        when(gameEtlService.reprocessDate(date)).thenReturn(1);
 
         KboScoreboardService service = new KboScoreboardService(
                 crawler,
@@ -101,9 +101,10 @@ class KboScoreboardServiceTest {
         GameDateCrawlResponse response = service.fetchGamesByDate(date);
 
         verify(gameCenterSyncService).saveToBronzeLayer(List.of(detail));
-        verify(gameEtlService).transformPendingDateRange(date, date);
+        verify(gameEtlService).reprocessDate(date);
         assertThat(response.requested()).isEqualTo(1);
         assertThat(response.matched()).isEqualTo(1);
+        assertThat(response.transformed()).isEqualTo(1);
         assertThat(response.savedGameCodes()).containsExactly(gameCode);
         assertThat(response.completedGameCodes()).isEmpty();
     }


### PR DESCRIPTION
## 변경 사항

- Admin 날짜별 경기 크롤링이 Bronze 변경 여부 및 기존 ETL 처리 여부와 관계없이 해당 날짜 Silver를 강제 재처리합니다.
- 강제 복구는 공식 `gameCode`로 기존 경기 행을 우선 조회하여 `game_id`를 유지하고 중복 생성을 방지합니다.
- 시작 시각, 점수, 스코어보드, 투수, 경기 상태를 Bronze 원본과 동기화합니다.
- Admin 응답에 날짜 범위의 실제 ETL 처리 합계인 `transformed`를 추가합니다.
- 일반 스케줄러와 Poller의 pending ETL 및 상태 전이 보호는 기존대로 유지합니다.

## 검증

- `GameEtlServiceTest`: ETL 완료된 Bronze와 불일치한 Silver를 `gameCode`로 복구하고 신규 행을 저장하지 않는지 검증
- `AdminCrawlingServiceTest`: 날짜 범위의 `transformed` 합산 검증
- `KboScoreboardServiceTest`: 날짜별 크롤링이 강제 재처리를 호출하고 응답에 처리 건수를 반영하는지 검증
- 관련 대상 테스트 성공
- `:crawling:test` 전체 성공
- `:app:bootJar`, `:crawling:bootJar` 성공
- 전체 `test` 실행 시 로컬 Docker 미가동으로 Testcontainers 기반 E2E 12개가 초기화 실패했으며, 변경 관련 테스트 실패는 없음

## API Spec

### `POST /admin/crawling/games`

- 권한: `ADMIN`
- Query/Path parameter: 없음
- Request body:
  - `startDate`: ISO 날짜, 필수
  - `endDate`: ISO 날짜, 필수, `startDate` 이상
  - `sleepMillis`: 선택, 0~60000, 기본 3000
  - `reviewRetryDelayMinutes`: 선택, 0~1440, 기본 30
- Response `200 OK`:
  - 기존 필드 `requested`, `saved`, `skipped`, `reviewSaved`, `reviewQueued`, `failed`, `savedGameCodes`, `failedGameCodes`, `failedDates` 유지
  - `transformed`: 요청 날짜 범위에서 Bronze를 Silver로 강제 재처리한 경기 수 추가
- Validation error: 잘못된 날짜 범위 또는 제한값은 `400 Bad Request`
- Authorization error: Admin 권한이 없으면 기존 인증/인가 정책에 따른 오류

### `POST /api/kbo/games/by-date`

- Request body: `{ "date": "YYYY-MM-DD" }`, 날짜 필수
- Response `200 OK`: `requested`, `matched`, `saved`, `skipped`, `transformed`, `savedGameCodes`, `completedGameCodes`
- 변경 동작: Bronze 신규/변경 건만 처리하던 pending ETL 대신 해당 날짜 Bronze 전체를 강제 재처리하며, `transformed`에 실제 처리 건수를 반환
- Validation error: 날짜 누락 시 `400 Bad Request`

## 호환성 및 마이그레이션

- DB 마이그레이션 없음
- Admin 응답의 `transformed`는 additive 필드
- 기존 요청 형식과 나머지 응답 필드는 유지

Resolves #1128