### PR TITLE
fix: GameCenter 경기예정 상태 매핑

### DIFF
--- a/backend/app/src/main/java/com/yagubogu/game/domain/GameState.java
+++ b/backend/app/src/main/java/com/yagubogu/game/domain/GameState.java
@@ -3,6 +3,8 @@ package com.yagubogu.game.domain;
 import com.yagubogu.game.exception.GameSyncException;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
+import java.util.regex.Pattern;
 
 public enum GameState {
 
@@ -13,6 +15,7 @@ public enum GameState {
     ;
 
     private static final List<GameState> FINALIZED_GAME_STATES = List.of(COMPLETED, CANCELED);
+    private static final Pattern LIVE_INNING_PATTERN = Pattern.compile("\\d+회\\s*(초|말)");
 
     private final Integer stateNumber;
     private final String statusName;
@@ -30,14 +33,37 @@ public enum GameState {
     }
 
     public static GameState fromName(final String state) {
-        if (state == null || state.isEmpty()) {
+        if (state == null || state.isBlank()) {
             return GameState.SCHEDULED;
         }
 
-        return Arrays.stream(values())
-                .filter(status -> state.contains(status.statusName))
-                .findFirst()
-                .orElse(LIVE);
+        return tryFromName(state)
+                .orElseThrow(() -> new GameSyncException("Unknown game status: " + state));
+    }
+
+    public static Optional<GameState> tryFromName(final String state) {
+        if (state == null || state.isBlank()) {
+            return Optional.empty();
+        }
+
+        String normalized = state.trim();
+        if (normalized.contains("경기전") || normalized.contains("경기예정")) {
+            return Optional.of(SCHEDULED);
+        }
+        if (normalized.contains("종료")) {
+            return Optional.of(COMPLETED);
+        }
+        if (normalized.contains("취소")) {
+            return Optional.of(CANCELED);
+        }
+        if (normalized.equals(LIVE.statusName)
+                || normalized.contains("경기중")
+                || normalized.contains("진행중")
+                || normalized.contains("중단")
+                || LIVE_INNING_PATTERN.matcher(normalized).find()) {
+            return Optional.of(LIVE);
+        }
+        return Optional.empty();
     }
 
     public boolean canTransitionTo(GameState newState) {

--- a/backend/app/src/test/java/com/yagubogu/game/domain/GameStateTest.java
+++ b/backend/app/src/test/java/com/yagubogu/game/domain/GameStateTest.java
@@ -1,0 +1,48 @@
+package com.yagubogu.game.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.yagubogu.game.exception.GameSyncException;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class GameStateTest {
+
+    @DisplayName("KBO 경기 상태 문구를 명시적인 GameState로 변환한다")
+    @ParameterizedTest
+    @MethodSource("knownGameStates")
+    void parseKnownGameState(final String status, final GameState expected) {
+        assertThat(GameState.tryFromName(status)).contains(expected);
+        assertThat(GameState.fromName(status)).isEqualTo(expected);
+    }
+
+    static Stream<Arguments> knownGameStates() {
+        return Stream.of(
+                Arguments.of("경기전", GameState.SCHEDULED),
+                Arguments.of("경기예정", GameState.SCHEDULED),
+                Arguments.of("경기중", GameState.LIVE),
+                Arguments.of("3회초", GameState.LIVE),
+                Arguments.of("우천중단", GameState.LIVE),
+                Arguments.of("경기종료", GameState.COMPLETED),
+                Arguments.of("경기취소", GameState.CANCELED)
+        );
+    }
+
+    @DisplayName("알 수 없는 경기 상태는 LIVE로 추정하지 않는다")
+    @ParameterizedTest
+    @MethodSource("unknownGameStates")
+    void doNotGuessUnknownStateAsLive(final String status) {
+        assertThat(GameState.tryFromName(status)).isEmpty();
+        assertThatThrownBy(() -> GameState.fromName(status))
+                .isInstanceOf(GameSyncException.class)
+                .hasMessageContaining("Unknown game status");
+    }
+
+    static Stream<String> unknownGameStates() {
+        return Stream.of("상태확인중", "중계 준비", "-");
+    }
+}

--- a/backend/crawling/src/main/java/yagubogu/crawling/game/service/crawler/KboGameCenterCrawler/GameCenterSyncService.java
+++ b/backend/crawling/src/main/java/yagubogu/crawling/game/service/crawler/KboGameCenterCrawler/GameCenterSyncService.java
@@ -63,7 +63,12 @@ public class GameCenterSyncService {
         String homeTeam = detail.getHomeTeamName();
         String awayTeam = detail.getAwayTeamName();
         LocalTime startTime = parseTime(detail.getStartTime());
-        GameState state = GameState.fromName(detail.getStatus());
+        GameState state = GameState.tryFromName(detail.getStatus()).orElse(null);
+        if (state == null) {
+            log.warn("[BRONZE] 알 수 없는 GameCenter 경기 상태로 저장 생략: gameCode={}, status={}",
+                    detail.getGameCode(), detail.getStatus());
+            return false;
+        }
 
         boolean updated = bronzeGameService.updateGameState(
                 detail.getGameCode(), date, stadium, homeTeam, awayTeam, startTime, state

--- a/backend/crawling/src/test/java/yagubogu/crawling/game/service/crawler/KboGameCenterCrawler/GameCenterSyncServiceTest.java
+++ b/backend/crawling/src/test/java/yagubogu/crawling/game/service/crawler/KboGameCenterCrawler/GameCenterSyncServiceTest.java
@@ -1,0 +1,74 @@
+package yagubogu.crawling.game.service.crawler.KboGameCenterCrawler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.yagubogu.game.domain.GameState;
+import com.yagubogu.game.service.BronzeGameService;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import yagubogu.crawling.game.dto.GameCenterDetail;
+
+class GameCenterSyncServiceTest {
+
+    private final KboGameCenterCrawler crawler = mock(KboGameCenterCrawler.class);
+    private final BronzeGameService bronzeGameService = mock(BronzeGameService.class);
+    private final GameCenterSyncService service = new GameCenterSyncService(crawler, bronzeGameService);
+
+    @DisplayName("GameCenter의 경기예정 상태를 SCHEDULED로 저장한다")
+    @Test
+    void saveScheduledGame() {
+        GameCenterDetail detail = gameDetail("경기예정");
+        when(bronzeGameService.updateGameState(
+                "20260814HHSS0",
+                LocalDate.of(2026, 8, 14),
+                "대구",
+                "삼성",
+                "한화",
+                LocalTime.of(19, 0),
+                GameState.SCHEDULED
+        )).thenReturn(true);
+
+        int updatedCount = service.saveToBronzeLayer(List.of(detail));
+
+        assertThat(updatedCount).isEqualTo(1);
+        verify(bronzeGameService).updateGameState(
+                "20260814HHSS0",
+                LocalDate.of(2026, 8, 14),
+                "대구",
+                "삼성",
+                "한화",
+                LocalTime.of(19, 0),
+                GameState.SCHEDULED
+        );
+    }
+
+    @DisplayName("알 수 없는 GameCenter 상태는 기존 Bronze 상태를 덮어쓰지 않는다")
+    @Test
+    void skipUnknownGameState() {
+        GameCenterDetail detail = gameDetail("중계 준비");
+
+        int updatedCount = service.saveToBronzeLayer(List.of(detail));
+
+        assertThat(updatedCount).isZero();
+        verifyNoInteractions(bronzeGameService);
+    }
+
+    private GameCenterDetail gameDetail(final String status) {
+        GameCenterDetail detail = new GameCenterDetail();
+        detail.setGameCode("20260814HHSS0");
+        detail.setGameDate("20260814");
+        detail.setStadiumName("대구");
+        detail.setHomeTeamName("삼성");
+        detail.setAwayTeamName("한화");
+        detail.setStartTime("19:00");
+        detail.setStatus(status);
+        return detail;
+    }
+}


### PR DESCRIPTION
## 문제

GameCenter가 경기 전 상태를 `경기예정`으로 제공하지만 기존 파서는 `경기전`만 `SCHEDULED`로 인식하고, 미등록 문자열을 `LIVE`로 처리했습니다. 그 결과 2026-08-14 예정 경기 5건이 Bronze와 Silver 모두 `LIVE`로 저장됐습니다.

## 변경 사항

- `경기전`, `경기예정`을 `SCHEDULED`로 명시 매핑합니다.
- `경기중`, `진행중`, 이닝 진행 표기, 중단 상태를 `LIVE`로 명시 매핑합니다.
- 종료·취소 상태를 문구 기반으로 명시 매핑합니다.
- 알 수 없는 상태는 더 이상 `LIVE`로 추정하지 않고 `GameSyncException`을 발생시킵니다.
- GameCenter 동기화에서는 안전 파싱에 실패한 상태를 Bronze에 저장하지 않고 경고 로그를 남깁니다.

## 검증

- `GameStateTest`: 예정/진행/종료/취소 상태와 알 수 없는 상태 검증
- `GameCenterSyncServiceTest`: `경기예정`의 SCHEDULED 저장 및 미등록 상태 저장 생략 검증
- `:crawling:test` 전체 성공
- `:app:bootJar`, `:crawling:bootJar` 성공

## API Spec

### `POST /admin/crawling/games`

- Method/Path: 기존과 동일
- Request/Response/검증/상태 코드: 변경 없음
- 동작 변경: GameCenter의 `경기예정`을 `SCHEDULED`로 수집하여 요청 날짜 Bronze/Silver를 올바른 상태로 강제 재처리합니다.
- 복구 방법: 이 PR 배포 후 `startDate=2026-08-14`, `endDate=2026-08-14`로 실행하면 현재 잘못 저장된 오늘 경기 5건을 복구할 수 있습니다.

### 내부 `POST /api/kbo/games/by-date`

- Method/Path, 요청·응답 형식, 검증, 상태 코드: 변경 없음
- 동작 변경: `경기예정` 상태가 `LIVE`가 아닌 `SCHEDULED`로 반영됩니다.

## 호환성 및 마이그레이션

- DB 마이그레이션 없음
- API 스키마 변경 없음
- 알 수 없는 KBO 상태는 데이터 오염 대신 경고와 처리 실패로 관측됩니다.

Resolves #1131