### PR TITLE
fix: 장소 동기화 실패 조기 감지 + 수동 동기화 API 추가 + 검색 반경 3km 확대

### DIFF
--- a/backend/app/src/main/java/com/yagubogu/admin/controller/AdminController.java
+++ b/backend/app/src/main/java/com/yagubogu/admin/controller/AdminController.java
@@ -5,12 +5,15 @@ import com.yagubogu.admin.dto.AdminCrawlingGamesResponse;
 import com.yagubogu.admin.service.AdminCrawlingService;
 import com.yagubogu.auth.annotation.RequireRole;
 import com.yagubogu.member.domain.Role;
+import com.yagubogu.place.dto.PlaceSyncResult;
+import com.yagubogu.place.service.PlaceSyncService;
 import com.yagubogu.stat.service.LocationCheckInRankingSyncService;
 import com.yagubogu.stat.service.StatSyncService;
 import io.swagger.v3.oas.annotations.Hidden;
 import jakarta.validation.Valid;
 import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -26,6 +29,7 @@ public class AdminController {
     private final StatSyncService statSyncService;
     private final LocationCheckInRankingSyncService locationCheckInRankingSyncService;
     private final AdminCrawlingService adminCrawlingService;
+    private final PlaceSyncService placeSyncService;
 
     @PostMapping("/victory-fairy-rankings/sync")
     public ResponseEntity<Void> syncVictoryRankings() {
@@ -44,6 +48,20 @@ public class AdminController {
         int syncedCount = locationCheckInRankingSyncService.rebuildAll();
 
         return ResponseEntity.ok(syncedCount);
+    }
+
+    /**
+     * 구장 주변 장소를 즉시 재동기화한다. 매일 새벽 3시 스케줄러를 기다릴 수 없을 때(서비스키 교체 직후 등) 사용한다.
+     *
+     * <p>구장 x 카테고리 조합을 순회하며 외부 API를 호출하므로 응답까지 수 분 이상 걸릴 수 있다.
+     * 프록시 타임아웃으로 응답을 못 받아도 서버 측 동기화는 계속 진행되며, 진행 상황은 {@code [PlaceSync]} 로그로 확인한다.
+     * 이미 동기화가 진행 중이면 409를 반환한다 — 중복 실행은 서비스키의 일일 트래픽 한도를 그대로 소모한다.</p>
+     */
+    @PostMapping("/places/sync")
+    public ResponseEntity<PlaceSyncResult> syncPlaces() {
+        return placeSyncService.syncAll()
+                .map(ResponseEntity::ok)
+                .orElseGet(() -> ResponseEntity.status(HttpStatus.CONFLICT).build());
     }
 
     @PostMapping("/crawling/games")

--- a/backend/app/src/main/java/com/yagubogu/place/config/TourApiProperties.java
+++ b/backend/app/src/main/java/com/yagubogu/place/config/TourApiProperties.java
@@ -1,13 +1,23 @@
 package com.yagubogu.place.config;
 
+import jakarta.validation.constraints.NotBlank;
 import java.time.Duration;
 import lombok.Getter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
 
+/**
+ * 서비스키는 기동 시점에 검증한다.
+ * GitHub Actions는 등록되지 않은 시크릿을 경고 없이 빈 문자열로 치환하기 때문에,
+ * 검증이 없으면 앱이 정상 기동하고 헬스체크까지 통과한 뒤 매일 새벽 3시 폴링에서만 전부 실패한다.
+ * (하루 한 번 도는 작업이라 발견까지 24시간이 걸린다.)
+ */
 @Getter
+@Validated
 @ConfigurationProperties(prefix = "tour.api")
 public class TourApiProperties {
 
+    @NotBlank(message = "TOUR_API_SERVICE_KEY가 비어 있습니다. 공공데이터포털에서 발급받은 디코딩된(Decoded) 서비스키를 설정하세요.")
     private final String serviceKey;
     private final String baseUrl;
     private final int radius;

--- a/backend/app/src/main/java/com/yagubogu/place/dto/PlaceSyncResult.java
+++ b/backend/app/src/main/java/com/yagubogu/place/dto/PlaceSyncResult.java
@@ -1,0 +1,8 @@
+package com.yagubogu.place.dto;
+
+/**
+ * 구장 x 카테고리 조합 단위의 동기화 성공/실패 집계.
+ * 조합 하나가 실패해도 나머지는 계속 진행되므로 둘을 함께 봐야 실제 상태를 알 수 있다.
+ */
+public record PlaceSyncResult(int success, int failed) {
+}

--- a/backend/app/src/main/java/com/yagubogu/place/service/PlaceSyncService.java
+++ b/backend/app/src/main/java/com/yagubogu/place/service/PlaceSyncService.java
@@ -1,9 +1,12 @@
 package com.yagubogu.place.service;
 
 import com.yagubogu.place.domain.PlaceCategory;
+import com.yagubogu.place.dto.PlaceSyncResult;
 import com.yagubogu.stadium.domain.Stadium;
 import com.yagubogu.stadium.repository.StadiumRepository;
 import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -21,7 +24,30 @@ public class PlaceSyncService {
     private final PlaceStadiumSyncService placeStadiumSyncService;
     private final StadiumRepository stadiumRepository;
 
-    public void syncAll() {
+    /**
+     * 스케줄러와 관리자 수동 트리거가 같은 진입점을 쓰므로 동시 실행을 막는다.
+     * 한 번의 전체 동기화는 목록 조회 외에 신규 장소마다 상세 조회가 2회씩 붙어 호출량이 크고,
+     * 공공데이터포털 서비스키에는 일일 트래픽 한도가 있어 중복 실행이 그대로 한도 소모로 이어진다.
+     */
+    private final AtomicBoolean running = new AtomicBoolean(false);
+
+    /**
+     * @return 동기화 집계. 이미 다른 동기화가 진행 중이면 {@link Optional#empty()}
+     */
+    public Optional<PlaceSyncResult> syncAll() {
+        if (!running.compareAndSet(false, true)) {
+            log.warn("[PlaceSync] Sync already in progress; skipping this trigger");
+            return Optional.empty();
+        }
+
+        try {
+            return Optional.of(doSyncAll());
+        } finally {
+            running.set(false);
+        }
+    }
+
+    private PlaceSyncResult doSyncAll() {
         List<Stadium> stadiums = stadiumRepository.findAll();
         log.info("[PlaceSync] Starting sync for {} stadiums x {} categories",
                 stadiums.size(), PlaceCategory.values().length);
@@ -43,5 +69,7 @@ public class PlaceSyncService {
         }
 
         log.info("[PlaceSync] Completed: success={}, failed={}", success, failed);
+
+        return new PlaceSyncResult(success, failed);
     }
 }

--- a/backend/app/src/main/resources/application.yml
+++ b/backend/app/src/main/resources/application.yml
@@ -83,7 +83,7 @@ tour:
     # 공공데이터포털에서 발급받은 디코딩된(Decoded) 서비스키를 사용하세요. (이중 인코딩 방지)
     service-key: ${TOUR_API_SERVICE_KEY}
     base-url: https://apis.data.go.kr/B551011/KorService2
-    radius: 1000        # 구장 중심으로부터 반경 (미터)
+    radius: 3000        # 구장 중심으로부터 반경 (미터)
     num-of-rows: 50     # 한 번에 가져올 최대 결과 수
     connect-timeout: 10s
     read-timeout: 30s

--- a/backend/app/src/test/java/com/yagubogu/place/config/TourApiPropertiesTest.java
+++ b/backend/app/src/test/java/com/yagubogu/place/config/TourApiPropertiesTest.java
@@ -1,0 +1,52 @@
+package com.yagubogu.place.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * 서비스키 누락이 기동 시점에 잡히는지 검증한다.
+ * GitHub Actions는 등록되지 않은 시크릿을 빈 문자열로 치환하므로, 검증이 없으면 앱이 정상 기동한 뒤
+ * 매일 새벽 3시 폴링에서만 전부 실패한다 — 실제로 그 경로로 장애가 하루 동안 드러나지 않았다.
+ */
+class TourApiPropertiesTest {
+
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+            .withUserConfiguration(TourApiPropertiesConfig.class)
+            .withPropertyValues(
+                    "tour.api.base-url=https://apis.data.go.kr/B551011/KorService2",
+                    "tour.api.radius=3000",
+                    "tour.api.num-of-rows=50",
+                    "tour.api.connect-timeout=10s",
+                    "tour.api.read-timeout=30s"
+            );
+
+    @DisplayName("서비스키가 비어 있으면 기동에 실패한다")
+    @Test
+    void 서비스키가_비어_있으면_기동_실패() {
+        contextRunner.withPropertyValues("tour.api.service-key=")
+                .run(context -> assertThat(context).hasFailed()
+                        .getFailure()
+                        .hasStackTraceContaining("TOUR_API_SERVICE_KEY"));
+    }
+
+    @DisplayName("서비스키가 있으면 정상 바인딩된다")
+    @Test
+    void 서비스키가_있으면_정상_바인딩() {
+        contextRunner.withPropertyValues("tour.api.service-key=decoded-service-key")
+                .run(context -> {
+                    assertThat(context).hasNotFailed();
+                    assertThat(context.getBean(TourApiProperties.class).getServiceKey())
+                            .isEqualTo("decoded-service-key");
+                });
+    }
+
+    @Configuration
+    @EnableConfigurationProperties(TourApiProperties.class)
+    static class TourApiPropertiesConfig {
+    }
+}

--- a/backend/app/src/test/java/com/yagubogu/place/service/PlaceSyncServiceTest.java
+++ b/backend/app/src/test/java/com/yagubogu/place/service/PlaceSyncServiceTest.java
@@ -1,17 +1,22 @@
 package com.yagubogu.place.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willAnswer;
 import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import com.yagubogu.place.domain.PlaceCategory;
+import com.yagubogu.place.dto.PlaceSyncResult;
 import com.yagubogu.stadium.domain.Stadium;
 import com.yagubogu.stadium.domain.StadiumLevel;
 import com.yagubogu.stadium.repository.StadiumRepository;
 import java.lang.reflect.Field;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -62,6 +67,48 @@ class PlaceSyncServiceTest {
 
         // 예외가 나도 순회 자체는 10번(2 구장 x 5 카테고리) 다 시도된다
         verify(placeStadiumSyncService, times(10))
+                .syncForStadium(any(Stadium.class), any(PlaceCategory.class));
+    }
+
+    @DisplayName("syncAll은 성공/실패한 조합 수를 집계해 반환한다")
+    @Test
+    void syncAll_성공_실패_집계() {
+        Stadium jamsil = stadium(1L, "잠실", 37.5122, 127.0715);
+        given(stadiumRepository.findAll()).willReturn(List.of(jamsil));
+        // 특정 조합만 실패시킨다. 인자를 좁혀 stubbing하면 나머지 호출이 strict stubs에 걸려
+        // PotentialStubbingProblem이 발생하고, 그것까지 실패로 집계되어 검증이 흐려진다.
+        willAnswer(invocation -> {
+            if (invocation.getArgument(1) == PlaceCategory.RESTAURANT) {
+                throw new RuntimeException("sync failed");
+            }
+            return null;
+        }).given(placeStadiumSyncService).syncForStadium(any(Stadium.class), any(PlaceCategory.class));
+
+        Optional<PlaceSyncResult> actual = placeSyncService.syncAll();
+
+        // 1개 구장 x 5개 카테고리 중 RESTAURANT 하나만 실패
+        assertThat(actual).contains(new PlaceSyncResult(4, 1));
+    }
+
+    @DisplayName("이미 동기화가 진행 중이면 중복 실행하지 않고 빈 결과를 반환한다")
+    @Test
+    void syncAll_이미_진행_중이면_중복_실행하지_않음() {
+        Stadium jamsil = stadium(1L, "잠실", 37.5122, 127.0715);
+        given(stadiumRepository.findAll()).willReturn(List.of(jamsil));
+
+        // 동기화가 진행 중인 동안 다시 트리거된 상황(스케줄러와 관리자 수동 트리거가 겹친 경우)
+        List<Optional<PlaceSyncResult>> reentrantResults = new ArrayList<>();
+        willAnswer(invocation -> {
+            reentrantResults.add(placeSyncService.syncAll());
+            return null;
+        }).given(placeStadiumSyncService).syncForStadium(any(Stadium.class), any(PlaceCategory.class));
+
+        Optional<PlaceSyncResult> actual = placeSyncService.syncAll();
+
+        assertThat(actual).contains(new PlaceSyncResult(5, 0));
+        assertThat(reentrantResults).hasSize(5).allMatch(Optional::isEmpty);
+        // 중복 트리거가 무시되므로 위임은 5번(1 구장 x 5 카테고리)만 일어난다
+        verify(placeStadiumSyncService, times(5))
                 .syncForStadium(any(Stadium.class), any(PlaceCategory.class));
     }
 


### PR DESCRIPTION
## 📌 관련 이슈
- close #1133

## ✨ 변경 내용

### 1. 서비스키가 비어 있으면 기동 시점에 실패 (fix)

`TourApiProperties`에 `@Validated` + `@NotBlank`를 적용했습니다.

`places`가 dev/prod 모두 비어 있던 원인은 GitHub Actions 리포지토리 시크릿에 `TOUR_API_SERVICE_KEY`가 등록되지 않은 것이었습니다. Actions는 없는 시크릿을 경고 없이 빈 문자열로 치환하고, 검증이 없으니 앱은 정상 기동하고 헬스체크까지 통과합니다. 실패는 매일 03:00 폴링에서만 드러나서 발견까지 24시간이 걸렸습니다. 이제 같은 상황이면 배포 단계에서 바로 실패합니다.

검증 테스트: `TourApiPropertiesTest`

### 2. 관리자 수동 동기화 API (feat)

`POST /admin/places/sync` (`@RequireRole(Role.ADMIN)`)

- 200 + `{"success": n, "failed": n}` — 구장 x 카테고리 조합 단위 집계
- 409 — 이미 동기화가 진행 중

장소를 채우는 경로가 매일 03:00 스케줄러 하나뿐이라 서비스키를 고쳐도 다음 새벽까지 확인이 불가능했습니다. 스케줄러와 수동 트리거가 같은 진입점을 쓰므로 `AtomicBoolean`으로 동시 실행을 막았습니다 — 전체 동기화는 호출량이 크고 서비스키에 일일 트래픽 한도가 있어 중복 실행이 그대로 한도 소모로 이어집니다.

주의: 동기 처리라 응답까지 수 분 이상 걸릴 수 있습니다. 프록시 타임아웃으로 응답을 못 받아도 서버 측 동기화는 계속 진행되며, 진행 상황은 `[PlaceSync]` 로그로 확인합니다.

### 3. 검색 반경 1km → 3km (feat)

`tour.api.radius: 1000` → `3000`

## 🎸 기타 참고 사항

**배포 필요**: 시크릿은 등록을 완료했지만 환경변수는 `docker run` 시점에 고정되므로, 이 PR이 머지되어 컨테이너가 재생성되어야 반영됩니다. 머지 후 위 수동 API로 즉시 동기화할 수 있습니다.

**반경 확대와 관련해 후속 검토가 필요한 두 가지** (이 PR에서는 건드리지 않았습니다):

1. `numOfRows=50` 상한 — 3km로 넓히면 후보가 크게 늘어나는데, `locationBasedList2` 호출에 `arrange` 파라미터를 지정하지 않아 거리순 정렬이 보장되지 않습니다. 결과적으로 "가장 가까운 50곳"이 아니라 "임의의 50곳"이 저장될 수 있습니다. `arrange=E`(거리순) 추가가 맞아 보이는데, 파라미터가 잘못되면 `INVALID_REQUEST_PARAMETER_ERROR`로 전 조합이 실패하는 변경이라 실제 서비스키로 한 번 확인한 뒤 별도 PR로 넣는 편이 안전하다고 판단했습니다. `PlaceRepository.findAllByStadiumIdAndCategory`에도 정렬이 없어 조회 응답 순서 역시 보장되지 않습니다.
2. 트래픽 사용량 — 최초 동기화는 목록 50회에 더해 신규 장소마다 상세 조회가 2회씩 붙어 수천 회 규모입니다. 개발계정 한도(일 1000회)라면 중간부터 `code=22`로 실패하므로, 운영계정 상향 여부를 확인해야 합니다.

**테스트**: 로컬 Docker 데몬이 꺼져 있어 Testcontainers 기반 13개(E2E, MySQL 통합)는 실행하지 못했습니다. 나머지 226개는 통과했습니다. CI 결과 확인이 필요합니다.