### PR TITLE
feat: 잠금화면 위젯 API 구현

### DIFF
--- a/backend/app/src/main/java/com/yagubogu/member/domain/Member.java
+++ b/backend/app/src/main/java/com/yagubogu/member/domain/Member.java
@@ -58,6 +58,9 @@ public class Member extends BaseEntity {
     @JoinColumn(name = "representative_badge_id", nullable = true)
     private Badge representativeBadge;
 
+    @Column(name = "widget_enabled", nullable = false)
+    private boolean widgetEnabled = true;
+
     public Member(final Team team, final Nickname nickname, final String email, final OAuthProvider provider,
                   final String oauthId, final Role role, final String imageUrl, final Badge representativeBadge) {
         this.team = team;
@@ -92,5 +95,9 @@ public class Member extends BaseEntity {
 
     public void updateBadge(final Badge badge) {
         this.representativeBadge = badge;
+    }
+
+    public void updateWidgetEnabled(final boolean widgetEnabled) {
+        this.widgetEnabled = widgetEnabled;
     }
 }

--- a/backend/app/src/main/java/com/yagubogu/member/domain/Member.java
+++ b/backend/app/src/main/java/com/yagubogu/member/domain/Member.java
@@ -58,9 +58,6 @@ public class Member extends BaseEntity {
     @JoinColumn(name = "representative_badge_id", nullable = true)
     private Badge representativeBadge;
 
-    @Column(name = "widget_enabled", nullable = false)
-    private boolean widgetEnabled = true;
-
     public Member(final Team team, final Nickname nickname, final String email, final OAuthProvider provider,
                   final String oauthId, final Role role, final String imageUrl, final Badge representativeBadge) {
         this.team = team;
@@ -97,7 +94,4 @@ public class Member extends BaseEntity {
         this.representativeBadge = badge;
     }
 
-    public void updateWidgetEnabled(final boolean widgetEnabled) {
-        this.widgetEnabled = widgetEnabled;
-    }
 }

--- a/backend/app/src/main/java/com/yagubogu/member/service/MemberService.java
+++ b/backend/app/src/main/java/com/yagubogu/member/service/MemberService.java
@@ -26,6 +26,8 @@ import com.yagubogu.member.repository.MemberRepository;
 import com.yagubogu.stat.service.StatService;
 import com.yagubogu.team.domain.Team;
 import com.yagubogu.team.repository.TeamRepository;
+import com.yagubogu.widget.repository.WidgetDeviceRepository;
+import com.yagubogu.widget.repository.WidgetLiveActivityRepository;
 import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -45,6 +47,8 @@ public class MemberService {
     private final MemberBadgeRepository memberBadgeRepository;
     private final ApplicationEventPublisher publisher;
     private final StatService statService;
+    private final WidgetDeviceRepository widgetDeviceRepository;
+    private final WidgetLiveActivityRepository widgetLiveActivityRepository;
 
     @Value("${app.s3.default-profile-image-url}")
     private String defaultProfileImageUrl;
@@ -64,6 +68,8 @@ public class MemberService {
     public void removeMember(final Long memberId) {
         Member member = getMember(memberId);
 
+        widgetLiveActivityRepository.deleteAllByDeviceMember(member);
+        widgetDeviceRepository.deleteAllByMember(member);
         member.delete();
     }
 

--- a/backend/app/src/main/java/com/yagubogu/widget/controller/v1/WidgetController.java
+++ b/backend/app/src/main/java/com/yagubogu/widget/controller/v1/WidgetController.java
@@ -1,0 +1,80 @@
+package com.yagubogu.widget.controller.v1;
+
+import com.yagubogu.auth.annotation.RequireRole;
+import com.yagubogu.auth.dto.MemberClaims;
+import com.yagubogu.widget.dto.v1.WidgetDeviceRegisterRequest;
+import com.yagubogu.widget.dto.v1.WidgetLiveActivityRegisterRequest;
+import com.yagubogu.widget.dto.v1.WidgetSettingsRequest;
+import com.yagubogu.widget.dto.v1.WidgetSettingsResponse;
+import com.yagubogu.widget.service.WidgetService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RequireRole
+@RestController
+public class WidgetController implements WidgetControllerInterface {
+
+    private final WidgetService widgetService;
+
+    @Override
+    public ResponseEntity<Void> registerDevice(
+            final MemberClaims memberClaims,
+            @Valid @RequestBody final WidgetDeviceRegisterRequest request
+    ) {
+        widgetService.registerDevice(memberClaims.id(), request);
+
+        return ResponseEntity.noContent().build();
+    }
+
+    @Override
+    public ResponseEntity<Void> registerLiveActivity(
+            final MemberClaims memberClaims,
+            @Valid @RequestBody final WidgetLiveActivityRegisterRequest request
+    ) {
+        widgetService.registerLiveActivity(memberClaims.id(), request);
+
+        return ResponseEntity.noContent().build();
+    }
+
+    @Override
+    public ResponseEntity<Void> removeLiveActivity(
+            final MemberClaims memberClaims,
+            @PathVariable final String activityId
+    ) {
+        widgetService.removeLiveActivity(memberClaims.id(), activityId);
+
+        return ResponseEntity.noContent().build();
+    }
+
+    @Override
+    public ResponseEntity<Void> removeDevice(
+            final MemberClaims memberClaims,
+            @PathVariable final String deviceId
+    ) {
+        widgetService.removeDevice(memberClaims.id(), deviceId);
+
+        return ResponseEntity.noContent().build();
+    }
+
+    @Override
+    public ResponseEntity<WidgetSettingsResponse> findSettings(final MemberClaims memberClaims) {
+        WidgetSettingsResponse response = widgetService.findSettings(memberClaims.id());
+
+        return ResponseEntity.ok(response);
+    }
+
+    @Override
+    public ResponseEntity<WidgetSettingsResponse> updateSettings(
+            final MemberClaims memberClaims,
+            @Valid @RequestBody final WidgetSettingsRequest request
+    ) {
+        WidgetSettingsResponse response = widgetService.updateSettings(memberClaims.id(), request);
+
+        return ResponseEntity.ok(response);
+    }
+}

--- a/backend/app/src/main/java/com/yagubogu/widget/controller/v1/WidgetController.java
+++ b/backend/app/src/main/java/com/yagubogu/widget/controller/v1/WidgetController.java
@@ -62,8 +62,11 @@ public class WidgetController implements WidgetControllerInterface {
     }
 
     @Override
-    public ResponseEntity<WidgetSettingsResponse> findSettings(final MemberClaims memberClaims) {
-        WidgetSettingsResponse response = widgetService.findSettings(memberClaims.id());
+    public ResponseEntity<WidgetSettingsResponse> findSettings(
+            final MemberClaims memberClaims,
+            @PathVariable final String deviceId
+    ) {
+        WidgetSettingsResponse response = widgetService.findSettings(memberClaims.id(), deviceId);
 
         return ResponseEntity.ok(response);
     }
@@ -71,9 +74,10 @@ public class WidgetController implements WidgetControllerInterface {
     @Override
     public ResponseEntity<WidgetSettingsResponse> updateSettings(
             final MemberClaims memberClaims,
+            @PathVariable final String deviceId,
             @Valid @RequestBody final WidgetSettingsRequest request
     ) {
-        WidgetSettingsResponse response = widgetService.updateSettings(memberClaims.id(), request);
+        WidgetSettingsResponse response = widgetService.updateSettings(memberClaims.id(), deviceId, request);
 
         return ResponseEntity.ok(response);
     }

--- a/backend/app/src/main/java/com/yagubogu/widget/controller/v1/WidgetControllerInterface.java
+++ b/backend/app/src/main/java/com/yagubogu/widget/controller/v1/WidgetControllerInterface.java
@@ -72,16 +72,28 @@ public interface WidgetControllerInterface {
             @PathVariable String deviceId
     );
 
-    @Operation(summary = "위젯 사용 설정 조회")
-    @GetMapping("/settings")
+    @Operation(summary = "디바이스별 위젯 사용 설정 조회")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "설정 조회 성공"),
+            @ApiResponse(responseCode = "400", description = "deviceId 형식 오류"),
+            @ApiResponse(responseCode = "404", description = "디바이스를 찾을 수 없음")
+    })
+    @GetMapping("/devices/{deviceId}/settings")
     ResponseEntity<WidgetSettingsResponse> findSettings(
-            @Parameter(hidden = true) MemberClaims memberClaims
+            @Parameter(hidden = true) MemberClaims memberClaims,
+            @PathVariable String deviceId
     );
 
-    @Operation(summary = "위젯 사용 설정 변경")
-    @PatchMapping("/settings")
+    @Operation(summary = "디바이스별 위젯 사용 설정 변경")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "설정 변경 성공"),
+            @ApiResponse(responseCode = "400", description = "요청값 또는 deviceId 형식 오류"),
+            @ApiResponse(responseCode = "404", description = "디바이스를 찾을 수 없음")
+    })
+    @PatchMapping("/devices/{deviceId}/settings")
     ResponseEntity<WidgetSettingsResponse> updateSettings(
             @Parameter(hidden = true) MemberClaims memberClaims,
+            @PathVariable String deviceId,
             @Valid @RequestBody WidgetSettingsRequest request
     );
 }

--- a/backend/app/src/main/java/com/yagubogu/widget/controller/v1/WidgetControllerInterface.java
+++ b/backend/app/src/main/java/com/yagubogu/widget/controller/v1/WidgetControllerInterface.java
@@ -1,0 +1,87 @@
+package com.yagubogu.widget.controller.v1;
+
+import com.yagubogu.auth.dto.MemberClaims;
+import com.yagubogu.widget.dto.v1.WidgetDeviceRegisterRequest;
+import com.yagubogu.widget.dto.v1.WidgetLiveActivityRegisterRequest;
+import com.yagubogu.widget.dto.v1.WidgetSettingsRequest;
+import com.yagubogu.widget.dto.v1.WidgetSettingsResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Tag(name = "Widget", description = "잠금화면 실시간 스코어 위젯 API")
+@RequestMapping("/widgets")
+public interface WidgetControllerInterface {
+
+    @Operation(summary = "디바이스 푸시 토큰 등록 또는 갱신")
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "등록 또는 갱신 성공"),
+            @ApiResponse(responseCode = "400", description = "요청값 오류"),
+            @ApiResponse(responseCode = "401", description = "인증 실패")
+    })
+    @PostMapping("/devices")
+    ResponseEntity<Void> registerDevice(
+            @Parameter(hidden = true) MemberClaims memberClaims,
+            @Valid @RequestBody WidgetDeviceRegisterRequest request
+    );
+
+    @Operation(summary = "iOS Live Activity 갱신 토큰 등록 또는 갱신")
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "등록 또는 갱신 성공"),
+            @ApiResponse(responseCode = "400", description = "요청값 또는 플랫폼 오류"),
+            @ApiResponse(responseCode = "404", description = "디바이스 또는 경기를 찾을 수 없음"),
+            @ApiResponse(responseCode = "409", description = "이미 사용 중인 activityId")
+    })
+    @PostMapping("/live-activities")
+    ResponseEntity<Void> registerLiveActivity(
+            @Parameter(hidden = true) MemberClaims memberClaims,
+            @Valid @RequestBody WidgetLiveActivityRegisterRequest request
+    );
+
+    @Operation(summary = "iOS Live Activity 갱신 토큰 해제")
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "해제 성공"),
+            @ApiResponse(responseCode = "404", description = "활동을 찾을 수 없음")
+    })
+    @DeleteMapping("/live-activities/{activityId}")
+    ResponseEntity<Void> removeLiveActivity(
+            @Parameter(hidden = true) MemberClaims memberClaims,
+            @PathVariable String activityId
+    );
+
+    @Operation(summary = "디바이스 푸시 토큰 해제")
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "해제 성공"),
+            @ApiResponse(responseCode = "400", description = "deviceId 형식 오류"),
+            @ApiResponse(responseCode = "404", description = "디바이스를 찾을 수 없음")
+    })
+    @DeleteMapping("/devices/{deviceId}")
+    ResponseEntity<Void> removeDevice(
+            @Parameter(hidden = true) MemberClaims memberClaims,
+            @PathVariable String deviceId
+    );
+
+    @Operation(summary = "위젯 사용 설정 조회")
+    @GetMapping("/settings")
+    ResponseEntity<WidgetSettingsResponse> findSettings(
+            @Parameter(hidden = true) MemberClaims memberClaims
+    );
+
+    @Operation(summary = "위젯 사용 설정 변경")
+    @PatchMapping("/settings")
+    ResponseEntity<WidgetSettingsResponse> updateSettings(
+            @Parameter(hidden = true) MemberClaims memberClaims,
+            @Valid @RequestBody WidgetSettingsRequest request
+    );
+}

--- a/backend/app/src/main/java/com/yagubogu/widget/domain/WidgetDevice.java
+++ b/backend/app/src/main/java/com/yagubogu/widget/domain/WidgetDevice.java
@@ -45,6 +45,9 @@ public class WidgetDevice {
     @Column(name = "app_version", length = 50)
     private String appVersion;
 
+    @Column(name = "enabled", nullable = false)
+    private boolean enabled = true;
+
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
@@ -86,5 +89,10 @@ public class WidgetDevice {
 
     public boolean isIos() {
         return platform == WidgetPlatform.IOS;
+    }
+
+    public void updateEnabled(final boolean enabled) {
+        this.enabled = enabled;
+        this.updatedAt = LocalDateTime.now();
     }
 }

--- a/backend/app/src/main/java/com/yagubogu/widget/domain/WidgetDevice.java
+++ b/backend/app/src/main/java/com/yagubogu/widget/domain/WidgetDevice.java
@@ -1,0 +1,90 @@
+package com.yagubogu.widget.domain;
+
+import com.yagubogu.member.domain.Member;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Table(name = "widget_devices")
+@Entity
+public class WidgetDevice {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "widget_device_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "platform", nullable = false, length = 20)
+    private WidgetPlatform platform;
+
+    @Column(name = "device_id", nullable = false, unique = true, length = 36)
+    private String deviceId;
+
+    @Column(name = "push_token", nullable = false, length = 4096)
+    private String pushToken;
+
+    @Column(name = "app_version", length = 50)
+    private String appVersion;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    public WidgetDevice(
+            final Member member,
+            final WidgetPlatform platform,
+            final String deviceId,
+            final String pushToken,
+            final String appVersion
+    ) {
+        this.member = member;
+        this.platform = platform;
+        this.deviceId = deviceId;
+        this.pushToken = pushToken;
+        this.appVersion = appVersion;
+        this.createdAt = LocalDateTime.now();
+        this.updatedAt = this.createdAt;
+    }
+
+    public void updateRegistration(
+            final Member member,
+            final WidgetPlatform platform,
+            final String pushToken,
+            final String appVersion
+    ) {
+        this.member = member;
+        this.platform = platform;
+        this.pushToken = pushToken;
+        this.appVersion = appVersion;
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    public boolean belongsTo(final long memberId) {
+        return member.isSameId(memberId);
+    }
+
+    public boolean isIos() {
+        return platform == WidgetPlatform.IOS;
+    }
+}

--- a/backend/app/src/main/java/com/yagubogu/widget/domain/WidgetLiveActivity.java
+++ b/backend/app/src/main/java/com/yagubogu/widget/domain/WidgetLiveActivity.java
@@ -1,0 +1,71 @@
+package com.yagubogu.widget.domain;
+
+import com.yagubogu.game.domain.Game;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Table(name = "widget_live_activities")
+@Entity
+public class WidgetLiveActivity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "widget_live_activity_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "widget_device_id", nullable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    private WidgetDevice device;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "game_id", nullable = false)
+    private Game game;
+
+    @Column(name = "activity_id", nullable = false, unique = true, length = 255)
+    private String activityId;
+
+    @Column(name = "update_token", nullable = false, length = 4096)
+    private String updateToken;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    public WidgetLiveActivity(
+            final WidgetDevice device,
+            final Game game,
+            final String activityId,
+            final String updateToken
+    ) {
+        this.device = device;
+        this.game = game;
+        this.activityId = activityId;
+        this.updateToken = updateToken;
+        this.createdAt = LocalDateTime.now();
+        this.updatedAt = this.createdAt;
+    }
+
+    public void update(final String activityId, final String updateToken) {
+        this.activityId = activityId;
+        this.updateToken = updateToken;
+        this.updatedAt = LocalDateTime.now();
+    }
+}

--- a/backend/app/src/main/java/com/yagubogu/widget/domain/WidgetPlatform.java
+++ b/backend/app/src/main/java/com/yagubogu/widget/domain/WidgetPlatform.java
@@ -1,0 +1,6 @@
+package com.yagubogu.widget.domain;
+
+public enum WidgetPlatform {
+    IOS,
+    ANDROID
+}

--- a/backend/app/src/main/java/com/yagubogu/widget/dto/v1/WidgetDeviceRegisterRequest.java
+++ b/backend/app/src/main/java/com/yagubogu/widget/dto/v1/WidgetDeviceRegisterRequest.java
@@ -1,0 +1,23 @@
+package com.yagubogu.widget.dto.v1;
+
+import com.yagubogu.widget.domain.WidgetPlatform;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+public record WidgetDeviceRegisterRequest(
+        @NotNull WidgetPlatform platform,
+        @NotBlank
+        @Pattern(
+                regexp = "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$",
+                message = "deviceId must be a valid UUID"
+        )
+        String deviceId,
+        @NotBlank
+        @Size(max = 4096)
+        String pushToken,
+        @Size(max = 50)
+        String appVersion
+) {
+}

--- a/backend/app/src/main/java/com/yagubogu/widget/dto/v1/WidgetLiveActivityRegisterRequest.java
+++ b/backend/app/src/main/java/com/yagubogu/widget/dto/v1/WidgetLiveActivityRegisterRequest.java
@@ -1,0 +1,20 @@
+package com.yagubogu.widget.dto.v1;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.Size;
+
+public record WidgetLiveActivityRegisterRequest(
+        @NotBlank
+        @Pattern(
+                regexp = "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$",
+                message = "deviceId must be a valid UUID"
+        )
+        String deviceId,
+        @NotNull @Positive Long gameId,
+        @NotBlank @Size(max = 255) String activityId,
+        @NotBlank @Size(max = 4096) String updateToken
+) {
+}

--- a/backend/app/src/main/java/com/yagubogu/widget/dto/v1/WidgetSettingsRequest.java
+++ b/backend/app/src/main/java/com/yagubogu/widget/dto/v1/WidgetSettingsRequest.java
@@ -1,0 +1,8 @@
+package com.yagubogu.widget.dto.v1;
+
+import jakarta.validation.constraints.NotNull;
+
+public record WidgetSettingsRequest(
+        @NotNull Boolean enabled
+) {
+}

--- a/backend/app/src/main/java/com/yagubogu/widget/dto/v1/WidgetSettingsResponse.java
+++ b/backend/app/src/main/java/com/yagubogu/widget/dto/v1/WidgetSettingsResponse.java
@@ -1,0 +1,6 @@
+package com.yagubogu.widget.dto.v1;
+
+public record WidgetSettingsResponse(
+        boolean enabled
+) {
+}

--- a/backend/app/src/main/java/com/yagubogu/widget/repository/WidgetDeviceRepository.java
+++ b/backend/app/src/main/java/com/yagubogu/widget/repository/WidgetDeviceRepository.java
@@ -1,0 +1,17 @@
+package com.yagubogu.widget.repository;
+
+import com.yagubogu.member.domain.Member;
+import com.yagubogu.widget.domain.WidgetDevice;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface WidgetDeviceRepository extends JpaRepository<WidgetDevice, Long> {
+
+    Optional<WidgetDevice> findByDeviceId(String deviceId);
+
+    Optional<WidgetDevice> findByDeviceIdAndMemberId(String deviceId, Long memberId);
+
+    void deleteAllByMember(Member member);
+}

--- a/backend/app/src/main/java/com/yagubogu/widget/repository/WidgetLiveActivityRepository.java
+++ b/backend/app/src/main/java/com/yagubogu/widget/repository/WidgetLiveActivityRepository.java
@@ -1,0 +1,23 @@
+package com.yagubogu.widget.repository;
+
+import com.yagubogu.game.domain.Game;
+import com.yagubogu.member.domain.Member;
+import com.yagubogu.widget.domain.WidgetDevice;
+import com.yagubogu.widget.domain.WidgetLiveActivity;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface WidgetLiveActivityRepository extends JpaRepository<WidgetLiveActivity, Long> {
+
+    Optional<WidgetLiveActivity> findByDeviceAndGame(WidgetDevice device, Game game);
+
+    Optional<WidgetLiveActivity> findByActivityId(String activityId);
+
+    Optional<WidgetLiveActivity> findByActivityIdAndDeviceMemberId(String activityId, Long memberId);
+
+    void deleteAllByDevice(WidgetDevice device);
+
+    void deleteAllByDeviceMember(Member member);
+}

--- a/backend/app/src/main/java/com/yagubogu/widget/service/WidgetService.java
+++ b/backend/app/src/main/java/com/yagubogu/widget/service/WidgetService.java
@@ -65,9 +65,7 @@ public class WidgetService {
 
     @Transactional
     public void registerLiveActivity(final long memberId, final WidgetLiveActivityRegisterRequest request) {
-        String deviceId = normalizeDeviceId(request.deviceId());
-        WidgetDevice device = widgetDeviceRepository.findByDeviceIdAndMemberId(deviceId, memberId)
-                .orElseThrow(() -> new NotFoundException("Widget device is not found"));
+        WidgetDevice device = getOwnedDevice(memberId, request.deviceId());
         if (!device.isIos()) {
             throw new BadRequestException("Live Activity is available only on IOS devices");
         }
@@ -109,26 +107,35 @@ public class WidgetService {
 
     @Transactional
     public void removeDevice(final long memberId, final String rawDeviceId) {
-        String deviceId = normalizeDeviceId(rawDeviceId);
-        WidgetDevice device = widgetDeviceRepository.findByDeviceIdAndMemberId(deviceId, memberId)
-                .orElseThrow(() -> new NotFoundException("Widget device is not found"));
+        WidgetDevice device = getOwnedDevice(memberId, rawDeviceId);
 
         widgetLiveActivityRepository.deleteAllByDevice(device);
         widgetDeviceRepository.delete(device);
     }
 
-    public WidgetSettingsResponse findSettings(final long memberId) {
-        Member member = getMember(memberId);
+    public WidgetSettingsResponse findSettings(final long memberId, final String deviceId) {
+        WidgetDevice device = getOwnedDevice(memberId, deviceId);
 
-        return new WidgetSettingsResponse(member.isWidgetEnabled());
+        return new WidgetSettingsResponse(device.isEnabled());
     }
 
     @Transactional
-    public WidgetSettingsResponse updateSettings(final long memberId, final WidgetSettingsRequest request) {
-        Member member = getMember(memberId);
-        member.updateWidgetEnabled(request.enabled());
+    public WidgetSettingsResponse updateSettings(
+            final long memberId,
+            final String deviceId,
+            final WidgetSettingsRequest request
+    ) {
+        WidgetDevice device = getOwnedDevice(memberId, deviceId);
+        device.updateEnabled(request.enabled());
 
-        return new WidgetSettingsResponse(member.isWidgetEnabled());
+        return new WidgetSettingsResponse(device.isEnabled());
+    }
+
+    private WidgetDevice getOwnedDevice(final long memberId, final String rawDeviceId) {
+        String deviceId = normalizeDeviceId(rawDeviceId);
+
+        return widgetDeviceRepository.findByDeviceIdAndMemberId(deviceId, memberId)
+                .orElseThrow(() -> new NotFoundException("Widget device is not found"));
     }
 
     private Member getMember(final long memberId) {

--- a/backend/app/src/main/java/com/yagubogu/widget/service/WidgetService.java
+++ b/backend/app/src/main/java/com/yagubogu/widget/service/WidgetService.java
@@ -1,0 +1,146 @@
+package com.yagubogu.widget.service;
+
+import com.yagubogu.game.domain.Game;
+import com.yagubogu.game.repository.GameRepository;
+import com.yagubogu.global.exception.BadRequestException;
+import com.yagubogu.global.exception.ConflictException;
+import com.yagubogu.global.exception.NotFoundException;
+import com.yagubogu.member.domain.Member;
+import com.yagubogu.member.repository.MemberRepository;
+import com.yagubogu.widget.domain.WidgetDevice;
+import com.yagubogu.widget.domain.WidgetLiveActivity;
+import com.yagubogu.widget.domain.WidgetPlatform;
+import com.yagubogu.widget.dto.v1.WidgetDeviceRegisterRequest;
+import com.yagubogu.widget.dto.v1.WidgetLiveActivityRegisterRequest;
+import com.yagubogu.widget.dto.v1.WidgetSettingsRequest;
+import com.yagubogu.widget.dto.v1.WidgetSettingsResponse;
+import com.yagubogu.widget.repository.WidgetDeviceRepository;
+import com.yagubogu.widget.repository.WidgetLiveActivityRepository;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Service
+public class WidgetService {
+
+    private final MemberRepository memberRepository;
+    private final GameRepository gameRepository;
+    private final WidgetDeviceRepository widgetDeviceRepository;
+    private final WidgetLiveActivityRepository widgetLiveActivityRepository;
+
+    @Transactional
+    public void registerDevice(final long memberId, final WidgetDeviceRegisterRequest request) {
+        Member member = getMember(memberId);
+        String deviceId = normalizeDeviceId(request.deviceId());
+
+        widgetDeviceRepository.findByDeviceId(deviceId)
+                .ifPresentOrElse(
+                        device -> updateDevice(device, member, request),
+                        () -> widgetDeviceRepository.save(new WidgetDevice(
+                                member,
+                                request.platform(),
+                                deviceId,
+                                request.pushToken(),
+                                request.appVersion()
+                        ))
+                );
+    }
+
+    private void updateDevice(
+            final WidgetDevice device,
+            final Member member,
+            final WidgetDeviceRegisterRequest request
+    ) {
+        boolean ownerChanged = !device.belongsTo(member.getId());
+        boolean changedToAndroid = device.isIos() && request.platform() == WidgetPlatform.ANDROID;
+
+        if (ownerChanged || changedToAndroid) {
+            widgetLiveActivityRepository.deleteAllByDevice(device);
+        }
+        device.updateRegistration(member, request.platform(), request.pushToken(), request.appVersion());
+    }
+
+    @Transactional
+    public void registerLiveActivity(final long memberId, final WidgetLiveActivityRegisterRequest request) {
+        String deviceId = normalizeDeviceId(request.deviceId());
+        WidgetDevice device = widgetDeviceRepository.findByDeviceIdAndMemberId(deviceId, memberId)
+                .orElseThrow(() -> new NotFoundException("Widget device is not found"));
+        if (!device.isIos()) {
+            throw new BadRequestException("Live Activity is available only on IOS devices");
+        }
+
+        Game game = gameRepository.findById(request.gameId())
+                .orElseThrow(() -> new NotFoundException("Game is not found"));
+        WidgetLiveActivity activity = widgetLiveActivityRepository.findByDeviceAndGame(device, game)
+                .orElse(null);
+
+        validateActivityIdOwner(request.activityId(), activity);
+        if (activity == null) {
+            widgetLiveActivityRepository.save(new WidgetLiveActivity(
+                    device,
+                    game,
+                    request.activityId(),
+                    request.updateToken()
+            ));
+            return;
+        }
+        activity.update(request.activityId(), request.updateToken());
+    }
+
+    private void validateActivityIdOwner(final String activityId, final WidgetLiveActivity targetActivity) {
+        widgetLiveActivityRepository.findByActivityId(activityId)
+                .filter(existing -> targetActivity == null || !existing.getId().equals(targetActivity.getId()))
+                .ifPresent(existing -> {
+                    throw new ConflictException("Activity ID already exists");
+                });
+    }
+
+    @Transactional
+    public void removeLiveActivity(final long memberId, final String activityId) {
+        WidgetLiveActivity activity = widgetLiveActivityRepository
+                .findByActivityIdAndDeviceMemberId(activityId, memberId)
+                .orElseThrow(() -> new NotFoundException("Live Activity is not found"));
+
+        widgetLiveActivityRepository.delete(activity);
+    }
+
+    @Transactional
+    public void removeDevice(final long memberId, final String rawDeviceId) {
+        String deviceId = normalizeDeviceId(rawDeviceId);
+        WidgetDevice device = widgetDeviceRepository.findByDeviceIdAndMemberId(deviceId, memberId)
+                .orElseThrow(() -> new NotFoundException("Widget device is not found"));
+
+        widgetLiveActivityRepository.deleteAllByDevice(device);
+        widgetDeviceRepository.delete(device);
+    }
+
+    public WidgetSettingsResponse findSettings(final long memberId) {
+        Member member = getMember(memberId);
+
+        return new WidgetSettingsResponse(member.isWidgetEnabled());
+    }
+
+    @Transactional
+    public WidgetSettingsResponse updateSettings(final long memberId, final WidgetSettingsRequest request) {
+        Member member = getMember(memberId);
+        member.updateWidgetEnabled(request.enabled());
+
+        return new WidgetSettingsResponse(member.isWidgetEnabled());
+    }
+
+    private Member getMember(final long memberId) {
+        return memberRepository.findById(memberId)
+                .orElseThrow(() -> new NotFoundException("Member is not found"));
+    }
+
+    private String normalizeDeviceId(final String deviceId) {
+        try {
+            return UUID.fromString(deviceId).toString();
+        } catch (IllegalArgumentException exception) {
+            throw new BadRequestException("deviceId must be a valid UUID");
+        }
+    }
+}

--- a/backend/app/src/main/resources/db/migration/mysql/V21__create_widget_resources.sql
+++ b/backend/app/src/main/resources/db/migration/mysql/V21__create_widget_resources.sql
@@ -1,0 +1,36 @@
+ALTER TABLE members
+    ADD COLUMN widget_enabled BOOLEAN NOT NULL DEFAULT TRUE;
+
+CREATE TABLE widget_devices
+(
+    widget_device_id BIGINT        NOT NULL AUTO_INCREMENT,
+    member_id        BIGINT        NOT NULL,
+    platform         VARCHAR(20)   NOT NULL,
+    device_id        VARCHAR(36)   NOT NULL,
+    push_token       VARCHAR(4096) NOT NULL,
+    app_version      VARCHAR(50)   NULL,
+    created_at       DATETIME(6)   NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    updated_at       DATETIME(6)   NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+    PRIMARY KEY (widget_device_id),
+    UNIQUE KEY uq_widget_devices_device_id (device_id),
+    INDEX idx_widget_devices_member_platform (member_id, platform),
+    CONSTRAINT fk_widget_devices_member FOREIGN KEY (member_id) REFERENCES members (member_id)
+) ENGINE = InnoDB;
+
+CREATE TABLE widget_live_activities
+(
+    widget_live_activity_id BIGINT        NOT NULL AUTO_INCREMENT,
+    widget_device_id        BIGINT        NOT NULL,
+    game_id                 BIGINT        NOT NULL,
+    activity_id             VARCHAR(255)  NOT NULL,
+    update_token            VARCHAR(4096) NOT NULL,
+    created_at              DATETIME(6)   NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    updated_at              DATETIME(6)   NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+    PRIMARY KEY (widget_live_activity_id),
+    UNIQUE KEY uq_widget_live_activities_activity_id (activity_id),
+    UNIQUE KEY uq_widget_live_activities_device_game (widget_device_id, game_id),
+    INDEX idx_widget_live_activities_game (game_id),
+    CONSTRAINT fk_widget_live_activities_device FOREIGN KEY (widget_device_id)
+        REFERENCES widget_devices (widget_device_id) ON DELETE CASCADE,
+    CONSTRAINT fk_widget_live_activities_game FOREIGN KEY (game_id) REFERENCES games (game_id)
+) ENGINE = InnoDB;

--- a/backend/app/src/main/resources/db/migration/mysql/V21__create_widget_resources.sql
+++ b/backend/app/src/main/resources/db/migration/mysql/V21__create_widget_resources.sql
@@ -1,6 +1,3 @@
-ALTER TABLE members
-    ADD COLUMN widget_enabled BOOLEAN NOT NULL DEFAULT TRUE;
-
 CREATE TABLE widget_devices
 (
     widget_device_id BIGINT        NOT NULL AUTO_INCREMENT,
@@ -9,6 +6,7 @@ CREATE TABLE widget_devices
     device_id        VARCHAR(36)   NOT NULL,
     push_token       VARCHAR(4096) NOT NULL,
     app_version      VARCHAR(50)   NULL,
+    enabled          BOOLEAN       NOT NULL DEFAULT TRUE,
     created_at       DATETIME(6)   NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
     updated_at       DATETIME(6)   NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
     PRIMARY KEY (widget_device_id),

--- a/backend/app/src/test/java/com/yagubogu/member/service/MemberServiceTest.java
+++ b/backend/app/src/test/java/com/yagubogu/member/service/MemberServiceTest.java
@@ -39,6 +39,11 @@ import com.yagubogu.support.member.MemberBuilder;
 import com.yagubogu.support.member.MemberFactory;
 import com.yagubogu.team.domain.Team;
 import com.yagubogu.team.repository.TeamRepository;
+import com.yagubogu.widget.repository.WidgetDeviceRepository;
+import com.yagubogu.widget.domain.WidgetDevice;
+import com.yagubogu.widget.domain.WidgetLiveActivity;
+import com.yagubogu.widget.domain.WidgetPlatform;
+import com.yagubogu.widget.repository.WidgetLiveActivityRepository;
 import jakarta.persistence.EntityManager;
 import java.time.Clock;
 import java.time.LocalDate;
@@ -118,10 +123,16 @@ public class MemberServiceTest {
     @Autowired
     private LocationCheckInRankingRepository locationCheckInRankingRepository;
 
+    @Autowired
+    private WidgetDeviceRepository widgetDeviceRepository;
+
+    @Autowired
+    private WidgetLiveActivityRepository widgetLiveActivityRepository;
+
     @BeforeEach
     void setUp() {
         memberService = new MemberService(memberRepository, teamRepository, badgeRepository, memberBadgeRepository,
-                publisher, statService);
+                publisher, statService, widgetDeviceRepository, widgetLiveActivityRepository);
     }
 
     @DisplayName("멤버가 응원하는 팀을 조회한다")
@@ -233,6 +244,26 @@ public class MemberServiceTest {
         // given
         Member member = memberFactory.save(MemberBuilder::build);
         Long memberId = member.getId();
+        WidgetDevice widgetDevice = widgetDeviceRepository.save(new WidgetDevice(
+                member,
+                WidgetPlatform.IOS,
+                java.util.UUID.randomUUID().toString(),
+                "push-token",
+                "3.1.0"
+        ));
+        Team homeTeam = teamRepository.findByTeamCode("HT").orElseThrow();
+        Team awayTeam = teamRepository.findByTeamCode("LG").orElseThrow();
+        Stadium stadium = stadiumRepository.findAll().getFirst();
+        Game game = gameFactory.save(builder -> builder
+                .homeTeam(homeTeam)
+                .awayTeam(awayTeam)
+                .stadium(stadium));
+        widgetLiveActivityRepository.save(new WidgetLiveActivity(
+                widgetDevice,
+                game,
+                "activity-id",
+                "update-token"
+        ));
 
         // when
         memberService.removeMember(memberId);
@@ -241,6 +272,8 @@ public class MemberServiceTest {
         SoftAssertions.assertSoftly(softAssertions -> {
             softAssertions.assertThat(member.isDeleted()).isTrue();
             softAssertions.assertThat(member.getDeletedAt()).isNotNull();
+            softAssertions.assertThat(widgetDeviceRepository.count()).isZero();
+            softAssertions.assertThat(widgetLiveActivityRepository.count()).isZero();
         });
     }
 
@@ -577,7 +610,8 @@ public class MemberServiceTest {
                 Clock.system(ZoneId.of("Asia/Seoul"))
         );
         MemberService realMemberService = new MemberService(memberRepository, teamRepository, badgeRepository,
-                memberBadgeRepository, publisher, realStatService);
+                memberBadgeRepository, publisher, realStatService, widgetDeviceRepository,
+                widgetLiveActivityRepository);
 
         // when — findMemberProfile 내부에서 LocalDate.now().getYear() = 2026 사용
         MemberProfileResponse actual = realMemberService.findMemberProfile(member.getId());

--- a/backend/app/src/test/java/com/yagubogu/support/base/E2eTestBase.java
+++ b/backend/app/src/test/java/com/yagubogu/support/base/E2eTestBase.java
@@ -57,6 +57,8 @@ public abstract class E2eTestBase {
             em.createNativeQuery("SET FOREIGN_KEY_CHECKS = 0").executeUpdate();
 
             // Keep lookup tables (teams, stadiums) seeded by Flyway
+            em.createNativeQuery("TRUNCATE TABLE widget_live_activities").executeUpdate();
+            em.createNativeQuery("TRUNCATE TABLE widget_devices").executeUpdate();
             em.createNativeQuery("TRUNCATE TABLE members").executeUpdate();
             em.createNativeQuery("TRUNCATE TABLE games").executeUpdate();
             em.createNativeQuery("TRUNCATE TABLE refresh_tokens").executeUpdate();

--- a/backend/app/src/test/java/com/yagubogu/widget/WidgetE2eTest.java
+++ b/backend/app/src/test/java/com/yagubogu/widget/WidgetE2eTest.java
@@ -1,0 +1,259 @@
+package com.yagubogu.widget;
+
+import com.yagubogu.auth.config.AuthTestConfig;
+import com.yagubogu.game.domain.Game;
+import com.yagubogu.global.config.JpaAuditingConfig;
+import com.yagubogu.member.domain.Member;
+import com.yagubogu.member.domain.Role;
+import com.yagubogu.stadium.domain.Stadium;
+import com.yagubogu.stadium.repository.StadiumRepository;
+import com.yagubogu.support.auth.AuthFactory;
+import com.yagubogu.support.base.E2eTestBase;
+import com.yagubogu.support.game.GameFactory;
+import com.yagubogu.support.member.MemberBuilder;
+import com.yagubogu.support.member.MemberFactory;
+import com.yagubogu.team.domain.Team;
+import com.yagubogu.team.repository.TeamRepository;
+import com.yagubogu.widget.domain.WidgetDevice;
+import com.yagubogu.widget.domain.WidgetPlatform;
+import com.yagubogu.widget.dto.v1.WidgetDeviceRegisterRequest;
+import com.yagubogu.widget.dto.v1.WidgetLiveActivityRegisterRequest;
+import com.yagubogu.widget.dto.v1.WidgetSettingsRequest;
+import com.yagubogu.widget.dto.v1.WidgetSettingsResponse;
+import com.yagubogu.widget.repository.WidgetDeviceRepository;
+import com.yagubogu.widget.repository.WidgetLiveActivityRepository;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpHeaders;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Import({AuthTestConfig.class, JpaAuditingConfig.class})
+class WidgetE2eTest extends E2eTestBase {
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private MemberFactory memberFactory;
+
+    @Autowired
+    private AuthFactory authFactory;
+
+    @Autowired
+    private GameFactory gameFactory;
+
+    @Autowired
+    private TeamRepository teamRepository;
+
+    @Autowired
+    private StadiumRepository stadiumRepository;
+
+    @Autowired
+    private WidgetDeviceRepository widgetDeviceRepository;
+
+    @Autowired
+    private WidgetLiveActivityRepository widgetLiveActivityRepository;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+    }
+
+    @DisplayName("디바이스 푸시 토큰을 등록하고 갱신한다")
+    @Test
+    void registerDevice() {
+        Member member = memberFactory.save(MemberBuilder::build);
+        String accessToken = accessToken(member);
+        String deviceId = UUID.randomUUID().toString();
+
+        registerDevice(accessToken, deviceId, "old-token", WidgetPlatform.IOS);
+        registerDevice(accessToken, deviceId, "new-token", WidgetPlatform.IOS);
+
+        assertThat(widgetDeviceRepository.count()).isEqualTo(1);
+        assertThat(widgetDeviceRepository.findByDeviceId(deviceId).orElseThrow().getPushToken())
+                .isEqualTo("new-token");
+    }
+
+    @DisplayName("iOS Live Activity를 등록하고 해제한다")
+    @Test
+    void registerAndRemoveLiveActivity() {
+        Member member = memberFactory.save(MemberBuilder::build);
+        String accessToken = accessToken(member);
+        String deviceId = UUID.randomUUID().toString();
+        String activityId = UUID.randomUUID().toString();
+        Game game = saveGame();
+        registerDevice(accessToken, deviceId, "start-token", WidgetPlatform.IOS);
+
+        RestAssured.given().log().all()
+                .contentType(ContentType.JSON)
+                .header(HttpHeaders.AUTHORIZATION, accessToken)
+                .body(new WidgetLiveActivityRegisterRequest(
+                        deviceId,
+                        game.getId(),
+                        activityId,
+                        "update-token"
+                ))
+                .when().post("/api/v1/widgets/live-activities")
+                .then().log().all()
+                .statusCode(204);
+
+        assertThat(widgetLiveActivityRepository.findByActivityId(activityId)).isPresent();
+
+        RestAssured.given().log().all()
+                .header(HttpHeaders.AUTHORIZATION, accessToken)
+                .pathParam("activityId", activityId)
+                .when().delete("/api/v1/widgets/live-activities/{activityId}")
+                .then().log().all()
+                .statusCode(204);
+
+        assertThat(widgetLiveActivityRepository.findByActivityId(activityId)).isEmpty();
+    }
+
+    @DisplayName("디바이스를 해제하면 연결된 Live Activity도 제거한다")
+    @Test
+    void removeDevice() {
+        Member member = memberFactory.save(MemberBuilder::build);
+        String accessToken = accessToken(member);
+        String deviceId = UUID.randomUUID().toString();
+        String activityId = UUID.randomUUID().toString();
+        Game game = saveGame();
+        registerDevice(accessToken, deviceId, "start-token", WidgetPlatform.IOS);
+        registerActivity(accessToken, deviceId, game.getId(), activityId);
+
+        RestAssured.given().log().all()
+                .header(HttpHeaders.AUTHORIZATION, accessToken)
+                .pathParam("deviceId", deviceId)
+                .when().delete("/api/v1/widgets/devices/{deviceId}")
+                .then().log().all()
+                .statusCode(204);
+
+        assertThat(widgetDeviceRepository.findByDeviceId(deviceId)).isEmpty();
+        assertThat(widgetLiveActivityRepository.findByActivityId(activityId)).isEmpty();
+    }
+
+    @DisplayName("위젯 사용 설정의 기본값을 조회하고 변경한다")
+    @Test
+    void settings() {
+        Member member = memberFactory.save(MemberBuilder::build);
+        String accessToken = accessToken(member);
+
+        WidgetSettingsResponse initial = RestAssured.given().log().all()
+                .contentType(ContentType.JSON)
+                .header(HttpHeaders.AUTHORIZATION, accessToken)
+                .when().get("/api/v1/widgets/settings")
+                .then().log().all()
+                .statusCode(200)
+                .extract().as(WidgetSettingsResponse.class);
+
+        WidgetSettingsResponse updated = RestAssured.given().log().all()
+                .contentType(ContentType.JSON)
+                .header(HttpHeaders.AUTHORIZATION, accessToken)
+                .body(new WidgetSettingsRequest(false))
+                .when().patch("/api/v1/widgets/settings")
+                .then().log().all()
+                .statusCode(200)
+                .extract().as(WidgetSettingsResponse.class);
+
+        assertThat(initial.enabled()).isTrue();
+        assertThat(updated.enabled()).isFalse();
+    }
+
+    @DisplayName("잘못된 deviceId 형식은 400을 반환한다")
+    @Test
+    void registerDevice_invalidDeviceId() {
+        Member member = memberFactory.save(MemberBuilder::build);
+
+        RestAssured.given().log().all()
+                .contentType(ContentType.JSON)
+                .header(HttpHeaders.AUTHORIZATION, accessToken(member))
+                .body(new WidgetDeviceRegisterRequest(WidgetPlatform.IOS, "invalid", "token", null))
+                .when().post("/api/v1/widgets/devices")
+                .then().log().all()
+                .statusCode(400);
+    }
+
+    @DisplayName("인증 없이 위젯 API를 호출하면 401을 반환한다")
+    @Test
+    void findSettings_unauthorized() {
+        RestAssured.given().log().all()
+                .contentType(ContentType.JSON)
+                .when().get("/api/v1/widgets/settings")
+                .then().log().all()
+                .statusCode(401);
+    }
+
+    @DisplayName("다른 회원의 Live Activity를 해제하면 404를 반환한다")
+    @Test
+    void removeLiveActivity_otherMember() {
+        Member owner = memberFactory.save(MemberBuilder::build);
+        Member other = memberFactory.save(MemberBuilder::build);
+        String ownerToken = accessToken(owner);
+        String deviceId = UUID.randomUUID().toString();
+        String activityId = UUID.randomUUID().toString();
+        Game game = saveGame();
+        registerDevice(ownerToken, deviceId, "start-token", WidgetPlatform.IOS);
+        registerActivity(ownerToken, deviceId, game.getId(), activityId);
+
+        RestAssured.given().log().all()
+                .header(HttpHeaders.AUTHORIZATION, accessToken(other))
+                .pathParam("activityId", activityId)
+                .when().delete("/api/v1/widgets/live-activities/{activityId}")
+                .then().log().all()
+                .statusCode(404);
+
+        assertThat(widgetLiveActivityRepository.findByActivityId(activityId)).isPresent();
+    }
+
+    private void registerDevice(
+            final String accessToken,
+            final String deviceId,
+            final String pushToken,
+            final WidgetPlatform platform
+    ) {
+        RestAssured.given().log().all()
+                .contentType(ContentType.JSON)
+                .header(HttpHeaders.AUTHORIZATION, accessToken)
+                .body(new WidgetDeviceRegisterRequest(platform, deviceId, pushToken, "3.1.0"))
+                .when().post("/api/v1/widgets/devices")
+                .then().log().all()
+                .statusCode(204);
+    }
+
+    private void registerActivity(
+            final String accessToken,
+            final String deviceId,
+            final long gameId,
+            final String activityId
+    ) {
+        RestAssured.given().log().all()
+                .contentType(ContentType.JSON)
+                .header(HttpHeaders.AUTHORIZATION, accessToken)
+                .body(new WidgetLiveActivityRegisterRequest(deviceId, gameId, activityId, "update-token"))
+                .when().post("/api/v1/widgets/live-activities")
+                .then().log().all()
+                .statusCode(204);
+    }
+
+    private String accessToken(final Member member) {
+        return authFactory.getAccessTokenByMemberId(member.getId(), Role.USER);
+    }
+
+    private Game saveGame() {
+        Team homeTeam = teamRepository.findByTeamCode("HT").orElseThrow();
+        Team awayTeam = teamRepository.findByTeamCode("LG").orElseThrow();
+        Stadium stadium = stadiumRepository.findAll().getFirst();
+
+        return gameFactory.save(builder -> builder
+                .homeTeam(homeTeam)
+                .awayTeam(awayTeam)
+                .stadium(stadium));
+    }
+}

--- a/backend/app/src/test/java/com/yagubogu/widget/WidgetE2eTest.java
+++ b/backend/app/src/test/java/com/yagubogu/widget/WidgetE2eTest.java
@@ -139,16 +139,21 @@ class WidgetE2eTest extends E2eTestBase {
         assertThat(widgetLiveActivityRepository.findByActivityId(activityId)).isEmpty();
     }
 
-    @DisplayName("위젯 사용 설정의 기본값을 조회하고 변경한다")
+    @DisplayName("위젯 사용 설정을 디바이스별로 조회하고 변경한다")
     @Test
     void settings() {
         Member member = memberFactory.save(MemberBuilder::build);
         String accessToken = accessToken(member);
+        String disabledDeviceId = UUID.randomUUID().toString();
+        String enabledDeviceId = UUID.randomUUID().toString();
+        registerDevice(accessToken, disabledDeviceId, "disabled-device-token", WidgetPlatform.IOS);
+        registerDevice(accessToken, enabledDeviceId, "enabled-device-token", WidgetPlatform.ANDROID);
 
         WidgetSettingsResponse initial = RestAssured.given().log().all()
                 .contentType(ContentType.JSON)
                 .header(HttpHeaders.AUTHORIZATION, accessToken)
-                .when().get("/api/v1/widgets/settings")
+                .pathParam("deviceId", disabledDeviceId)
+                .when().get("/api/v1/widgets/devices/{deviceId}/settings")
                 .then().log().all()
                 .statusCode(200)
                 .extract().as(WidgetSettingsResponse.class);
@@ -156,14 +161,25 @@ class WidgetE2eTest extends E2eTestBase {
         WidgetSettingsResponse updated = RestAssured.given().log().all()
                 .contentType(ContentType.JSON)
                 .header(HttpHeaders.AUTHORIZATION, accessToken)
+                .pathParam("deviceId", disabledDeviceId)
                 .body(new WidgetSettingsRequest(false))
-                .when().patch("/api/v1/widgets/settings")
+                .when().patch("/api/v1/widgets/devices/{deviceId}/settings")
+                .then().log().all()
+                .statusCode(200)
+                .extract().as(WidgetSettingsResponse.class);
+
+        WidgetSettingsResponse otherDevice = RestAssured.given().log().all()
+                .contentType(ContentType.JSON)
+                .header(HttpHeaders.AUTHORIZATION, accessToken)
+                .pathParam("deviceId", enabledDeviceId)
+                .when().get("/api/v1/widgets/devices/{deviceId}/settings")
                 .then().log().all()
                 .statusCode(200)
                 .extract().as(WidgetSettingsResponse.class);
 
         assertThat(initial.enabled()).isTrue();
         assertThat(updated.enabled()).isFalse();
+        assertThat(otherDevice.enabled()).isTrue();
     }
 
     @DisplayName("잘못된 deviceId 형식은 400을 반환한다")
@@ -183,9 +199,12 @@ class WidgetE2eTest extends E2eTestBase {
     @DisplayName("인증 없이 위젯 API를 호출하면 401을 반환한다")
     @Test
     void findSettings_unauthorized() {
+        String deviceId = UUID.randomUUID().toString();
+
         RestAssured.given().log().all()
                 .contentType(ContentType.JSON)
-                .when().get("/api/v1/widgets/settings")
+                .pathParam("deviceId", deviceId)
+                .when().get("/api/v1/widgets/devices/{deviceId}/settings")
                 .then().log().all()
                 .statusCode(401);
     }

--- a/backend/app/src/test/java/com/yagubogu/widget/service/WidgetServiceTest.java
+++ b/backend/app/src/test/java/com/yagubogu/widget/service/WidgetServiceTest.java
@@ -1,0 +1,229 @@
+package com.yagubogu.widget.service;
+
+import com.yagubogu.auth.config.AuthTestConfig;
+import com.yagubogu.game.domain.Game;
+import com.yagubogu.game.repository.GameRepository;
+import com.yagubogu.global.config.JpaAuditingConfig;
+import com.yagubogu.global.exception.BadRequestException;
+import com.yagubogu.global.exception.NotFoundException;
+import com.yagubogu.member.domain.Member;
+import com.yagubogu.member.repository.MemberRepository;
+import com.yagubogu.stadium.domain.Stadium;
+import com.yagubogu.stadium.repository.StadiumRepository;
+import com.yagubogu.support.game.GameFactory;
+import com.yagubogu.support.member.MemberBuilder;
+import com.yagubogu.support.member.MemberFactory;
+import com.yagubogu.team.domain.Team;
+import com.yagubogu.team.repository.TeamRepository;
+import com.yagubogu.widget.domain.WidgetDevice;
+import com.yagubogu.widget.domain.WidgetLiveActivity;
+import com.yagubogu.widget.domain.WidgetPlatform;
+import com.yagubogu.widget.dto.v1.WidgetDeviceRegisterRequest;
+import com.yagubogu.widget.dto.v1.WidgetLiveActivityRegisterRequest;
+import com.yagubogu.widget.dto.v1.WidgetSettingsRequest;
+import com.yagubogu.widget.repository.WidgetDeviceRepository;
+import com.yagubogu.widget.repository.WidgetLiveActivityRepository;
+import jakarta.persistence.EntityManager;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@Import({AuthTestConfig.class, JpaAuditingConfig.class})
+@DataJpaTest
+class WidgetServiceTest {
+
+    private WidgetService widgetService;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private GameRepository gameRepository;
+
+    @Autowired
+    private WidgetDeviceRepository widgetDeviceRepository;
+
+    @Autowired
+    private WidgetLiveActivityRepository widgetLiveActivityRepository;
+
+    @Autowired
+    private MemberFactory memberFactory;
+
+    @Autowired
+    private GameFactory gameFactory;
+
+    @Autowired
+    private TeamRepository teamRepository;
+
+    @Autowired
+    private StadiumRepository stadiumRepository;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    @BeforeEach
+    void setUp() {
+        widgetService = new WidgetService(
+                memberRepository,
+                gameRepository,
+                widgetDeviceRepository,
+                widgetLiveActivityRepository
+        );
+    }
+
+    @DisplayName("디바이스를 등록하고 같은 deviceId의 토큰을 갱신한다")
+    @Test
+    void registerDevice_upsert() {
+        Member member = memberFactory.save(MemberBuilder::build);
+        String deviceId = UUID.randomUUID().toString();
+
+        widgetService.registerDevice(member.getId(), deviceRequest(deviceId, "old-token", WidgetPlatform.IOS));
+        widgetService.registerDevice(member.getId(), deviceRequest(deviceId, "new-token", WidgetPlatform.IOS));
+
+        assertThat(widgetDeviceRepository.count()).isEqualTo(1);
+        WidgetDevice device = widgetDeviceRepository.findByDeviceId(deviceId).orElseThrow();
+        assertThat(device.getPushToken()).isEqualTo("new-token");
+    }
+
+    @DisplayName("같은 앱 설치에서 로그인 회원이 바뀌면 소유권을 이전하고 기존 활동을 제거한다")
+    @Test
+    void registerDevice_changedOwner() {
+        Member oldMember = memberFactory.save(MemberBuilder::build);
+        Member newMember = memberFactory.save(MemberBuilder::build);
+        Game game = saveGame();
+        String deviceId = UUID.randomUUID().toString();
+
+        widgetService.registerDevice(oldMember.getId(), deviceRequest(deviceId, "old-token", WidgetPlatform.IOS));
+        widgetService.registerLiveActivity(
+                oldMember.getId(),
+                activityRequest(deviceId, game.getId(), "activity", "update-token")
+        );
+
+        widgetService.registerDevice(newMember.getId(), deviceRequest(deviceId, "new-token", WidgetPlatform.IOS));
+
+        WidgetDevice device = widgetDeviceRepository.findByDeviceId(deviceId).orElseThrow();
+        assertThat(device.getMember().getId()).isEqualTo(newMember.getId());
+        assertThat(widgetLiveActivityRepository.count()).isZero();
+    }
+
+    @DisplayName("Android 디바이스에는 Live Activity를 등록할 수 없다")
+    @Test
+    void registerLiveActivity_androidDevice() {
+        Member member = memberFactory.save(MemberBuilder::build);
+        Game game = saveGame();
+        String deviceId = UUID.randomUUID().toString();
+        widgetService.registerDevice(member.getId(), deviceRequest(deviceId, "fcm-token", WidgetPlatform.ANDROID));
+
+        assertThatThrownBy(() -> widgetService.registerLiveActivity(
+                member.getId(),
+                activityRequest(deviceId, game.getId(), "activity", "update-token")
+        )).isExactlyInstanceOf(BadRequestException.class)
+                .hasMessage("Live Activity is available only on IOS devices");
+    }
+
+    @DisplayName("같은 디바이스와 경기의 Live Activity 토큰을 갱신한다")
+    @Test
+    void registerLiveActivity_upsert() {
+        Member member = memberFactory.save(MemberBuilder::build);
+        Game game = saveGame();
+        String deviceId = UUID.randomUUID().toString();
+        widgetService.registerDevice(member.getId(), deviceRequest(deviceId, "start-token", WidgetPlatform.IOS));
+
+        widgetService.registerLiveActivity(
+                member.getId(),
+                activityRequest(deviceId, game.getId(), "activity-1", "old-update-token")
+        );
+        widgetService.registerLiveActivity(
+                member.getId(),
+                activityRequest(deviceId, game.getId(), "activity-1", "new-update-token")
+        );
+
+        assertThat(widgetLiveActivityRepository.count()).isEqualTo(1);
+        WidgetLiveActivity activity = widgetLiveActivityRepository.findByActivityId("activity-1").orElseThrow();
+        assertThat(activity.getUpdateToken()).isEqualTo("new-update-token");
+    }
+
+    @DisplayName("다른 회원의 Live Activity를 삭제할 수 없다")
+    @Test
+    void removeLiveActivity_otherMember() {
+        Member owner = memberFactory.save(MemberBuilder::build);
+        Member other = memberFactory.save(MemberBuilder::build);
+        Game game = saveGame();
+        String deviceId = UUID.randomUUID().toString();
+        widgetService.registerDevice(owner.getId(), deviceRequest(deviceId, "start-token", WidgetPlatform.IOS));
+        widgetService.registerLiveActivity(
+                owner.getId(),
+                activityRequest(deviceId, game.getId(), "activity", "update-token")
+        );
+
+        assertThatThrownBy(() -> widgetService.removeLiveActivity(other.getId(), "activity"))
+                .isExactlyInstanceOf(NotFoundException.class)
+                .hasMessage("Live Activity is not found");
+        assertThat(widgetLiveActivityRepository.count()).isEqualTo(1);
+    }
+
+    @DisplayName("디바이스를 삭제하면 연결된 Live Activity도 삭제한다")
+    @Test
+    void removeDevice() {
+        Member member = memberFactory.save(MemberBuilder::build);
+        Game game = saveGame();
+        String deviceId = UUID.randomUUID().toString();
+        widgetService.registerDevice(member.getId(), deviceRequest(deviceId, "start-token", WidgetPlatform.IOS));
+        widgetService.registerLiveActivity(
+                member.getId(),
+                activityRequest(deviceId, game.getId(), "activity", "update-token")
+        );
+
+        widgetService.removeDevice(member.getId(), deviceId);
+        entityManager.flush();
+
+        assertThat(widgetDeviceRepository.count()).isZero();
+        assertThat(widgetLiveActivityRepository.count()).isZero();
+    }
+
+    @DisplayName("위젯 사용 설정은 기본 true이고 변경할 수 있다")
+    @Test
+    void settings() {
+        Member member = memberFactory.save(MemberBuilder::build);
+
+        assertThat(widgetService.findSettings(member.getId()).enabled()).isTrue();
+
+        assertThat(widgetService.updateSettings(member.getId(), new WidgetSettingsRequest(false)).enabled()).isFalse();
+        assertThat(widgetService.findSettings(member.getId()).enabled()).isFalse();
+    }
+
+    private WidgetDeviceRegisterRequest deviceRequest(
+            final String deviceId,
+            final String pushToken,
+            final WidgetPlatform platform
+    ) {
+        return new WidgetDeviceRegisterRequest(platform, deviceId, pushToken, "3.1.0");
+    }
+
+    private WidgetLiveActivityRegisterRequest activityRequest(
+            final String deviceId,
+            final long gameId,
+            final String activityId,
+            final String updateToken
+    ) {
+        return new WidgetLiveActivityRegisterRequest(deviceId, gameId, activityId, updateToken);
+    }
+
+    private Game saveGame() {
+        Team homeTeam = teamRepository.findByTeamCode("HT").orElseThrow();
+        Team awayTeam = teamRepository.findByTeamCode("LG").orElseThrow();
+        Stadium stadium = stadiumRepository.findAll().getFirst();
+
+        return gameFactory.save(builder -> builder
+                .homeTeam(homeTeam)
+                .awayTeam(awayTeam)
+                .stadium(stadium));
+    }
+}

--- a/backend/app/src/test/java/com/yagubogu/widget/service/WidgetServiceTest.java
+++ b/backend/app/src/test/java/com/yagubogu/widget/service/WidgetServiceTest.java
@@ -188,15 +188,50 @@ class WidgetServiceTest {
         assertThat(widgetLiveActivityRepository.count()).isZero();
     }
 
-    @DisplayName("위젯 사용 설정은 기본 true이고 변경할 수 있다")
+    @DisplayName("위젯 사용 설정은 디바이스별로 기본 true이고 독립적으로 변경할 수 있다")
     @Test
     void settings() {
         Member member = memberFactory.save(MemberBuilder::build);
+        String disabledDeviceId = UUID.randomUUID().toString();
+        String enabledDeviceId = UUID.randomUUID().toString();
+        widgetService.registerDevice(
+                member.getId(),
+                deviceRequest(disabledDeviceId, "disabled-device-token", WidgetPlatform.IOS)
+        );
+        widgetService.registerDevice(
+                member.getId(),
+                deviceRequest(enabledDeviceId, "enabled-device-token", WidgetPlatform.ANDROID)
+        );
 
-        assertThat(widgetService.findSettings(member.getId()).enabled()).isTrue();
+        assertThat(widgetService.findSettings(member.getId(), disabledDeviceId).enabled()).isTrue();
+        assertThat(widgetService.findSettings(member.getId(), enabledDeviceId).enabled()).isTrue();
 
-        assertThat(widgetService.updateSettings(member.getId(), new WidgetSettingsRequest(false)).enabled()).isFalse();
-        assertThat(widgetService.findSettings(member.getId()).enabled()).isFalse();
+        assertThat(widgetService.updateSettings(
+                member.getId(),
+                disabledDeviceId,
+                new WidgetSettingsRequest(false)
+        ).enabled()).isFalse();
+        assertThat(widgetService.findSettings(member.getId(), disabledDeviceId).enabled()).isFalse();
+        assertThat(widgetService.findSettings(member.getId(), enabledDeviceId).enabled()).isTrue();
+
+        widgetService.registerDevice(
+                member.getId(),
+                deviceRequest(disabledDeviceId, "rotated-token", WidgetPlatform.IOS)
+        );
+        assertThat(widgetService.findSettings(member.getId(), disabledDeviceId).enabled()).isFalse();
+    }
+
+    @DisplayName("다른 회원의 디바이스 위젯 설정을 조회할 수 없다")
+    @Test
+    void findSettings_otherMember() {
+        Member owner = memberFactory.save(MemberBuilder::build);
+        Member other = memberFactory.save(MemberBuilder::build);
+        String deviceId = UUID.randomUUID().toString();
+        widgetService.registerDevice(owner.getId(), deviceRequest(deviceId, "push-token", WidgetPlatform.IOS));
+
+        assertThatThrownBy(() -> widgetService.findSettings(other.getId(), deviceId))
+                .isExactlyInstanceOf(NotFoundException.class)
+                .hasMessage("Widget device is not found");
     }
 
     private WidgetDeviceRegisterRequest deviceRequest(


### PR DESCRIPTION
## 구현 내용

- 디바이스 푸시 토큰 등록/갱신 및 해제 API를 구현했습니다.
- iOS Live Activity 갱신 토큰 등록/갱신 및 해제 API를 구현했습니다.
- **위젯 사용 설정을 계정 단위에서 디바이스 단위로 변경했습니다.**
- `widget_devices`, `widget_live_activities` Flyway 마이그레이션을 추가했습니다.
- `deviceId`를 설치 단위 전역 유니크 키로 사용해 계정 변경 시 소유권을 현재 회원에게 이전하고 기존 Live Activity를 정리합니다.
- 다른 회원의 디바이스/활동/설정 접근을 404로 차단합니다.
- 디바이스 해제 및 회원 탈퇴 시 연결된 Live Activity까지 정리합니다.
- 서비스 테스트와 MySQL/Testcontainers E2E 테스트를 추가했습니다.

## API Spec

모든 엔드포인트는 `Authorization: Bearer {accessToken}` 인증이 필요합니다.

### 디바이스 등록/갱신

- **Method/Path:** `POST /api/v1/widgets/devices`
- **Path/Query parameters:** 없음
- **Request body:**

```json
{
  "platform": "IOS",
  "deviceId": "5c1b9a20-0000-4000-8000-000000000000",
  "pushToken": "push-token",
  "appVersion": "3.1.0"
}
```

- **Validation:**
  - `platform`: 필수, `IOS | ANDROID`
  - `deviceId`: 필수, RFC UUID 형식
  - `pushToken`: 필수/공백 불가, 최대 4096자
  - `appVersion`: 선택, 최대 50자
- **Response:** body 없음
- **Status:** `204`, 잘못된 요청 `400`, 인증 실패 `401`
- **Behavior:** `deviceId` 기준 upsert. 신규 디바이스의 `enabled`는 `true`이며 토큰 재등록 후에도 기존 디바이스 설정은 유지됩니다. 다른 회원에게 소유권이 이전돼도 물리 디바이스 설정은 유지되고 기존 Live Activity는 삭제됩니다.

### iOS Live Activity 등록/갱신

- **Method/Path:** `POST /api/v1/widgets/live-activities`
- **Path/Query parameters:** 없음
- **Request body:**

```json
{
  "deviceId": "5c1b9a20-0000-4000-8000-000000000000",
  "gameId": 4021,
  "activityId": "F1E2D3C4-...",
  "updateToken": "update-token"
}
```

- **Validation:**
  - `deviceId`: 필수, RFC UUID 형식, 현재 회원 소유 디바이스
  - `gameId`: 필수, 양수, 존재하는 경기
  - `activityId`: 필수/공백 불가, 최대 255자, 전역 유니크
  - `updateToken`: 필수/공백 불가, 최대 4096자
  - 디바이스 플랫폼이 `IOS`여야 함
- **Response:** body 없음
- **Status:** `204`, 요청/플랫폼 오류 `400`, 디바이스/경기 없음 `404`, activityId 충돌 `409`
- **Behavior:** 같은 디바이스와 경기 조합은 activityId/updateToken을 갱신합니다.

### iOS Live Activity 해제

- **Method/Path:** `DELETE /api/v1/widgets/live-activities/{activityId}`
- **Path parameter:** `activityId`
- **Request body:** 없음
- **Response:** body 없음
- **Status:** `204`, 현재 회원 소유 활동이 없으면 `404`, 인증 실패 `401`

### 디바이스 해제

- **Method/Path:** `DELETE /api/v1/widgets/devices/{deviceId}`
- **Path parameter:** `deviceId` — RFC UUID 형식
- **Request body:** 없음
- **Response:** body 없음
- **Status:** `204`, UUID 형식 오류 `400`, 현재 회원 소유 디바이스가 없으면 `404`, 인증 실패 `401`
- **Behavior:** 연결된 Live Activity도 함께 삭제합니다.

### 디바이스별 위젯 사용 설정 조회

- **Method/Path:** `GET /api/v1/widgets/devices/{deviceId}/settings`
- **Path parameter:** `deviceId` — RFC UUID 형식, 현재 회원 소유 디바이스
- **Query parameters:** 없음
- **Request body:** 없음
- **Response:**

```json
{ "enabled": true }
```

- **Status:** `200`, UUID 형식 오류 `400`, 디바이스 없음/타 회원 소유 `404`, 인증 실패 `401`

### 디바이스별 위젯 사용 설정 변경

- **Method/Path:** `PATCH /api/v1/widgets/devices/{deviceId}/settings`
- **Path parameter:** `deviceId` — RFC UUID 형식, 현재 회원 소유 디바이스
- **Query parameters:** 없음
- **Request body:**

```json
{ "enabled": false }
```

- **Validation:** `enabled` 필수
- **Response:**

```json
{ "enabled": false }
```

- **Status:** `200`, 잘못된 요청/UUID 형식 오류 `400`, 디바이스 없음/타 회원 소유 `404`, 인증 실패 `401`
- **Behavior:** 해당 디바이스 설정만 변경하며 동일 계정의 다른 디바이스에는 영향을 주지 않습니다.

## Migration

- `V21__create_widget_resources.sql`
- `widget_devices.enabled BOOLEAN NOT NULL DEFAULT TRUE`
- 계정 단위 `members.widget_enabled` 컬럼은 생성하지 않습니다.
- `widget_devices.device_id`, `widget_live_activities.activity_id`에 유니크 제약을 추가했습니다.
- `widget_live_activities(widget_device_id, game_id)` 조합도 유니크합니다.
- 디바이스 FK는 `ON DELETE CASCADE`입니다.
- 현재 서버 에러 응답 컨벤션에 따라 오류 body는 `{ "message": string }` 형태입니다.

## 검증

- `./gradlew :app:test` ✅
- Widget 서비스 테스트 ✅
- MySQL/Flyway 기반 Widget E2E 테스트 ✅
- 디바이스별 설정 독립성 및 토큰 재등록 후 설정 유지 검증 ✅
- 인증, 입력 검증, 멱등 갱신, 소유권 차단, cascade 삭제 검증 ✅

Resolves #1136