### PR TITLE
fix(place): TourAPI 요청 간 딜레이 추가로 초당 요청 제한 대응

### DIFF
--- a/backend/app/src/main/java/com/yagubogu/place/client/TourApiClient.java
+++ b/backend/app/src/main/java/com/yagubogu/place/client/TourApiClient.java
@@ -31,6 +31,8 @@ public class TourApiClient {
     private final TourApiProperties props;
     private final ObjectMapper objectMapper;
 
+    private long lastRequestAtMillis = 0L;
+
     /**
      * 구장 주변 장소를 카테고리(contentTypeId, 카페는 cat3 추가)별로 한국관광공사 API로 조회합니다.
      *
@@ -65,6 +67,7 @@ public class TourApiClient {
         URI uri = builder.build(true).toUri();
 
         try {
+            throttle();
             String json = restClient.get()
                     .uri(uri)
                     .retrieve()
@@ -115,6 +118,7 @@ public class TourApiClient {
 
         URI uri = builder.build(true).toUri();
 
+        throttle();
         String json = restClient.get()
                 .uri(uri)
                 .retrieve()
@@ -226,6 +230,28 @@ public class TourApiClient {
         }
 
         return envelope.path("body");
+    }
+
+    /**
+     * TourAPI는 초당 요청 수를 제한한다(LIMITED_NUMBER_OF_SERVICE_REQUESTS_PER_SECOND_EXCEEDS_ERROR).
+     * 실제 HTTP 호출 직전마다 불러 마지막 호출 이후 {@code requestInterval}만큼 간격을 보장한다.
+     * 스케줄러/admin 수동 트리거 모두 단일 스레드로 순차 호출하는 구조라 synchronized로 충분하다.
+     */
+    private synchronized void throttle() {
+        long intervalMillis = props.getRequestInterval().toMillis();
+        if (intervalMillis <= 0) {
+            return;
+        }
+
+        long waitMillis = lastRequestAtMillis + intervalMillis - System.currentTimeMillis();
+        if (waitMillis > 0) {
+            try {
+                Thread.sleep(waitMillis);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        }
+        lastRequestAtMillis = System.currentTimeMillis();
     }
 
     private PlaceParam toParam(JsonNode item, long stadiumId) {

--- a/backend/app/src/main/java/com/yagubogu/place/config/TourApiProperties.java
+++ b/backend/app/src/main/java/com/yagubogu/place/config/TourApiProperties.java
@@ -22,15 +22,17 @@ public class TourApiProperties {
     private final String baseUrl;
     private final int radius;
     private final int numOfRows;
+    private final Duration requestInterval;
     private final Duration connectTimeout;
     private final Duration readTimeout;
 
     public TourApiProperties(String serviceKey, String baseUrl, int radius, int numOfRows,
-                             Duration connectTimeout, Duration readTimeout) {
+                             Duration requestInterval, Duration connectTimeout, Duration readTimeout) {
         this.serviceKey = serviceKey;
         this.baseUrl = baseUrl;
         this.radius = radius;
         this.numOfRows = numOfRows;
+        this.requestInterval = requestInterval;
         this.connectTimeout = connectTimeout;
         this.readTimeout = readTimeout;
     }

--- a/backend/app/src/main/resources/application.yml
+++ b/backend/app/src/main/resources/application.yml
@@ -85,6 +85,7 @@ tour:
     base-url: https://apis.data.go.kr/B551011/KorService2
     radius: 10000       # 구장 중심으로부터 반경 (미터)
     num-of-rows: 50     # 한 번에 가져올 최대 결과 수
+    request-interval: 100ms # 요청 간 최소 간격 (초당 요청 제한 대응, 100ms = 초당 10건)
     connect-timeout: 10s
     read-timeout: 30s
 

--- a/backend/app/src/test/java/com/yagubogu/place/client/TourApiClientTest.java
+++ b/backend/app/src/test/java/com/yagubogu/place/client/TourApiClientTest.java
@@ -48,6 +48,7 @@ class TourApiClientTest {
                 "test-service-key",
                 "https://apis.data.go.kr/B551011/KorService2",
                 1000, 50,
+                Duration.ZERO,
                 Duration.ofSeconds(10), Duration.ofSeconds(30)
         );
         tourApiClient = new TourApiClient(restClient, props, objectMapper);

--- a/backend/app/src/test/java/com/yagubogu/place/config/TourApiPropertiesTest.java
+++ b/backend/app/src/test/java/com/yagubogu/place/config/TourApiPropertiesTest.java
@@ -21,6 +21,7 @@ class TourApiPropertiesTest {
                     "tour.api.base-url=https://apis.data.go.kr/B551011/KorService2",
                     "tour.api.radius=3000",
                     "tour.api.num-of-rows=50",
+                    "tour.api.request-interval=100ms",
                     "tour.api.connect-timeout=10s",
                     "tour.api.read-timeout=30s"
             );

--- a/backend/app/src/test/resources/application.yml
+++ b/backend/app/src/test/resources/application.yml
@@ -70,6 +70,7 @@ tour:
     base-url: https://apis.data.go.kr/B551011/KorService2
     radius: 1000
     num-of-rows: 50
+    request-interval: 0ms
     connect-timeout: 10s
     read-timeout: 30s
 


### PR DESCRIPTION
10km로 반경을 확대하며 신규 장소가 늘어나 상세 조회(fetchDetail)가
연속 호출되면서 LIMITED_NUMBER_OF_SERVICE_REQUESTS_PER_SECOND_EXCEEDS_ERROR가 다발했다. 목록/상세 조회 직전마다 최소 간격(기본 100ms, 초당 10건)을
보장하도록 TourApiClient에 throttle을 추가하고, 값은 request-interval로 설정 가능하게 뺐다. 스케줄러와 admin 수동 트리거가 같은 TourApiClient
빈을 공유하므로 양쪽 모두 적용된다.

close #1141